### PR TITLE
tracer and velocity at n+1/2 for more accurate forcing

### DIFF
--- a/src/core/Physics.H
+++ b/src/core/Physics.H
@@ -25,16 +25,9 @@ public:
     //! Add momentum source terms
     virtual void add_momentum_sources(
         const amrex::Geometry& geom,
-        const LevelData& leveldata,
-        amrex::MultiFab& vel_forces) const = 0;
-
-    //! Add momentum source terms
-    virtual void add_momentum_sources(
-        const amrex::Geometry& geom,
         const amrex::MultiFab& density,
         const amrex::MultiFab& velocity,
-        const amrex::MultiFab& scalars_old,
-        const amrex::MultiFab& scalars_new,
+        const amrex::MultiFab& scalars,
         amrex::MultiFab& vel_forces) const = 0;
 };
 

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -87,13 +87,11 @@ public: // for cuda
     void compute_vel_forces (amrex::Vector<amrex::MultiFab*> const& vel_forces,
                              amrex::Vector<amrex::MultiFab const*> const& velocity,
                              amrex::Vector<amrex::MultiFab const*> const& density,
-                             amrex::Vector<amrex::MultiFab const*> const& tracer_old,
-                             amrex::Vector<amrex::MultiFab const*> const& tracer_new);
+                             amrex::Vector<amrex::MultiFab const*> const& tracer);
     void compute_vel_forces_on_level ( int lev,
                                        amrex::MultiFab& vel_forces,
                                        const amrex::MultiFab& density,
-                                       const amrex::MultiFab& tracer_old,
-                                       const amrex::MultiFab& tracer_new);
+                                       const amrex::MultiFab& tracer);
     void compute_vel_pressure_terms(int lev, amrex::MultiFab& vel_forces,
                                     const amrex::MultiFab& density);
 

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -633,7 +633,6 @@ void incflo::ApplyCorrector()
     // Allocate space for half-time density
     // *************************************************************************************
     Vector<MultiFab> density_nph;
-    Vector<MultiFab> velocity_nph;
     Vector<MultiFab> tracer_nph;
 
     for (int lev = 0; lev <= finest_level; ++lev) {

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -277,9 +277,9 @@ void incflo::ApplyPredictor (bool incremental_projection)
                             GetVecOfConstPtrs(vel_forces), GetVecOfConstPtrs(tra_forces),
                             m_time.current_time());
 
-    // velocity at n+1/2
+    // average face velocity at n+1/2 to cell center
     for (int lev = 0; lev <= finest_level; lev++){
-        amrex::average_face_to_cellcenter(velocity_nph[lev],0,Vector<const MultiFab*> {&u_mac[lev],&u_mac[lev],&u_mac[lev]});
+        amrex::average_face_to_cellcenter(velocity_nph[lev],0,Vector<const MultiFab*> {&u_mac[lev],&v_mac[lev],&w_mac[lev]});
     }
     
     // *************************************************************************************
@@ -666,7 +666,7 @@ void incflo::ApplyCorrector()
                             {}, {}, new_time);
 
     for (int lev = 0; lev <= finest_level; lev++){
-        amrex::average_face_to_cellcenter(velocity_nph[lev],0,Vector<const MultiFab*> {&u_mac[lev],&u_mac[lev],&u_mac[lev]});
+        amrex::average_face_to_cellcenter(velocity_nph[lev],0,Vector<const MultiFab*> {&u_mac[lev],&v_mac[lev],&w_mac[lev]});
     }
     
     // *************************************************************************************
@@ -756,7 +756,6 @@ void incflo::ApplyCorrector()
                 Array4<Real const> const& rho_o   = ld.density_o.const_array(mfi);
                 Array4<Real      > const& tra     = ld.tracer.array(mfi);
                 Array4<Real const> const& rho     = ld.density.const_array(mfi);
-                Array4<Real const> const& rho_nph = density_nph[lev].const_array(mfi);
                 Array4<Real const> const& dtdt_o  = ld.conv_tracer_o.const_array(mfi);
                 Array4<Real const> const& dtdt    = ld.conv_tracer.const_array(mfi);
                 Array4<Real const> const& tra_f   = (l_ntrac > 0) ? tra_forces[lev].const_array(mfi)

