### PR TITLE
Build fcompare before testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,10 @@ option(AMR_WIND_ENABLE_DOCUMENTATION "Build documentation" OFF)
 option(AMR_WIND_ENABLE_SPHINX_API_DOCS "Link Doxygen API docs to Sphinx" OFF)
 option(AMR_WIND_ENABLE_ALL_WARNINGS "Show most warnings for most compilers" OFF)
 option(AMR_WIND_ENABLE_FCOMPARE "Enable building fcompare when not testing" OFF)
-option(AMR_WIND_ENABLE_FEXTREMA "Enable building fextrema when not testing" OFF)
 
 #Enabling tests overrides the executable options
 option(AMR_WIND_ENABLE_TESTS "Enable testing suite" OFF)
 option(AMR_WIND_TEST_WITH_FCOMPARE "Check test plots against gold files" OFF)
-option(AMR_WIND_TEST_WITH_FEXTREMA "Check test plots against maxima and minima files" OFF)
 
 #Options for the executable
 option(AMR_WIND_ENABLE_MPI "Enable MPI" OFF)
@@ -29,6 +27,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ########################### AMReX #####################################
+
+set(AMREX_SUBMOD_LOCATION "submods/amrex")
 
 #Set amrex options
 set(USE_XSDK_DEFAULTS OFF)
@@ -56,7 +56,12 @@ set(ENABLE_BACKTRACE OFF)
 set(ENABLE_PROFPARSER OFF)
 set(ENABLE_CUDA OFF)
 set(ENABLE_ACC OFF)
-add_subdirectory(submods/amrex)
+
+add_subdirectory(${AMREX_SUBMOD_LOCATION})
+
+if(AMR_WIND_ENABLE_FCOMPARE OR AMR_WIND_TEST_WITH_FCOMPARE)
+  add_subdirectory(${AMREX_SUBMOD_LOCATION}/Tools/PlotFile)
+endif()
 
 ########################### AMR-Wind #####################################
 
@@ -111,11 +116,11 @@ file(MAKE_DIRECTORY ${GENERATED_FILES_DIR})
 
 #Generate the AMReX_buildInfo.cpp file with Python
 add_custom_target(generate_build_info_${amr_wind_exe_name} ALL
-   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/submods/amrex/Tools/C_scripts/makebuildinfo_C.py
-   --amrex_home "${CMAKE_SOURCE_DIR}/submods/amrex"                        
+   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/${AMREX_SUBMOD_LOCATION}/Tools/C_scripts/makebuildinfo_C.py
+   --amrex_home "${CMAKE_SOURCE_DIR}/${AMREX_SUBMOD_LOCATION}"
    --COMP ${CMAKE_CXX_COMPILER_ID} --COMP_VERSION ${CMAKE_CXX_COMPILER_VERSION}
    --FCOMP ${CMAKE_Fortran_COMPILER_ID} --FCOMP_VERSION ${CMAKE_Fortran_COMPILER_VERSION}
-   --GIT "${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/submods/amrex"
+   --GIT "${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/${AMREX_SUBMOD_LOCATION}"
    WORKING_DIRECTORY ${GENERATED_FILES_DIR} BYPRODUCTS ${GENERATED_FILES_DIR}/AMReX_buildInfo.cpp
    COMMENT "Generating AMReX_buildInfo.cpp"
 )                  

--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -53,11 +53,7 @@ function(add_test_r TEST_NAME NP)
     set(PLOT_TEST ${CURRENT_TEST_BINARY_DIR}/plt00010)
     # Find fcompare
     if(AMR_WIND_TEST_WITH_FCOMPARE)
-      set(FCOMPARE ${CMAKE_BINARY_DIR}/fcompare)
-    endif()
-    # Find fextrema
-    if(AMR_WIND_TEST_WITH_FEXTREMA)
-      set(FEXTREMA ${CMAKE_BINARY_DIR}/fextrema)
+      set(FCOMPARE ${CMAKE_BINARY_DIR}/${AMREX_SUBMOD_LOCATION}/Tools/PlotFile/fcompare)
     endif()
     # Make working directory for test
     file(MAKE_DIRECTORY ${CURRENT_TEST_BINARY_DIR})
@@ -71,17 +67,13 @@ function(add_test_r TEST_NAME NP)
     if(AMR_WIND_TEST_WITH_FCOMPARE)
       set(FCOMPARE_COMMAND "&& ${FCOMPARE} ${PLOT_GOLD} ${PLOT_TEST}")
     endif()
-    # Use fextrema to test diffs in plots against gold files
-    if(AMR_WIND_TEST_WITH_FEXTREMA)
-      set(FEXTREMA_COMMAND "&& ${FEXTREMA} ${PLOT_TEST} > ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.ext && ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_files/fextrema_compare.py -f ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.ext -g ${CURRENT_TEST_SOURCE_DIR}/${TEST_NAME}.ext.gold -t ${TOLERANCE}")
-    endif()
     if(AMR_WIND_ENABLE_MPI)
       set(MPI_COMMANDS "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NP} ${MPIEXEC_PREFLAGS}")
     else()
       unset(MPI_COMMANDS)
     endif()
     # Add test and actual test commands to CTest database
-    add_test(${TEST_NAME} sh -c "${MPI_COMMANDS} ${CMAKE_BINARY_DIR}/${amr_wind_exe_name} ${MPIEXEC_POSTFLAGS} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} ${FEXTREMA_COMMAND} ${FCOMPARE_COMMAND}")
+    add_test(${TEST_NAME} sh -c "${MPI_COMMANDS} ${CMAKE_BINARY_DIR}/${amr_wind_exe_name} ${MPIEXEC_POSTFLAGS} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} ${FCOMPARE_COMMAND}")
     # Set properties for test
     set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 1500 PROCESSORS ${NP} WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}/" LABELS "regression")
 endfunction(add_test_r)
@@ -112,6 +104,10 @@ add_test_r(tgv_godunov 4)
 
 #=============================================================================
 # Verification tests
+#=============================================================================
+
+#=============================================================================
+# Performance tests
 #=============================================================================
 
 #=============================================================================


### PR DESCRIPTION
This should hopefully fix fcompare in the nightly tests. I wasn't building it first. I also removed fextrema stuff because we should probably test against the kinetic energy output or something in travis instead.

The current warnings are a failure of my test script which I have fixed.