### PR TITLE
Compute kinetic energy turned back on

### DIFF
--- a/src/diffusion/DiffusionTensorOp.cpp
+++ b/src/diffusion/DiffusionTensorOp.cpp
@@ -125,10 +125,11 @@ DiffusionTensorOp::diffuse_velocity (Vector<MultiFab*> const& velocity,
             Array<MultiFab,AMREX_SPACEDIM> b = m_incflo->average_velocity_eta_to_faces(lev, *eta[lev]);
             
             // fixme not sure I want this here. this is the only place b is stored, however it is simple to grab eta from the first cell or extrapolate so maybe this can move somewhere else?
-            amrex::Print() << "warning wall model being called " << std::endl;
-            Real umag = sqrt(pow(m_incflo->vx_mean_ground,2) + pow(m_incflo->vy_mean_ground,2));
-            m_incflo->wall_model_bc(lev,m_incflo->utau,umag,GetArrOfConstPtrs(b),*density[lev],*velocity[lev]);
-            
+            if(m_incflo->m_probtype==35){
+                amrex::Print() << "warning wall model being called " << std::endl;
+                Real umag = sqrt(pow(m_incflo->vx_mean_ground,2) + pow(m_incflo->vy_mean_ground,2));
+                m_incflo->wall_model_bc(lev,m_incflo->utau,umag,GetArrOfConstPtrs(b),*density[lev],*velocity[lev]);
+            }
             m_reg_solve_op->setShearViscosity(lev, GetArrOfConstPtrs(b));
 
         }

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -80,8 +80,7 @@ void incflo::InitData ()
     }
     if(m_KE_int > 0 && !restart_flag)
     {
-        amrex::Abort("xxxxx m_KE_int todo");
-//        amrex::Print() << "Time, Kinetic Energy: " << m_cur_time << ", " << ComputeKineticEnergy() << std::endl;
+        amrex::Print() << "Time, Kinetic Energy: " << m_cur_time << ", " << ComputeKineticEnergy() << std::endl;
     }
 
 #ifdef AMREX_USE_EB


### PR DESCRIPTION
Do we want level_mask to be stored and reset during regrid? Or create it on the fly when needed? Will level mask be used for overset?