--- a/src/incflo_compute_forces.cpp
+++ b/src/incflo_compute_forces.cpp
@@ -35,8 +35,7 @@ void incflo::compute_tra_forces (Vector<MultiFab*> const& tra_forces,
 void incflo::compute_vel_forces (Vector<MultiFab*> const& vel_forces,
                                  Vector<MultiFab const*> const& velocity,
                                  Vector<MultiFab const*> const& density,
-                                 Vector<MultiFab const*> const& tracer_old,
-                                 Vector<MultiFab const*> const& tracer_new)
+                                 Vector<MultiFab const*> const& tracer)
 {
     // FIXME: Clean up problem type specific logic
     if (m_probtype == 35) {
@@ -45,13 +44,13 @@ void incflo::compute_vel_forces (Vector<MultiFab*> const& vel_forces,
 
             for (auto& pp: m_physics) {
                 pp->add_momentum_sources(
-                    Geom(lev), *density[lev], *velocity[lev], *tracer_old[lev], *tracer_new[lev], *vel_forces[lev]);
+                    Geom(lev), *density[lev], *velocity[lev], *tracer[lev], *vel_forces[lev]);
             }
         }
     } else {
         for (int lev = 0; lev <= finest_level; ++lev)
             compute_vel_forces_on_level(
-                lev, *vel_forces[lev], *density[lev], *tracer_old[lev],*tracer_new[lev]);
+                lev, *vel_forces[lev], *density[lev], *tracer[lev]);
     }
 }
 
@@ -81,8 +80,7 @@ void incflo::compute_vel_pressure_terms(int lev, amrex::MultiFab& vel_forces,
 void incflo::compute_vel_forces_on_level (int lev,
                                                 MultiFab& vel_forces,
                                           const MultiFab& density,
-                                          const MultiFab& tracer_old,
-                                          const MultiFab& tracer_new)
+                                          const MultiFab& tracer)
 {
     GpuArray<Real,3> l_gravity{m_gravity[0],m_gravity[1],m_gravity[2]};
     GpuArray<Real,3> l_gp0{m_gp0[0], m_gp0[1], m_gp0[2]};
@@ -100,13 +98,12 @@ void incflo::compute_vel_forces_on_level (int lev,
         if (m_use_boussinesq) {
             // This uses a Boussinesq approximation where the buoyancy depends on
             //      first tracer rather than density
-            Array4<Real const> const& tra_o = tracer_old.const_array(mfi);
-            Array4<Real const> const& tra_n = tracer_new.const_array(mfi);
+            Array4<Real const> const& tra = tracer.const_array(mfi);
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                const int n = 0;
-                Real rhoinv = 1.0/rho(i,j,k);
-                Real ft = 0.5 * (tra_o(i,j,k,n) + tra_n(i,j,k,n));
+                const int n = 0;//fixme this won't work in the future
+                const Real rhoinv = 1.0/rho(i,j,k);
+                const Real ft = tra(i,j,k,n);
                 vel_f(i,j,k,0) = -gradp(i,j,k,0)*rhoinv + l_gravity[0] * ft;
                 vel_f(i,j,k,1) = -gradp(i,j,k,1)*rhoinv + l_gravity[1] * ft;
                 vel_f(i,j,k,2) = -gradp(i,j,k,2)*rhoinv + l_gravity[2] * ft;

--- a/src/utilities/io.cpp
+++ b/src/utilities/io.cpp
@@ -474,14 +474,16 @@ void incflo::WritePlotFile()
                 compute_vel_pressure_terms(lev, forcing, m_leveldata[lev]->density);
 
                 for (auto& pp: m_physics) {
-                    pp->add_momentum_sources(
-                        Geom(lev), *m_leveldata[lev], forcing);
+                    pp->add_momentum_sources(Geom(lev),
+                                             m_leveldata[lev]->density,
+                                             m_leveldata[lev]->velocity,
+                                             m_leveldata[lev]->tracer,
+                                             forcing);
                 }
 
             } else {
                 compute_vel_forces_on_level(lev, forcing,
                                             m_leveldata[lev]->density,
-                                            m_leveldata[lev]->tracer,
                                             m_leveldata[lev]->tracer);
             }
         }

--- a/src/wind_energy/ABL.H
+++ b/src/wind_energy/ABL.H
@@ -32,21 +32,15 @@ public:
         const amrex::Geometry& geom,
         LevelData& leveldata) const override;
 
+    //! Perform tasks necessary before advancing timestep
     void pre_advance_work() override;
-
-    //! Add momentum source terms
-    void add_momentum_sources(
-        const amrex::Geometry& geom,
-        const LevelData& leveldata,
-        amrex::MultiFab& vel_forces) const override;
 
     //! Add momentum source terms
     void add_momentum_sources(
         const amrex::Geometry& geom,
         const amrex::MultiFab& density,
         const amrex::MultiFab& velocity,
-        const amrex::MultiFab& scalars_old,
-        const amrex::MultiFab& scalars_new,
+        const amrex::MultiFab& scalars,
         amrex::MultiFab& vel_forces) const override;
 
     const ABLFieldInit& abl_initializer() const { return *m_field_init; }

