### PR TITLE
log law improvements

### DIFF
--- a/src/boundary_conditions/incflo_set_velocity_bcs.cpp
+++ b/src/boundary_conditions/incflo_set_velocity_bcs.cpp
@@ -476,7 +476,7 @@ incflo::set_velocity_bcs(Real time,
     const Real nu = mu/ro_0;//fixme should be variable density
 
     amrex::ParallelFor(bx_xy_lo_3D,
-      [bct_klo,dom_lo,nsw,slip,wall_model,p_bc_u,p_bc_v,vel_arr,vx_mean_ground_,vy_mean_ground_,utau_,dz,Cs_ds2,nu,nu_mean_ground_] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      [bct_klo,dom_lo,nsw,slip,wall_model,p_bc_u,p_bc_v,vel_arr,vx_mean_ground_,vy_mean_ground_,utau_,nu_mean_ground_] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
       const int bcv = bct_klo(i,j,dom_lo[2]-1,1);
       const int bct = bct_klo(i,j,dom_lo[2]-1,0);
@@ -496,23 +496,11 @@ incflo::set_velocity_bcs(Real time,
           const Real uh = sqrt(pow(vx_mean_ground_,2) + pow(vy_mean_ground_,2));
           
 //          fixme should I just pass in eddy viscosity (stored in eta)?
-          
-          // velocity derivatives
-          // assuming velocity at wall equals zero
-          // use dz/2 since it is over half a cell
-          // dudz = 2*(u_1/2 - u_0)/dz
-          const Real uz =  2.0*vel_arr(i,j,dom_lo[2],0)/dz;
-          const Real vz =  2.0*vel_arr(i,j,dom_lo[2],1)/dz;
-          const Real wz =  2.0*vel_arr(i,j,dom_lo[2],2)/dz;
-          
-          // strain rate with all x y terms dropped
-          const Real sr = sqrt( 2.0 * pow(wz, 2) + pow(vz, 2) + pow(uz, 2));
-          const Real nut = nu_mean_ground_; //nu + Cs_ds2*sr;
 
           // simple shear stress model for neutral BL
           // apply as an inhomogeneous Neumann BC
-          vel_arr(i,j,k,0) = utau_*utau_*vx/uh/nut;
-          vel_arr(i,j,k,1) = utau_*utau_*vy/uh/nut;
+          vel_arr(i,j,k,0) = utau_*utau_*vx/uh/nu_mean_ground_;
+          vel_arr(i,j,k,1) = utau_*utau_*vy/uh/nu_mean_ground_;
 
           // Dirichlet BC
           vel_arr(i,j,k,2) = 0.0;

--- a/src/boundary_conditions/incflo_set_velocity_bcs.cpp
+++ b/src/boundary_conditions/incflo_set_velocity_bcs.cpp
@@ -468,12 +468,6 @@ incflo::set_velocity_bcs(Real time,
 
   if (ndwn > 0)
   {
-    const Real dx = geom[lev].CellSize()[0];
-    const Real dy = geom[lev].CellSize()[1];
-    const Real dz = geom[lev].CellSize()[2];
-    const Real ds = pow(dx*dy*dz,1.0/3.0);
-    const Real Cs_ds2 = pow(Smagorinsky_Lilly_SGS_constant*ds,2);
-    const Real nu = mu/ro_0;//fixme should be variable density
 
     amrex::ParallelFor(bx_xy_lo_3D,
       [bct_klo,dom_lo,nsw,slip,wall_model,p_bc_u,p_bc_v,vel_arr,vx_mean_ground_,vy_mean_ground_,utau_,nu_mean_ground_] AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/src/boundary_conditions/incflo_set_velocity_bcs.cpp
+++ b/src/boundary_conditions/incflo_set_velocity_bcs.cpp
@@ -156,6 +156,7 @@ incflo::set_velocity_bcs(Real time,
 
   const Real vx_mean_ground_ = vx_mean_ground;
   const Real vy_mean_ground_ = vy_mean_ground;
+  const Real nu_mean_ground_ = nu_mean_ground;
   const Real utau_ = utau;
     
   // Coefficients for linear extrapolation to ghost cells -- divide by 3 below
@@ -475,7 +476,7 @@ incflo::set_velocity_bcs(Real time,
     const Real nu = mu/ro_0;//fixme should be variable density
 
     amrex::ParallelFor(bx_xy_lo_3D,
-      [bct_klo,dom_lo,nsw,slip,wall_model,p_bc_u,p_bc_v,vel_arr,vx_mean_ground_,vy_mean_ground_,utau_,dz,Cs_ds2,nu] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      [bct_klo,dom_lo,nsw,slip,wall_model,p_bc_u,p_bc_v,vel_arr,vx_mean_ground_,vy_mean_ground_,utau_,dz,Cs_ds2,nu,nu_mean_ground_] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
       const int bcv = bct_klo(i,j,dom_lo[2]-1,1);
       const int bct = bct_klo(i,j,dom_lo[2]-1,0);
@@ -506,7 +507,7 @@ incflo::set_velocity_bcs(Real time,
           
           // strain rate with all x y terms dropped
           const Real sr = sqrt( 2.0 * pow(wz, 2) + pow(vz, 2) + pow(uz, 2));
-          const Real nut = nu + Cs_ds2*sr;
+          const Real nut = nu_mean_ground_; //nu + Cs_ds2*sr;
 
           // simple shear stress model for neutral BL
           // apply as an inhomogeneous Neumann BC

--- a/src/diffusion/DiffusionOp.cpp
+++ b/src/diffusion/DiffusionOp.cpp
@@ -309,6 +309,8 @@ void DiffusionOp::diffuse_scalar(      Vector<std::unique_ptr<MultiFab>>& scal_i
 
     for(int lev = 0; lev <= finest_level; lev++)
     {
+        // fixme this is broken there is no way to loop over eta_tracer (mu_in)
+        // ok for 1 tracer but will break when using more than 1 tracer... ksgs
         average_cellcenter_to_face(GetArrOfPtrs(b[lev]), *mu_in[lev], geom[lev]);
 
         for(int dir = 0; dir < AMREX_SPACEDIM; dir++)

--- a/src/diffusion/DiffusionOp.cpp
+++ b/src/diffusion/DiffusionOp.cpp
@@ -311,7 +311,7 @@ void DiffusionOp::diffuse_scalar(      Vector<std::unique_ptr<MultiFab>>& scal_i
     {
         // fixme this is broken there is no way to loop over eta_tracer (mu_in)
         // ok for 1 tracer but will break when using more than 1 tracer... ksgs
-        AMREX_ASSERT(ntrac<=1);
+        AMREX_ALWAYS_ASSERT(ntrac<=1);
         average_cellcenter_to_face(GetArrOfPtrs(b[lev]), *mu_in[lev], geom[lev]);
 
         for(int dir = 0; dir < AMREX_SPACEDIM; dir++)

--- a/src/diffusion/DiffusionOp.cpp
+++ b/src/diffusion/DiffusionOp.cpp
@@ -311,6 +311,7 @@ void DiffusionOp::diffuse_scalar(      Vector<std::unique_ptr<MultiFab>>& scal_i
     {
         // fixme this is broken there is no way to loop over eta_tracer (mu_in)
         // ok for 1 tracer but will break when using more than 1 tracer... ksgs
+        AMREX_ASSERT(ntrac<=1);
         average_cellcenter_to_face(GetArrOfPtrs(b[lev]), *mu_in[lev], geom[lev]);
 
         for(int dir = 0; dir < AMREX_SPACEDIM; dir++)

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -173,7 +173,7 @@ public:
     //////////////////////////////////////////////////////////////////////////////////////////////
 
     void ComputeVorticity(Real time_in);
-    double ComputeKineticEnergy();
+    Real ComputeKineticEnergy();
 
     //////////////////////////////////////////////////////////////////////////////////////////////
     //
@@ -190,7 +190,8 @@ public:
     void set_mfab_spatial_averaging_quantities(MultiFab &mfab, int lev, FArrayBox &fab, int index);
     void plane_average(const MultiFab& mfab, FArrayBox& avg_fab, const Real area, const int axis, const int ncomp);
     void spatially_average_quantities_down(bool plot=true);
-    
+    void set_average_quantities(FArrayBox& avg_fab, int s, int b, int axis);
+
     Real volWgtSum (int lev, const MultiFab & mf, int comp, bool local=false);
 
     //////////////////////////////////////////////////////////////////////////////////////////////
@@ -554,23 +555,22 @@ private:
     Real zRefHeight = 50.0;
     Real theta_amplitude = 0.8;
     Real abl_forcing_height = 90.0;
-    Real kappa = 0.4; //von Karman constant
+    Real kappa = 0.41; //von Karman constant
     Real surface_roughness_z0 = 0.15; // surface roughness [m]
     Real corfac = 1.45842318e-4; // 2*earth_angular_velocity
-    Real latitude = 0.7208209811;
+    Real latitude = 0.7208209811; // radians
     Real thermalExpansionCoeff; // initialized in the readABLparameters now
-    Real Smagorinsky_Lilly_SGS_constant = 0.18; // 0.18 <= Cs <= 0.25
+    Real Smagorinsky_Lilly_SGS_constant = 0.135;
+    Real log_law_sampling_height = 40.0;
+
 //    Vector<Real> east{Vector<Real>{1.0, 0.0, 0.0}};
 //    Vector<Real> north{Vector<Real>{0.0, 1.0, 0.0}};
 //    Vector<Real> up{Vector<Real>{0.0, 0.0, 1.0}};
-
     
     Real vx_mean; //fixme pick a better name
     Real vy_mean;
     Real vx_mean_ground;
     Real vy_mean_ground;
-    Real nu_mean_ground;
-    Real z_ground;
     Real utau;
 
     

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -561,7 +561,7 @@ private:
     Real latitude = 0.7208209811; // radians
     Real thermalExpansionCoeff; // initialized in the readABLparameters now
     Real Smagorinsky_Lilly_SGS_constant = 0.135;
-    Real log_law_sampling_height = 40.0;
+    Real log_law_sampling_height = 0.1; // a small number will default to the first cell
 
 //    Vector<Real> east{Vector<Real>{1.0, 0.0, 0.0}};
 //    Vector<Real> north{Vector<Real>{0.0, 1.0, 0.0}};

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -571,6 +571,7 @@ private:
     Real vy_mean;
     Real vx_mean_ground;
     Real vy_mean_ground;
+    Real nu_mean_ground;
     Real utau;
 
     

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -164,7 +164,7 @@ void incflo::ApplyPredictor(bool incremental_projection)
        int extrap_dir_bcs = 0;
        incflo_set_velocity_bcs (cur_time, vel_o, extrap_dir_bcs);
        diffusion_op->ComputeDivTau(divtau_old,    vel_o, density_o, eta_old);
-
+       amrex::Abort("fixme this should be eta_tracer not mu_s");
        diffusion_op->ComputeLapS  (  laps_old, tracer_o, density_o, mu_s);
     } else {
        for (int lev = 0; lev <= finest_level; lev++)

--- a/src/setup/init.cpp
+++ b/src/setup/init.cpp
@@ -159,6 +159,7 @@ void incflo::ReadABLParameters()
     pp.query("thermalExpansionCoeff",thermalExpansionCoeff);
 
     pp.query("Smagorinsky_Lilly_SGS_constant",Smagorinsky_Lilly_SGS_constant);
+    pp.query("log_law_sampling_height",log_law_sampling_height);
     
 }
 void incflo::ReadIOParameters()

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -758,7 +758,7 @@ void incflo::set_average_quantities(FArrayBox& avg_fab, int s, int b, int axis){
         height = abl_forcing_height;
         ind = s + floor((abl_forcing_height - zlo)/dz - 0.5);
         const Real z1 = zlo + (ind+0.5)*dz;
-        c = (log_law_sampling_height-z1)/dz;
+        c = (abl_forcing_height-z1)/dz;
     }
 
     if(ind   < 0) amrex::Abort("abl_forcing_height is set incorrectly since conversion to integer is negative \n");

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -671,6 +671,114 @@ void incflo::plane_average(const MultiFab& mfab, FArrayBox& avg_fab, const Real 
 }
 
 
+void incflo::set_average_quantities(FArrayBox& avg_fab, int s, int b, int axis){
+
+    AMREX_ALWAYS_ASSERT(s>=0);
+    AMREX_ALWAYS_ASSERT(b>s);
+
+    // fixme switch this to a 1d array
+    const auto fab_arr = avg_fab.array();
+    
+    const Real dz = geom[0].CellSize(axis);
+    const Real zlo = geom[0].ProbLo(axis);
+    
+    const Real half_height = zlo + 0.5*dz;
+    Real nu_mean_ground;
+    // set the velocity at the first cell above the ground
+    switch (axis) {
+        case 0:
+            vx_mean_ground = fab_arr(s,0,0,u_avg);
+            vy_mean_ground = fab_arr(s,0,0,v_avg);
+            nu_mean_ground = fab_arr(s,0,0,nu_avg);
+            break;
+        case 1:
+            vx_mean_ground = fab_arr(0,s,0,u_avg);
+            vy_mean_ground = fab_arr(0,s,0,v_avg);
+            nu_mean_ground = fab_arr(0,s,0,nu_avg);
+
+            break;
+        case 2:
+            vx_mean_ground = fab_arr(0,0,s,u_avg);
+            vy_mean_ground = fab_arr(0,0,s,v_avg);
+            nu_mean_ground = fab_arr(0,0,s,nu_avg);
+            break;
+    }
+    amrex::Print() << "nu mean ground: " << nu_mean_ground << std::endl;
+    amrex::Print() << "ground half cell height, vx, vy: " << half_height << ' ' << vx_mean_ground  << ' ' << vy_mean_ground << std::endl;
+
+    
+    // search for cells near log_law_sampling_height
+    Real height = half_height;
+    Real c = 0.0;
+    int ind = s;
+        
+    if(log_law_sampling_height > half_height){
+        height = log_law_sampling_height;
+        ind = s + floor((log_law_sampling_height - zlo)/dz - 0.5);
+        const Real z1 = zlo + (ind+0.5)*dz;
+        c = (log_law_sampling_height-z1)/dz;
+    }
+
+    if(ind   < 0) amrex::Abort("low_law_sampling_height is set incorrectly since conversion to integer is negative \n");
+    if(ind+1 > b) amrex::Abort("low_law_sampling_height is set incorrectly since conversion to integer is larger than domain \n");
+
+    Real vx,vy;
+    switch (axis) {
+        case 0:
+            vx = fab_arr(ind,0,0,u_avg)*(1.0-c) + fab_arr(ind+1,0,0,u_avg)*c;
+            vy = fab_arr(ind,0,0,v_avg)*(1.0-c) + fab_arr(ind+1,0,0,v_avg)*c;
+            break;
+        case 1:
+            vx = fab_arr(0,ind,0,u_avg)*(1.0-c) + fab_arr(0,ind+1,0,u_avg)*c;
+            vy = fab_arr(0,ind,0,v_avg)*(1.0-c) + fab_arr(0,ind+1,0,v_avg)*c;
+            break;
+        case 2:
+            vx = fab_arr(0,0,ind,u_avg)*(1.0-c) + fab_arr(0,0,ind+1,u_avg)*c;
+            vy = fab_arr(0,0,ind,v_avg)*(1.0-c) + fab_arr(0,0,ind+1,v_avg)*c;
+            break;
+    }
+    
+    const Real uh = sqrt(pow(vx,2) + pow(vy,2));
+        
+    // simple shear stress model for neutral BL
+    // apply as an inhomogeneous Neumann BC
+    utau = kappa*uh/log(height/surface_roughness_z0);
+    
+    amrex::Print() << "log law sampling height, u, utau: " << height << ' ' << uh  << ' ' << utau << std::endl;
+  
+    
+    // search for cells near abl_forcing_height
+    c = 0.0;
+    ind = s;
+    if(abl_forcing_height > half_height){
+        height = abl_forcing_height;
+        ind = s + floor((abl_forcing_height - zlo)/dz - 0.5);
+        const Real z1 = zlo + (ind+0.5)*dz;
+        c = (log_law_sampling_height-z1)/dz;
+    }
+
+    if(ind   < 0) amrex::Abort("abl_forcing_height is set incorrectly since conversion to integer is negative \n");
+    if(ind+1 > b) amrex::Abort("abl_forcing_height is set incorrectly since conversion to integer is larger than domain \n");
+   
+    switch (axis) {
+        case 0:
+            vx_mean = fab_arr(ind,0,0,u_avg)*(1.0-c) + fab_arr(ind+1,0,0,u_avg)*c;
+            vy_mean = fab_arr(ind,0,0,v_avg)*(1.0-c) + fab_arr(ind+1,0,0,v_avg)*c;
+            break;
+        case 1:
+            vx_mean = fab_arr(0,ind,0,u_avg)*(1.0-c) + fab_arr(0,ind+1,0,u_avg)*c;
+            vy_mean = fab_arr(0,ind,0,v_avg)*(1.0-c) + fab_arr(0,ind+1,0,v_avg)*c;
+            break;
+        case 2:
+            vx_mean = fab_arr(0,0,ind,u_avg)*(1.0-c) + fab_arr(0,0,ind+1,u_avg)*c;
+            vy_mean = fab_arr(0,0,ind,v_avg)*(1.0-c) + fab_arr(0,0,ind+1,v_avg)*c;
+            break;
+    }
+    
+    amrex::Print() << "abl forcing height z, vx, vy: " << height << ' ' << vx_mean << ' ' << vy_mean << std::endl;
+    
+}
+
 
 void incflo::spatially_average_quantities_down(bool plot)
 {
@@ -716,9 +824,9 @@ void incflo::spatially_average_quantities_down(bool plot)
     fab.setVal(0.0);
 
     // count number of cells in plane
-    Real area = 1.0;
+    Real nplane_cells = 1.0;
     for(int i=0;i<AMREX_SPACEDIM;++i){
-        if(i!=axis) area *= (dom_hi[i]-dom_lo[i]+1);
+        if(i!=axis) nplane_cells *= (dom_hi[i]-dom_lo[i]+1);
     }
          
     
@@ -733,7 +841,7 @@ void incflo::spatially_average_quantities_down(bool plot)
 //    average_down(fine_mfab, crse_mfab, geom[fine_lev], geom[crse_lev], 0, ncomp, ratio);
 
     // ncomp is used here and is safer but it could actually be 4 depending on the ordering of average down function
-    plane_average(crse_mfab, fab, area, axis, ncomp);
+    plane_average(crse_mfab, fab, nplane_cells, axis, ncomp);
 
     //fixme put in a loop like above
     // sum all fabs together
@@ -746,55 +854,60 @@ void incflo::spatially_average_quantities_down(bool plot)
 
     fab.setVal(0.0);
     
-    plane_average(crse_mfab,fab,area,axis,ncomp);
+    plane_average(crse_mfab,fab,nplane_cells,axis,ncomp);
 
     // sum all fabs together
     ParallelDescriptor::ReduceRealSum(fab.dataPtr(0),fab.size());
   
     
-    // fixme piggy backing on this function but this belongs somewhere else
-    // maybe keep this 1d average in global memory and then make these functions separate?
-    AMREX_ASSERT(axis==2);
-    const auto& fab_arr = fab.array();
+    // set all the stored average quantities
+    set_average_quantities(fab,s,b,axis);
     
-    // no need to do a loop should be able to find the index because of fixed cell size
-    for(int i=s; i <= b; ++i){
-        const Real z = geom[0].ProbLo(axis) + (i+0.5)*geom[0].CellSize(axis);
-        if(z > 0.0) {
-            vx_mean_ground = fab_arr(0,0,i,u_avg);
-            vy_mean_ground = fab_arr(0,0,i,v_avg);
-            nu_mean_ground = fab_arr(0,0,i,nu_avg);
-            z_ground = z;
-           
-            amrex::Print() << "ground height z: " << z_ground << " vx_mean_ground: " << vx_mean_ground << " vy_mean_ground: " << vy_mean_ground << std::endl;
-            
-            // fixme circular dependency so need to hack this for now
-            if(nstep == -1) nu_mean_ground = 1.0;
-            amrex::Print() << "nu mean ground: " << nu_mean_ground << std::endl;
-
-            break;
-        }
-    }
-    
-    // simple shear stress model for neutral BL
-    // apply as an inhomogeneous Neumann BC
-    const Real uh = sqrt(pow(vx_mean_ground,2) + pow(vy_mean_ground,2)) + 1.0e-12;
-    utau = kappa*uh/log(z_ground/surface_roughness_z0);
-    amrex::Print() << "utau: " << utau << std::endl;
-    
-    for(int i=s; i < b; ++i){
-
-        const Real z1 = geom[0].ProbLo(axis) + (i+0.5+0)*geom[0].CellSize(axis);
-        const Real z2 = geom[0].ProbLo(axis) + (i+0.5+1)*geom[0].CellSize(axis);
-
-        if(z1 <= abl_forcing_height && z2 >= abl_forcing_height) {
-            const Real c = (abl_forcing_height-z1)/(z2-z1);
-            vx_mean = fab_arr(0,0,i,u_avg)*(1.0-c) + fab_arr(0,0,i+1,u_avg)*c;
-            vy_mean = fab_arr(0,0,i,v_avg)*(1.0-c) + fab_arr(0,0,i+1,v_avg)*c;
-            amrex::Print() << "abl forcing height z: " << abl_forcing_height << " vx_mean: " << vx_mean << " vy_mean: " << vy_mean << std::endl;
-            break;
-        }
-    } 
+//    // fixme piggy backing on this function but this belongs somewhere else
+//    // maybe keep this 1d average in global memory and then make these functions separate?
+//    AMREX_ASSERT(axis==2);
+//    const auto& fab_arr = fab.array();
+//    Real z_ground;
+//
+//    // no need to do a loop should be able to find the index because of fixed cell size
+//    for(int i=s; i <= b; ++i){
+//        const Real z = geom[0].ProbLo(axis) + (i+0.5)*geom[0].CellSize(axis);
+//        if(z > 0.0) {
+//            vx_mean_ground = fab_arr(0,0,i,u_avg);
+//            vy_mean_ground = fab_arr(0,0,i,v_avg);
+////            nu_mean_ground = fab_arr(0,0,i,nu_avg);
+//            z_ground = z;
+//
+//            amrex::Print() << "ground height z: " << z_ground << " vx_mean_ground: " << vx_mean_ground << " vy_mean_ground: " << vy_mean_ground << std::endl;
+//
+//            // fixme circular dependency so need to hack this for now
+////            if(nstep == -1) nu_mean_ground = 1.0;
+////            amrex::Print() << "nu mean ground: " << nu_mean_ground << std::endl;
+//
+//            break;
+//        }
+//    }
+//
+//    // simple shear stress model for neutral BL
+//    // apply as an inhomogeneous Neumann BC
+//    const Real uh = sqrt(pow(vx_mean_ground,2) + pow(vy_mean_ground,2)) + 1.0e-12;
+//    utau = kappa*uh/log(z_ground/surface_roughness_z0);
+//    amrex::Print() << "zground,u,utau: " << z_ground << ' ' << uh << ' ' << utau << std::endl;
+//
+//    for(int i=s; i < b; ++i){
+//
+//        const Real z1 = geom[0].ProbLo(axis) + (i+0.5+0)*geom[0].CellSize(axis);
+//        const Real z2 = geom[0].ProbLo(axis) + (i+0.5+1)*geom[0].CellSize(axis);
+//        if(z1 <= abl_forcing_height && z2 >= abl_forcing_height) {
+//            amrex::Print() << "ind: " << i << std::endl;
+//
+//            const Real c = (abl_forcing_height-z1)/(z2-z1);
+//            vx_mean = fab_arr(0,0,i,u_avg)*(1.0-c) + fab_arr(0,0,i+1,u_avg)*c;
+//            vy_mean = fab_arr(0,0,i,v_avg)*(1.0-c) + fab_arr(0,0,i+1,v_avg)*c;
+//            amrex::Print() << "abl forcing height z: " << abl_forcing_height << " vx_mean: " << vx_mean << " vy_mean: " << vy_mean << std::endl;
+//            break;
+//        }
+//    }
     
     
     


### PR DESCRIPTION
A few enhancements to specify where the log law should be satisfied (turned off by default), removed the for loop used for searching for specific heights and cleaned up that function. Attempted a local eddy viscosity for wall model but it doesn't work as well as global method, so it was removed. After chatting with amrex crew set_velocity_bc should be used for ghost cells only and not for specifying the derivative of velocity. A new function will be added later that can be called before diffuse velocity that will specify derivatives for the non-homogeneous Neumann BC's. 