### PR TITLE
Fix warnings in amr-wind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set(amr_wind_unit_test_exe_name "${amr_wind_exe_name}_unit_tests")
 add_executable(${amr_wind_exe_name} "")
 
 include(${CMAKE_SOURCE_DIR}/cmake/set_compile_flags.cmake)
+include(${CMAKE_SOURCE_DIR}/cmake/amr-wind-utils.cmake)
 
 #Keep our Fortran module files confined to a unique directory for each executable 
 set_target_properties(${amr_wind_exe_name} PROPERTIES Fortran_MODULE_DIRECTORY

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -1,0 +1,17 @@
+
+# target_link_libraries_system
+#
+# This function is similar to target_link_libraries but allows the includes
+# determined from the library to be added as system includes to suppress
+# warnings generated from those header files
+#
+# https://stackoverflow.com/questions/52135983/cmake-target-link-libraries-include-as-system-to-suppress-compiler-warnings/52136398#52136398
+#
+function(target_link_libraries_system target)
+  set(libs ${ARGN})
+  foreach(lib ${libs})
+    get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(${target} SYSTEM PRIVATE ${lib_include_dirs})
+    target_link_libraries(${target} ${lib})
+  endforeach(lib)
+endfunction(target_link_libraries_system)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,4 +39,4 @@ if(AMR_WIND_ENABLE_EB)
 endif()
 
 #Link to amrex library
-target_link_libraries(${amr_wind_exe_name} PRIVATE amrex)
+target_link_libraries_system(${amr_wind_exe_name} amrex)

--- a/src/convection/incflo_MAC_bcs.cpp
+++ b/src/convection/incflo_MAC_bcs.cpp
@@ -11,7 +11,7 @@ void incflo_set_mac_bcs (Box const& domain,
                          Array4<Real> const& w,
                          Array4<Real const> const& vel,
                          Vector<BCRec> const& h_bcrec,
-                         BCRec const* d_bcrec)
+                         BCRec const* /* d_bcrec */)
 {
     int idim = 0;
     if (h_bcrec[idim].lo(idim) == BCType::ext_dir and

--- a/src/convection/incflo_MAC_projection.cpp
+++ b/src/convection/incflo_MAC_projection.cpp
@@ -38,7 +38,7 @@ incflo::apply_MAC_projection (Vector<MultiFab*> const& u_mac,
                               Vector<MultiFab*> const& v_mac,
                               Vector<MultiFab*> const& w_mac,
                               Vector<MultiFab const*> const& density,
-                              Real time)
+                              Real /* time */)
 {
     BL_PROFILE("incflo::apply_MAC_projection()");
 

--- a/src/convection/incflo_compute_advection_term.cpp
+++ b/src/convection/incflo_compute_advection_term.cpp
@@ -78,7 +78,12 @@ incflo::compute_convective_term (Vector<MultiFab*> const& conv_u,
 }
 
 void
-incflo::compute_convective_term (Box const& bx, int lev, MFIter const& mfi,
+incflo::compute_convective_term (Box const& bx, int lev,
+#ifdef AMREX_USE_EB
+                                 MFIter const& mfi,
+#else
+                                 MFIter const&,
+#endif
                                  Array4<Real> const& dvdt, // velocity
                                  Array4<Real> const& drdt, // density
                                  Array4<Real> const& dtdt, // tracer

--- a/src/convection/incflo_correct_small_cells.cpp
+++ b/src/convection/incflo_correct_small_cells.cpp
@@ -2,6 +2,7 @@
 
 using namespace amrex;
 
+#ifdef AMREX_USE_EB
 void
 incflo::incflo_correct_small_cells (Vector<MultiFab*      > const& vel_in,
                                     Vector<MultiFab const*> const& u_mac,
@@ -9,7 +10,6 @@ incflo::incflo_correct_small_cells (Vector<MultiFab*      > const& vel_in,
                                     Vector<MultiFab const*> const& w_mac)
 
 {
-#ifdef AMREX_USE_EB
     BL_PROFILE("incflo::incflo_correct_small_cells");
 
     for (int lev = 0; lev <= finest_level; lev++)
@@ -71,5 +71,12 @@ incflo::incflo_correct_small_cells (Vector<MultiFab*      > const& vel_in,
           }
        }
     }
-#endif
 }
+#else
+void
+incflo::incflo_correct_small_cells (Vector<MultiFab*      > const& /* vel_in */,
+                                    Vector<MultiFab const*> const& /* u_mac  */,
+                                    Vector<MultiFab const*> const& /* v_mac  */,
+                                    Vector<MultiFab const*> const& /* w_mac  */)
+{}
+#endif

--- a/src/convection/incflo_godunov_ppm.H
+++ b/src/convection/incflo_godunov_ppm.H
@@ -686,13 +686,13 @@ void Godunov_trans_xbc(const int i, const int j, const int k, const int n,
                               const amrex::Array4<const amrex::Real> &s, 
                                     amrex::Real &lo,
                                     amrex::Real &hi,
-                                    amrex::Real &uedge,
+                                    amrex::Real & /* uedge */,
                               const int bclo, const int bchi, 
                               const int domlo, const int domhi)
 {
     using namespace amrex;
 
-    constexpr amrex::Real small_vel = 1e-10;
+    // constexpr amrex::Real small_vel = 1e-10;
 
     // Low X
     if (i <= domlo)
@@ -743,16 +743,16 @@ void Godunov_trans_xbc(const int i, const int j, const int k, const int n,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void Godunov_trans_ybc(const int i, const int j, const int k, const int n,
-                              const amrex::Array4<const amrex::Real> &s, 
-                                    amrex::Real &lo,
-                                    amrex::Real &hi,
-                                    amrex::Real vedge,
-                              const int bclo, const int bchi, 
-                              const int domlo, const int domhi)
+                       const amrex::Array4<const amrex::Real> &s,
+                       amrex::Real &lo,
+                       amrex::Real &hi,
+                       amrex::Real /* vedge */,
+                       const int bclo, const int bchi,
+                       const int domlo, const int domhi)
 {
     using namespace amrex;
 
-    constexpr amrex::Real small_vel = 1e-10;
+    // constexpr amrex::Real small_vel = 1e-10;
 
     // Low Y 
     if (j <= domlo)
@@ -803,16 +803,16 @@ void Godunov_trans_ybc(const int i, const int j, const int k, const int n,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void Godunov_trans_zbc(const int i, const int j, const int k, const int n,
-                              const amrex::Array4<const amrex::Real> &s, 
-                                    amrex::Real &lo,
-                                    amrex::Real &hi,
-                                    amrex::Real wedge,
-                              const int bclo, const int bchi, 
-                              const int domlo, const int domhi)
+                       const amrex::Array4<const amrex::Real> &s,
+                       amrex::Real &lo,
+                       amrex::Real &hi,
+                       amrex::Real /* wedge */,
+                       const int bclo, const int bchi,
+                       const int domlo, const int domhi)
 {
     using namespace amrex;
 
-    constexpr amrex::Real small_vel = 1e-10;
+    // constexpr amrex::Real small_vel = 1e-10;
 
     // Low Z
     if (k <= domlo)

--- a/src/convection/incflo_godunov_ppm.cpp
+++ b/src/convection/incflo_godunov_ppm.cpp
@@ -3,7 +3,7 @@
 
 using namespace amrex;
 
-void incflo::predict_ppm (int lev, Box const& bx, int ncomp,
+void incflo::predict_ppm (int lev, Box const& bx, int /* ncomp */,
                           Array4<Real> const& Imx,
                           Array4<Real> const& Ipx,
                           Array4<Real> const& Imy,

--- a/src/convection/incflo_godunov_predict.cpp
+++ b/src/convection/incflo_godunov_predict.cpp
@@ -8,7 +8,7 @@
 
 using namespace amrex;
 
-void incflo::predict_godunov (int lev, Real time, MultiFab& u_mac, MultiFab& v_mac,
+void incflo::predict_godunov (int lev, Real /* time */, MultiFab& u_mac, MultiFab& v_mac,
                               MultiFab& w_mac, MultiFab const& vel, MultiFab const& vel_forces)
 {
     Box const& domain = Geom(lev).Domain();

--- a/src/convection/incflo_mol_fluxes_eb.cpp
+++ b/src/convection/incflo_mol_fluxes_eb.cpp
@@ -4,6 +4,7 @@
 
 using namespace amrex;
 
+#ifdef AMREX_USE_EB
 namespace {
     std::pair<bool,bool> has_extdir (BCRec const* bcrec, int ncomp, int dir)
     {
@@ -16,7 +17,6 @@ namespace {
     }
 }
 
-#ifdef AMREX_USE_EB
 void incflo::compute_convective_fluxes_eb (int lev, Box const& bx, int ncomp,
                                            Array4<Real> const& fx,
                                            Array4<Real> const& fy,

--- a/src/derive/derive.cpp
+++ b/src/derive/derive.cpp
@@ -5,7 +5,7 @@
 
 using namespace amrex;
 
-void incflo::ComputeDivU(Real time_in)
+void incflo::ComputeDivU(Real /* time_in */)
 {
 #if 0
 
@@ -40,7 +40,7 @@ void incflo::ComputeDivU(Real time_in)
 #endif
 }
 
-void incflo::ComputeStrainrate(Real time_in)
+void incflo::ComputeStrainrate(Real /* time_in */)
 {
 #if 0
     BL_PROFILE("incflo::ComputeStrainrate");
@@ -313,7 +313,7 @@ Real incflo::ComputeKineticEnergy () const
 
 }
 
-void incflo::ComputeVorticity (int lev, Real t, MultiFab& vort, MultiFab const& vel)
+void incflo::ComputeVorticity (int lev, Real /* t */, MultiFab& vort, MultiFab const& vel)
 {
     BL_PROFILE("incflo::ComputeVorticity");
 

--- a/src/diffusion/DiffusionScalarOp.cpp
+++ b/src/diffusion/DiffusionScalarOp.cpp
@@ -86,7 +86,7 @@ void
 DiffusionScalarOp::diffuse_scalar (Vector<MultiFab*> const& tracer,
                                    Vector<MultiFab*> const& density,
                                    Vector<MultiFab const*> const& eta,
-                                   Real t, Real dt)
+                                   Real /* t */, Real dt)
 {
     //
     //      alpha a - beta div ( b grad )   <--->   rho - dt div ( mu grad )
@@ -201,7 +201,7 @@ void DiffusionScalarOp::compute_laps (Vector<MultiFab*> const& a_laps,
                                       Vector<MultiFab const*> const& a_tracer,
                                       Vector<MultiFab const*> const& a_density,
                                       Vector<MultiFab const*> const& a_eta,
-                                      Real t)
+                                      Real /* t */)
 {
     BL_PROFILE("DiffusionScalarOp::compute_laps");
 

--- a/src/diffusion/DiffusionTensorOp.cpp
+++ b/src/diffusion/DiffusionTensorOp.cpp
@@ -87,7 +87,7 @@ void
 DiffusionTensorOp::diffuse_velocity (Vector<MultiFab*> const& velocity,
                                      Vector<MultiFab const*> const& density,
                                      Vector<MultiFab const*> const& eta,
-                                     Real t, Real dt)
+                                     Real /* t */, Real dt)
 {
     //
     //      alpha a - beta div ( b grad )   <--->   rho - dt div ( mu grad )
@@ -198,7 +198,7 @@ void DiffusionTensorOp::compute_divtau (Vector<MultiFab*> const& a_divtau,
                                         Vector<MultiFab const*> const& a_velocity,
                                         Vector<MultiFab const*> const& a_density,
                                         Vector<MultiFab const*> const& a_eta,
-                                        Real t)
+                                        Real /* t */)
 {
     BL_PROFILE("DiffusionTensorOp::compute_divtau");
 

--- a/src/diffusion/incflo_diffusion.cpp
+++ b/src/diffusion/incflo_diffusion.cpp
@@ -158,14 +158,14 @@ incflo::wall_model_bc(const int lev,
         if (!gm.isPeriodic(idim)) {
             if (bx.smallEnd(idim) == domain.smallEnd(idim)) {
                 amrex::ParallelFor(amrex::bdryLo(bx, idim),
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_DEVICE (int , int , int ) noexcept
                 {
                     amrex::Abort("wall model bc assumes periodic should not be in here xlo");
                 });
             }
             if (bx.bigEnd(idim) == domain.bigEnd(idim)) {
                 amrex::ParallelFor(amrex::bdryHi(bx, idim),
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_DEVICE (int , int , int ) noexcept
                 {
                     amrex::Abort("wall model bc assumes periodic should not be in here xhi");
                 });
@@ -176,14 +176,14 @@ incflo::wall_model_bc(const int lev,
         if (!gm.isPeriodic(idim)) {
             if (bx.smallEnd(idim) == domain.smallEnd(idim)) {
                 amrex::ParallelFor(amrex::bdryLo(bx, idim),
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_DEVICE (int , int , int ) noexcept
                 {
                     amrex::Abort("wall model bc assumes periodic should not be in here ylo");
                 });
             }
             if (bx.bigEnd(idim) == domain.bigEnd(idim)) {
                 amrex::ParallelFor(amrex::bdryHi(bx, idim),
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=] AMREX_GPU_DEVICE (int , int , int ) noexcept
                 {
                     amrex::Abort("wall model bc assumes periodic should not be in here yhi");
                 });

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -215,7 +215,7 @@ void incflo::AverageDown()
     }
 }
 
-void incflo::AverageDownTo(int crse_lev)
+void incflo::AverageDownTo(int /* crse_lev */)
 {
     amrex::Abort("xxxxx TODO AverageDownTo");
 }

--- a/src/incflo_tagging.cpp
+++ b/src/incflo_tagging.cpp
@@ -8,7 +8,7 @@ using namespace amrex;
 
 // tag cells for refinement
 // overrides the pure virtual function in AmrCore
-void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow)
+void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int /* ngrow */)
 {
     BL_PROFILE("incflo::ErrorEst()");
 
@@ -61,7 +61,7 @@ void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow)
             Real rhoerr = tag_rho ? rhoerr_v[lev]: std::numeric_limits<Real>::max();
             Real gradrhoerr = tag_gradrho ? gradrhoerr_v[lev] : std::numeric_limits<Real>::max();
             amrex::ParallelFor(bx,
-            [tag_rho,tag_gradrho,rhoerr,gradrhoerr,tagval,rho,tag]
+            [tag_rho,tag_gradrho,rhoerr,gradrhoerr,rho,tag]
             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 if (tag_rho and rho(i,j,k) > rhoerr) {

--- a/src/prob/prob_bc.H
+++ b/src/prob/prob_bc.H
@@ -18,10 +18,10 @@ struct IncfloVelFill
 
     AMREX_GPU_DEVICE
     void operator() (const amrex::IntVect& iv, amrex::Array4<amrex::Real> const& vel,
-                     const int dcomp, const int numcomp,
-                     amrex::GeometryData const& geom, const amrex::Real time,
+                     const int /*dcomp */, const int /* numcomp */,
+                     amrex::GeometryData const& geom, const amrex::Real /* time */,
                      const amrex::BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
+                     const int /* orig_comp */) const
     {
         using namespace amrex;
 
@@ -113,10 +113,10 @@ struct IncfloDenFill
 
     AMREX_GPU_DEVICE
     void operator() (const amrex::IntVect& iv, amrex::Array4<amrex::Real> const& rho,
-                     const int dcomp, const int numcomp,
-                     amrex::GeometryData const& geom, const amrex::Real time,
+                     const int /* dcomp */, const int /* numcomp */,
+                     amrex::GeometryData const& geom, const amrex::Real /* time */,
                      const amrex::BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
+                     const int /* orig_comp */) const
     {
         using namespace amrex;
 
@@ -169,10 +169,10 @@ struct IncfloTracFill
 
     AMREX_GPU_DEVICE
     void operator() (const amrex::IntVect& iv, amrex::Array4<amrex::Real> const& tracer,
-                     const int dcomp, const int numcomp,
-                     amrex::GeometryData const& geom, const amrex::Real time,
+                     const int /* dcomp */, const int /* numcomp */,
+                     amrex::GeometryData const& geom, const amrex::Real /* time */,
                      const amrex::BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
+                     const int /* orig_comp */) const
     {
         using namespace amrex;
 
@@ -225,12 +225,16 @@ struct IncfloForFill
     constexpr IncfloForFill (int a_probtype) : probtype(a_probtype) {}
 
     AMREX_GPU_DEVICE
-    void operator() (const amrex::IntVect& iv, amrex::Array4<amrex::Real> const& vel,
-                     const int dcomp, const int numcomp,
-                     amrex::GeometryData const& geom, const amrex::Real time,
-                     const amrex::BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
-    {}
+	void operator()(const amrex::IntVect& /* iv */,
+					amrex::Array4<amrex::Real> const& /* vel */,
+					const int /* dcomp */,
+					const int /* numcomp */,
+					amrex::GeometryData const& /* geom */,
+					const amrex::Real /* time */,
+					const amrex::BCRec* /* bcr */,
+					const int /* bcomp */,
+					const int /* orig_comp */) const
+	{}
 };
 
 #endif

--- a/src/prob/prob_bc.cpp
+++ b/src/prob/prob_bc.cpp
@@ -2,8 +2,8 @@
 
 using namespace amrex;
 
-void incflo::prob_set_inflow_velocity (int grid_id, Orientation ori, Box const& bx,
-                                       Array4<Real> const& vel, int lev, Real time)
+void incflo::prob_set_inflow_velocity (int /* grid_id */, Orientation ori, Box const& bx,
+                                       Array4<Real> const& vel, int lev, Real /* time */)
 {
     if (31 == m_probtype)
     {
@@ -28,7 +28,6 @@ void incflo::prob_set_inflow_velocity (int grid_id, Orientation ori, Box const& 
     else if (41 == m_probtype)
     {
         Real dzinv = 1.0 / Geom(lev).Domain().length(2);
-        Real u = m_ic_u;
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real z = (k+0.5)*dzinv;

--- a/src/prob/prob_init_fluid.cpp
+++ b/src/prob/prob_init_fluid.cpp
@@ -119,15 +119,15 @@ void incflo::prob_init_fluid (int lev)
     }
 }
 
-void incflo::init_taylor_green (Box const& vbx, Box const& gbx,
-                                Array4<Real> const& p,
+void incflo::init_taylor_green (Box const& vbx, Box const& /* gbx */,
+                                Array4<Real> const& /* p */,
                                 Array4<Real> const& vel,
-                                Array4<Real> const& density,
-                                Array4<Real> const& tracer,
-                                Box const& domain,
+                                Array4<Real> const& /* density */,
+                                Array4<Real> const& /* tracer */,
+                                Box const& /* domain */,
                                 GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                                GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                                GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                                GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                                GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
@@ -140,15 +140,15 @@ void incflo::init_taylor_green (Box const& vbx, Box const& gbx,
     });
 }
 
-void incflo::init_taylor_green3d (Box const& vbx, Box const& gbx,
-                                  Array4<Real> const& p,
+void incflo::init_taylor_green3d (Box const& vbx, Box const& /* gbx */,
+                                  Array4<Real> const& /* p */,
                                   Array4<Real> const& vel,
-                                  Array4<Real> const& density,
-                                  Array4<Real> const& tracer,
-                                  Box const& domain,
+                                  Array4<Real> const& /* density */,
+                                  Array4<Real> const& /* tracer */,
+                                  Box const& /* domain */,
                                   GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                                  GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                                  GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                                  GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                                  GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
@@ -162,15 +162,15 @@ void incflo::init_taylor_green3d (Box const& vbx, Box const& gbx,
     });
 }
 
-void incflo::init_couette (Box const& vbx, Box const& gbx,
-                           Array4<Real> const& p,
+void incflo::init_couette (Box const& vbx, Box const& /* gbx */,
+                           Array4<Real> const& /* p */,
                            Array4<Real> const& vel,
-                           Array4<Real> const& density,
-                           Array4<Real> const& tracer,
+                           Array4<Real> const& /* density */,
+                           Array4<Real> const& /* tracer  */,
                            Box const& domain,
-                           GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                           GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                           GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                           GpuArray<Real, AMREX_SPACEDIM> const& /* dx */,
+                           GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                           GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     Real num_cells_y = static_cast<Real>(domain.length(1));
     amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -183,12 +183,12 @@ void incflo::init_couette (Box const& vbx, Box const& gbx,
 }
 
 
-void incflo::init_rayleigh_taylor (Box const& vbx, Box const& gbx,
-                                   Array4<Real> const& p,
+void incflo::init_rayleigh_taylor (Box const& vbx, Box const& /* gbx */,
+                                   Array4<Real> const& /* p */,
                                    Array4<Real> const& vel,
                                    Array4<Real> const& density,
-                                   Array4<Real> const& tracer,
-                                   Box const& domain,
+                                   Array4<Real> const& /* tracer */,
+                                   Box const& /* domain */,
                                    GpuArray<Real, AMREX_SPACEDIM> const& dx,
                                    GpuArray<Real, AMREX_SPACEDIM> const& problo,
                                    GpuArray<Real, AMREX_SPACEDIM> const& probhi)
@@ -214,15 +214,15 @@ void incflo::init_rayleigh_taylor (Box const& vbx, Box const& gbx,
     });
 }
 
-void incflo::init_tuscan (Box const& vbx, Box const& gbx,
-                          Array4<Real> const& p,
+void incflo::init_tuscan (Box const& vbx, Box const& /* gbx */,
+                          Array4<Real> const& /* p */,
                           Array4<Real> const& vel,
                           Array4<Real> const& density,
                           Array4<Real> const& tracer,
                           Box const& domain,
-                          GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                          GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                          GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                          GpuArray<Real, AMREX_SPACEDIM> const& /* dx */,
+                          GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                          GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     int half_num_cells = domain.length(2) / 2;
     Real T0 = .01;
@@ -239,12 +239,12 @@ void incflo::init_tuscan (Box const& vbx, Box const& gbx,
         }
     });
 }
-void incflo::init_periodic_tracer (Box const& vbx, Box const& gbx,
-                                   Array4<Real> const& p,
+void incflo::init_periodic_tracer (Box const& vbx, Box const& /* gbx */,
+                                   Array4<Real> const& /* p */,
                                    Array4<Real> const& vel,
-                                   Array4<Real> const& density,
+                                   Array4<Real> const& /* density */,
                                    Array4<Real> const& tracer,
-                                   Box const& domain,
+                                   Box const& /* domain */,
                                    GpuArray<Real, AMREX_SPACEDIM> const& dx,
                                    GpuArray<Real, AMREX_SPACEDIM> const& problo,
                                    GpuArray<Real, AMREX_SPACEDIM> const& probhi)
@@ -264,15 +264,15 @@ void incflo::init_periodic_tracer (Box const& vbx, Box const& gbx,
     });
 }
 
-void incflo::init_double_shear_layer (Box const& vbx, Box const& gbx,
-                                      Array4<Real> const& p,
+void incflo::init_double_shear_layer (Box const& vbx, Box const& /* gbx */,
+                                      Array4<Real> const& /* p */,
                                       Array4<Real> const& vel,
-                                      Array4<Real> const& density,
-                                      Array4<Real> const& tracer,
-                                      Box const& domain,
+                                      Array4<Real> const& /* density */,
+                                      Array4<Real> const& /* tracer */,
+                                      Box const& /* domain */,
                                       GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                                      GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                                      GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                                      GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                                      GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     static constexpr Real twopi = 2.0 * 3.1415926535897932;
      if (21 == m_probtype)
@@ -314,20 +314,19 @@ void incflo::init_double_shear_layer (Box const& vbx, Box const& gbx,
     };
 }
 
-void incflo::init_plane_poiseuille (Box const& vbx, Box const& gbx,
-                                    Array4<Real> const& p,
+void incflo::init_plane_poiseuille (Box const& vbx, Box const& /* gbx */,
+                                    Array4<Real> const& /* p */,
                                     Array4<Real> const& vel,
-                                    Array4<Real> const& density,
+                                    Array4<Real> const& /* density */,
                                     Array4<Real> const& tracer,
                                     Box const& domain,
-                                    GpuArray<Real, AMREX_SPACEDIM> const& dx,
-                                    GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                                    GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                                    GpuArray<Real, AMREX_SPACEDIM> const& /* dx */,
+                                    GpuArray<Real, AMREX_SPACEDIM> const& /* problo */,
+                                    GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
     Real dxinv = 1.0 / domain.length(0);
     Real dyinv = 1.0 / domain.length(1);
     Real dzinv = 1.0 / domain.length(2);
-    const auto dlo = amrex::lbound(domain);
     const auto dhi = amrex::ubound(domain);
 
     if (31 == m_probtype)
@@ -370,7 +369,6 @@ void incflo::init_plane_poiseuille (Box const& vbx, Box const& gbx,
     }
     else if (41 == m_probtype)
     {
-        Real u = m_ic_u;
         amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real z = (k+0.5)*dzinv;
@@ -470,25 +468,23 @@ void incflo::init_plane_poiseuille (Box const& vbx, Box const& gbx,
 }
 
 
-void incflo::init_abl (Box const& vbx, Box const& gbx,
-                       Array4<Real> const& p,
+void incflo::init_abl (Box const& vbx, Box const& /* gbx */,
+                       Array4<Real> const& /* p */,
                        Array4<Real> const& vel,
                        Array4<Real> const& density,
                        Array4<Real> const& tracer,
-                       Box const& domain,
+                       Box const& /* domain */,
                        GpuArray<Real, AMREX_SPACEDIM> const& dx,
                        GpuArray<Real, AMREX_SPACEDIM> const& problo,
-                       GpuArray<Real, AMREX_SPACEDIM> const& probhi)
+                       GpuArray<Real, AMREX_SPACEDIM> const& /* probhi */)
 {
-    
-    
-    const Real cutoff_height = m_cutoff_height;
+    // const Real cutoff_height = m_cutoff_height;
     const Real Uperiods = m_Uperiods;
     const Real Vperiods = m_Vperiods;
     const Real deltaU = m_deltaU;
     const Real deltaV = m_deltaV;
     const Real zRefHeight = m_zRefHeight;
-    const Real theta_amplitude = m_theta_amplitude;
+    // const Real theta_amplitude = m_theta_amplitude;
     
     const Real pi = std::acos(-1.0);
     const Real aval = Uperiods*2.0*pi/(geom[0].ProbHi(1) - geom[0].ProbLo(1));

--- a/src/rheology/incflo_rheology.cpp
+++ b/src/rheology/incflo_rheology.cpp
@@ -56,8 +56,8 @@ void incflo::compute_viscosity (Vector<MultiFab*> const& vel_eta,
                                 Vector<MultiFab*> const& tra_eta,
                                 Vector<MultiFab const*> const& rho,
                                 Vector<MultiFab const*> const& vel,
-                                Vector<MultiFab const*> const& tra,
-                                Real time, int nghost)
+                                Vector<MultiFab const*> const& /* tra */,
+                                Real /* time */, int nghost)
 {
     if (m_fluid_model == FluidModel::Newtonian)
     {

--- a/src/utilities/diagnostics.cpp
+++ b/src/utilities/diagnostics.cpp
@@ -5,7 +5,7 @@ using namespace amrex;
 //
 // Print maximum values (useful for tracking evolution)
 //
-void incflo::PrintMaxValues(Real time_in)
+void incflo::PrintMaxValues(Real /* time_in */)
 {
     
 #if AMREX_USE_EB


### PR DESCRIPTION
- Introduce a new CMake utility function that adds AMReX headers with `-isystem`
- Fix source code to remove all warnings in amr-wind source files