--- a/src/wind_energy/ABL.cpp
+++ b/src/wind_energy/ABL.cpp
@@ -57,41 +57,9 @@ void ABL::initialize_fields(
  */
 void ABL::add_momentum_sources(
     const amrex::Geometry& /* geom */,
-    const LevelData& leveldata,
-    amrex::MultiFab& vel_forces) const
-{
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-    for (amrex::MFIter mfi(vel_forces, amrex::TilingIfNotGPU()); mfi.isValid();
-         ++mfi) {
-        const auto& bx = mfi.tilebox();
-        const auto& vf = vel_forces.array(mfi);
-
-        // Boussinesq buoyancy term
-        if (m_has_boussinesq) {
-            const auto& scalars_old = leveldata.tracer_o.const_array(mfi);
-            const auto& scalars_new = leveldata.tracer.const_array(mfi);
-            (*m_boussinesq)(bx, scalars_old, scalars_new, vf);
-        }
-
-        // Coriolis term
-        if (m_has_coriolis) {
-            const auto& vel = leveldata.velocity.const_array(mfi);
-            (*m_coriolis)(bx, vel, vf);
-        }
-
-        // Driving pressure gradient term
-        if (m_has_driving_dpdx) (*m_abl_forcing)(bx, vf);
-    }
-}
-
-void ABL::add_momentum_sources(
-    const amrex::Geometry& /* geom */,
     const amrex::MultiFab& /* density */,
     const amrex::MultiFab& velocity,
-    const amrex::MultiFab& scalars_old,
-    const amrex::MultiFab& scalars_new,
+    const amrex::MultiFab& scalars,
     amrex::MultiFab& vel_forces) const
 {
 #ifdef _OPENMP
@@ -104,9 +72,8 @@ void ABL::add_momentum_sources(
 
         // Boussinesq buoyancy term
         if (m_has_boussinesq) {
-            const auto& scal_o = scalars_old.const_array(mfi);
-            const auto& scal_n = scalars_new.const_array(mfi);
-            (*m_boussinesq)(bx, scal_o, scal_n, vf);
+            const auto& scal = scalars.const_array(mfi);
+            (*m_boussinesq)(bx, scal, vf);
         }
 
         // Coriolis term

--- a/src/wind_energy/BoussinesqBuoyancy.H
+++ b/src/wind_energy/BoussinesqBuoyancy.H
@@ -16,8 +16,7 @@ public:
 
     void operator()(
         const amrex::Box& bx,
-        const amrex::Array4<const amrex::Real>& scalars_old,
-        const amrex::Array4<const amrex::Real>& scalars_new,
+        const amrex::Array4<const amrex::Real>& scalars,
         const amrex::Array4<amrex::Real>& vel_forces) const;
 
 private:

--- a/src/wind_energy/BoussinesqBuoyancy.cpp
+++ b/src/wind_energy/BoussinesqBuoyancy.cpp
@@ -40,8 +40,7 @@ BoussinesqBuoyancy::BoussinesqBuoyancy()
  */
 void BoussinesqBuoyancy::operator()(
     const amrex::Box& bx,
-    const amrex::Array4<const amrex::Real>& scalars_old,
-    const amrex::Array4<const amrex::Real>& scalars_new,
+    const amrex::Array4<const amrex::Real>& scalars,
     const amrex::Array4<amrex::Real>& vel_forces) const
 {
     const amrex::Real T0 = m_ref_theta;
@@ -50,8 +49,7 @@ void BoussinesqBuoyancy::operator()(
         m_gravity[0], m_gravity[1], m_gravity[2]};
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        const amrex::Real T = 0.5*(scalars_old(i, j, k, 0) + scalars_new(i, j, k, 0));
-        const amrex::Real fac = beta * (T0 - T);
+        const amrex::Real fac = beta * (T0 - scalars(i, j, k, 0));
 
         vel_forces(i, j, k, 0) += gravity[0] * fac;
         vel_forces(i, j, k, 1) += gravity[1] * fac;


### PR DESCRIPTION
this adds a multifab that holds tracer^{n+1/2} so that the forcing functions do not have two inputs, it also uses mac velocities and a face to cell average to get veloicity at n+1/2. With the Coriolis term on this will cause differences in an ABL regression test