### PR TITLE
Working ABL unit test 

### DIFF
--- a/src/wind_energy/CMakeLists.txt
+++ b/src/wind_energy/CMakeLists.txt
@@ -10,4 +10,4 @@ target_sources(${amr_wind_lib_name}
   )
 
 target_include_directories(
-  ${amr_wind_lib_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  ${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${amr_wind_unit_test_exe_name}
   test_config.cpp
   )
 
+add_subdirectory(aw_test_utils)
 add_subdirectory(core)
 
 target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${amr_wind_unit_test_exe_name}
 
 add_subdirectory(aw_test_utils)
 add_subdirectory(core)
+add_subdirectory(wind_energy)
 
 target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/unit_tests/aw_test_utils/AmrTestMesh.H
+++ b/unit_tests/aw_test_utils/AmrTestMesh.H
@@ -1,0 +1,110 @@
+#ifndef AMRTESTMESH_H
+#define AMRTESTMESH_H
+
+#include <memory>
+#include <unordered_map>
+
+#include "AMReX_AmrCore.H"
+#include "LevelData.H"
+
+namespace amr_wind_tests {
+
+/** Manager for handling data at a given AMR level
+ */
+class TestLevelData
+{
+public:
+    using FabFactoryType = amrex::FArrayBoxFactory;
+
+    TestLevelData(
+        const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm);
+
+    virtual ~TestLevelData() = default;
+
+    /** Create field data at this level
+     *
+     *  @param name Unique name to refer to this field
+     *  @param ncomp Number of components (default 1)
+     *  @param num_ghost Number of ghost cells (default 0)
+     *
+     *  @return MultiFab for the newly declared field
+     */
+    virtual amrex::MultiFab&
+    declare_field(const std::string& name, const int ncomp = 1, const int num_ghost = 0);
+
+    /** Return reference to a previously created field
+     *
+     *  @param name Unique string identifier for the field
+     */
+    virtual amrex::MultiFab& get_field(const std::string& name);
+
+protected:
+    const amrex::BoxArray& m_ba;
+    const amrex::DistributionMapping& m_dm;
+
+    std::unique_ptr<amrex::FabFactory<amrex::FArrayBox>> m_factory;
+
+    std::unordered_map<std::string, amrex::MultiFab> m_fields;
+};
+
+/** Base class for tests that require a valid Mesh
+ *
+ *  This class specializes amrex::AmrCore and provides a barebones interface
+ *  that can be used within unit test fixtures.
+ */
+class AmrTestMesh : public amrex::AmrCore
+{
+public:
+    AmrTestMesh();
+
+    virtual ~AmrTestMesh() = default;
+
+    //! Create the initial AMR hierarchy
+    virtual void initialize_mesh(amrex::Real current_time);
+
+    /** Create field data on on all levels of the AmrMesh
+     *
+     *  @param name Unique name to refer to this field
+     *  @param ncomp Number of components (default 1)
+     *  @param num_ghost Number of ghost cells (default 0)
+     *
+     *  @return MultiFab for the newly declared field
+     */
+    amrex::Vector<amrex::MultiFab*> declare_field(
+        const std::string& name, const int ncomp = 1, const int num_ghost = 0);
+
+    /** Return a vector of existing field on all levels
+     *
+     *  @param name Unique string identifier for the field
+     */
+    amrex::Vector<amrex::MultiFab*> get_field(const std::string& name);
+
+    //! Return the total number of existing levels in AMR hierarchy
+    int num_levels() const { return finest_level + 1; }
+
+protected:
+    virtual void MakeNewLevelFromScratch(
+        int lev, amrex::Real time, const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm) override;
+
+    virtual void MakeNewLevelFromCoarse(
+        int lev, amrex::Real time, const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm) override;
+
+    virtual void RemakeLevel(
+        int lev, amrex::Real time, const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm) override;
+
+    virtual void ClearLevel(int lev) override;
+
+    virtual void
+    ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
+        override;
+
+    amrex::Vector<std::unique_ptr<TestLevelData>> m_leveldata;
+};
+
+}
+
+#endif /* AMRTESTMESH_H */

--- a/unit_tests/aw_test_utils/AmrTestMesh.cpp
+++ b/unit_tests/aw_test_utils/AmrTestMesh.cpp
@@ -1,0 +1,110 @@
+#include "AmrTestMesh.H"
+#include "gtest/gtest.h"
+#include "AMReX_MultiFab.H"
+
+namespace amr_wind_tests {
+
+TestLevelData::TestLevelData(
+    const amrex::BoxArray& ba, const amrex::DistributionMapping& dm)
+    : m_ba(ba), m_dm(dm), m_factory(new amrex::FArrayBoxFactory())
+{}
+
+amrex::MultiFab& TestLevelData::declare_field(
+    const std::string& name, const int ncomp, const int num_ghost)
+{
+    auto found = m_fields.find(name);
+    if (found != m_fields.end()) {
+        amrex::Abort("Attempt to register existing field: " + name);
+    }
+
+    m_fields[name] = amrex::MultiFab();
+    m_fields[name].define(
+        m_ba, m_dm, ncomp, num_ghost, amrex::MFInfo(), *m_factory);
+
+    return m_fields[name];
+}
+
+amrex::MultiFab& TestLevelData::get_field(const std::string& name)
+{
+    auto found = m_fields.find(name);
+    if (found == m_fields.end()) {
+        amrex::Abort("Cannot find field: " + name);
+    }
+    return m_fields[name];
+}
+
+amrex::Vector<amrex::MultiFab*> AmrTestMesh::declare_field(
+    const std::string& name, const int ncomp, const int num_ghost)
+{
+    amrex::Vector<amrex::MultiFab*> vec(finest_level+1, nullptr);
+    for (int lev=0; lev < (finest_level + 1); ++lev) {
+        vec[lev] = &m_leveldata[lev]->declare_field(name, ncomp, num_ghost);
+    }
+    return vec;
+}
+
+amrex::Vector<amrex::MultiFab*> AmrTestMesh::get_field(const std::string& name)
+{
+    amrex::Vector<amrex::MultiFab*> vec(finest_level+1, nullptr);
+    for (int lev=0; lev < (finest_level + 1); ++lev) {
+        vec[lev] = &m_leveldata[lev]->get_field(name);
+    }
+    return vec;
+}
+
+AmrTestMesh::AmrTestMesh() : m_leveldata(max_level + 1) {}
+
+void AmrTestMesh::initialize_mesh(amrex::Real current_time)
+{
+    InitFromScratch(current_time);
+}
+
+void AmrTestMesh::MakeNewLevelFromScratch(
+    int lev,
+    amrex::Real /* time */,
+    const amrex::BoxArray& ba,
+    const amrex::DistributionMapping& dm)
+{
+    SetBoxArray(lev, ba);
+    SetDistributionMap(lev, dm);
+
+    m_leveldata[lev].reset(
+        new TestLevelData(boxArray(lev), DistributionMap(lev)));
+}
+
+void AmrTestMesh::MakeNewLevelFromCoarse(
+    int lev,
+    amrex::Real /* time */,
+    const amrex::BoxArray& ba,
+    const amrex::DistributionMapping& dm)
+{
+    SetBoxArray(lev, ba);
+    SetDistributionMap(lev, dm);
+
+    amrex::Abort("Not implemented");
+}
+
+void AmrTestMesh::RemakeLevel(
+    int lev,
+    amrex::Real /* time */,
+    const amrex::BoxArray& ba,
+    const amrex::DistributionMapping& dm)
+{
+    SetBoxArray(lev, ba);
+    SetDistributionMap(lev, dm);
+
+    amrex::Abort("Not implemented");
+}
+
+void AmrTestMesh::ClearLevel(int /* lev */)
+{
+    amrex::Abort("Not implemented");
+}
+
+void AmrTestMesh::ErrorEst(
+    int /* lev */, amrex::TagBoxArray& /* tags */, amrex::Real /* time */, int /* ngrow */)
+{
+    amrex::Abort("Not implemented");
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/aw_test_utils/AmrexTest.H
+++ b/unit_tests/aw_test_utils/AmrexTest.H
@@ -15,9 +15,9 @@ class AmrexTest : public ::testing::Test
 public:
     AmrexTest() = default;
 
-    ~AmrexTest() = default;
+    virtual ~AmrexTest() = default;
 
-    void SetUp() override
+    virtual void SetUp() override
     {
         amrex::ParmParse pp("utest");
         pp.query("keep_parameters", m_keep_parameters);
@@ -26,7 +26,7 @@ public:
             amrex::ParmParse::Initialize(0, nullptr, nullptr);
     }
 
-    void TearDown() override
+    virtual void TearDown() override
     {
         if (!m_keep_parameters) amrex::ParmParse::Finalize();
     }

--- a/unit_tests/aw_test_utils/CMakeLists.txt
+++ b/unit_tests/aw_test_utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 target_sources(
   ${amr_wind_unit_test_exe_name} PRIVATE
 
-  AmrexTest.cpp
+  AmrTestMesh.cpp
   )

--- a/unit_tests/aw_test_utils/CMakeLists.txt
+++ b/unit_tests/aw_test_utils/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(
   ${amr_wind_unit_test_exe_name} PRIVATE
 
+  pp_utils.cpp
   AmrTestMesh.cpp
+  MeshTest.cpp
   )

--- a/unit_tests/aw_test_utils/MeshTest.H
+++ b/unit_tests/aw_test_utils/MeshTest.H
@@ -1,0 +1,56 @@
+#ifndef MESHTEST_H
+#define MESHTEST_H
+
+#include <memory>
+
+#include "aw_test_utils/AmrexTest.H"
+#include "aw_test_utils/AmrTestMesh.H"
+#include "SimTime.H"
+
+namespace amr_wind_tests {
+
+/** Base class for test fixtures that require a valid AmrMesh instance
+ */
+class MeshTest : public AmrexTest
+{
+public:
+    MeshTest() = default;
+
+    virtual ~MeshTest() = default;
+
+    /** Populate the ParmParse instance with all the necessary input variables
+     *  for this test fixture
+     */
+    virtual void populate_parameters();
+
+    //! Create the mesh instance
+    virtual void create_mesh_instance();
+
+    //! Perform initialization actions
+    virtual void initialize_mesh();
+
+    amr_wind::SimTime& time()
+    {
+        if (!m_time)
+            m_time.reset(new amr_wind::SimTime());
+        return *m_time;
+    }
+
+    AmrTestMesh& mesh() { return *m_mesh; }
+
+    template <typename T>
+    T& mesh()
+    {
+        return dynamic_cast<T*>(*m_mesh);
+    }
+
+protected:
+    std::unique_ptr<AmrTestMesh> m_mesh;
+    std::unique_ptr<amr_wind::SimTime> m_time;
+
+    bool m_need_params{true};
+};
+
+}
+
+#endif /* MESHTEST_H */

--- a/unit_tests/aw_test_utils/MeshTest.cpp
+++ b/unit_tests/aw_test_utils/MeshTest.cpp
@@ -1,0 +1,26 @@
+#include "MeshTest.H"
+#include "pp_utils.H"
+
+namespace amr_wind_tests {
+
+void MeshTest::create_mesh_instance()
+{
+    if (!m_mesh) m_mesh.reset(new AmrTestMesh());
+}
+
+void MeshTest::initialize_mesh()
+{
+    if (m_need_params) populate_parameters();
+    create_mesh_instance();
+
+    m_mesh->initialize_mesh(0.0);
+}
+
+void MeshTest::populate_parameters()
+{
+    pp_utils::default_time_inputs();
+    pp_utils::default_mesh_inputs();
+    m_need_params = false;
+}
+
+}

--- a/unit_tests/aw_test_utils/iter_tools.H
+++ b/unit_tests/aw_test_utils/iter_tools.H
@@ -1,0 +1,37 @@
+#ifndef ITER_TOOLS_H
+#define ITER_TOOLS_H
+
+#include "AMReX_MultiFab.H"
+#include "AMReX_Vector.H"
+
+/** \file iter_tools.H
+ *  Iteration utilities
+ */
+
+namespace amr_wind_tests {
+
+/** Helper to run a functor over all levels of a given field
+ *
+ *  The functor is a void function that accepts two arguments: the current
+ *  level, and an MFIter instance for the MultiFab at the given level.
+ *
+ *  @param nlevels Number of valid levels in the AMR hierarchy
+ *  @param field MultiFabs for each of the `nlevels` levels
+ *  @param func Functor to execute over the MultiFabs
+ */
+template <typename Functor>
+void run_algorithm(
+    const int nlevels, amrex::Vector<amrex::MultiFab*>& field, Functor func)
+{
+    for (int lev = 0; lev < nlevels; ++lev) {
+        auto& lfab = *field[lev];
+
+        for (amrex::MFIter mfi(lfab); mfi.isValid(); ++mfi) {
+            func(lev, mfi);
+        }
+    }
+}
+
+} // namespace amr_wind_tests
+
+#endif /* ITER_TOOLS_H */

--- a/unit_tests/aw_test_utils/pp_utils.H
+++ b/unit_tests/aw_test_utils/pp_utils.H
@@ -1,0 +1,33 @@
+#ifndef PP_UTILS_H
+#define PP_UTILS_H
+
+#include <string>
+#include "AMReX_ParmParse.H"
+#include "AMReX_Vector.H"
+
+namespace amr_wind_tests {
+namespace pp_utils {
+
+template <typename T>
+void set_default(amrex::ParmParse& pp, const std::string& key, const T& val)
+{
+    if (!pp.contains(key.data())) pp.add(key.data(), val);
+}
+
+template <typename T>
+void set_default(
+    amrex::ParmParse& pp, const std::string& key, const amrex::Vector<T>& val)
+{
+    if (!pp.contains(key.data())) pp.addarr(key.data(), val);
+}
+
+//! Default inputs for amr_wind::SimTime
+void default_time_inputs();
+
+//! Default inputs for amrex::AmrCore
+void default_mesh_inputs();
+
+} // namespace pp_utils
+} // namespace amr_wind_tests
+
+#endif /* PP_UTILS_H */

--- a/unit_tests/aw_test_utils/pp_utils.cpp
+++ b/unit_tests/aw_test_utils/pp_utils.cpp
@@ -1,0 +1,55 @@
+#include "pp_utils.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind_tests {
+namespace pp_utils {
+
+void default_time_inputs()
+{
+    {
+        amrex::ParmParse pp;
+        pp.add("verbose", -1);
+        pp.add("stop_time", 2.0);
+        pp.add("max_step", 10.0);
+    }
+
+    {
+        amrex::ParmParse pp("amr");
+        pp.add("regrid_int", 3);
+        pp.add("plot_int", 1);
+        pp.add("check_int", 2);
+    }
+
+    {
+        amrex::ParmParse pp("incflo");
+        pp.add("fixed_dt", 0.1);
+        pp.add("cfl", 0.5);
+        pp.add("m_init_shrink", 0.1);
+    }
+}
+
+void default_mesh_inputs()
+{
+    {
+        amrex::ParmParse pp("amr");
+        amrex::Vector<int> ncell{{8, 8, 8}};
+
+        pp.add("verbose", 0);
+        pp.addarr("n_cell", ncell);
+        pp.add("max_level", 0);
+    }
+
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<amrex::Real> problo {{0.0, 0.0, 0.0}};
+        amrex::Vector<amrex::Real> probhi {{8.0, 8.0, 8.0}};
+        amrex::Vector<int> periodic{{1, 1, 1}};
+
+        pp.addarr("prob_lo", problo);
+        pp.addarr("prob_hi", probhi);
+        pp.addarr("is_periodic", periodic);
+    }
+}
+
+}
+}

--- a/unit_tests/aw_test_utils/test_utils.H
+++ b/unit_tests/aw_test_utils/test_utils.H
@@ -1,0 +1,107 @@
+/** \file test_utils.H
+ *  Utilities for assertions
+ */
+
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include "gtest/gtest.h"
+#include "AMReX_MultiFab.H"
+#include "AMReX_Vector.H"
+
+namespace amr_wind_tests {
+namespace utils {
+
+/** Return the minimum value of a field over all AMR levels
+ *
+ *  @param nlevels Number of levels that existing in this AMR hierarchy
+ *  @param field MultiFabs for the levels
+ *  @param ncomp The field component for which min value is desired (default: 0)
+ */
+inline amrex::Real field_min(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    const int ncomp = 0)
+{
+    amrex::Real min_val = std::numeric_limits<amrex::Real>::max();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        min_val = amrex::min(min_val, field[lev]->min(ncomp));
+    }
+    return min_val;
+}
+
+/** Return the maximum value of a field over all AMR levels
+ *
+ *  @param nlevels Number of levels that existing in this AMR hierarchy
+ *  @param field MultiFabs for the levels
+ *  @param ncomp The field component for which max value is desired (default: 0)
+ */
+inline amrex::Real field_max(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    const int ncomp = 0)
+{
+    amrex::Real max_val = -std::numeric_limits<amrex::Real>::max();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        max_val = amrex::max(max_val, field[lev]->max(ncomp));
+    }
+    return max_val;
+}
+
+/** Return the minimum value all components of a field over all AMR levels
+ *
+ *  @param nlevels Number of levels that existing in this AMR hierarchy
+ *  @param field MultiFabs for the levels
+ *  @param min_val Array of component values that are populated
+ */
+inline void field_min(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    amrex::Vector<amrex::Real>& min_val)
+{
+    for (int icomp=0; icomp < min_val.size(); ++icomp) {
+        min_val[icomp] = field_min(nlevels, field, icomp);
+    }
+}
+
+/** Return the maximum value all components of a field over all AMR levels
+ *
+ *  @param nlevels Number of levels that existing in this AMR hierarchy
+ *  @param field MultiFabs for the levels
+ *  @param max_val Array of component values that are populated
+ */
+inline void field_max(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    amrex::Vector<amrex::Real>& max_val)
+{
+    for (int icomp=0; icomp < max_val.size(); ++icomp) {
+        max_val[icomp] = field_max(nlevels, field, icomp);
+    }
+}
+
+inline void field_minmax(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    amrex::Real& min_val,
+    amrex::Real& max_val,
+    const int ncomp = 0)
+{
+    min_val = field_min(nlevels, field, ncomp);
+    max_val = field_max(nlevels, field, ncomp);
+}
+
+inline void field_minmax(
+    const int nlevels,
+    const amrex::Vector<amrex::MultiFab*>& field,
+    amrex::Vector<amrex::Real>& min_val,
+    amrex::Vector<amrex::Real>& max_val)
+{
+    field_min(nlevels, field, min_val);
+    field_max(nlevels, field, max_val);
+}
+
+} // namespace utils
+} // namespace amr_wind_tests
+
+#endif /* TEST_UTILS_H */

--- a/unit_tests/wind_energy/CMakeLists.txt
+++ b/unit_tests/wind_energy/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(${amr_wind_unit_test_exe_name} PRIVATE
+  test_abl.cpp
+  )

--- a/unit_tests/wind_energy/test_abl.cpp
+++ b/unit_tests/wind_energy/test_abl.cpp
@@ -1,0 +1,128 @@
+#include "aw_test_utils/MeshTest.H"
+#include "aw_test_utils/iter_tools.H"
+#include "aw_test_utils/test_utils.H"
+#include "ABLFieldInit.H"
+
+namespace amr_wind_tests {
+namespace {
+
+// Introduce namespace for the text fixture
+class ABLTest : public MeshTest
+{};
+
+void populate_abl_params()
+{
+    amrex::ParmParse pp("abl");
+
+    // Initial conditions (Temperature)
+    amrex::Vector<amrex::Real> theights{{0.0, 650.0, 750.0, 1000.0}};
+    amrex::Vector<amrex::Real> tvalues{{300.0, 300.0, 308.0, 308.75}};
+    pp.add("ntemperature", theights.size());
+    pp.addarr("temperature_heights", theights);
+    pp.addarr("temperature_values", tvalues);
+    pp.add("perturb_ref_height", 50.0);
+
+    // Boussinesq Buoyancy
+    const amrex::Real tecoeff = 1.0 / 300.0;
+    pp.add("reference_temperature", 300.0);
+    pp.add("thermal_expansion_coeff", tecoeff);
+
+    // ABL Forcing
+    pp.add("abl_forcing_height", 90.0);
+
+    // Coriolis term
+    pp.add("latitude", 45.0);
+
+    pp.add("kappa", 0.41);
+    pp.add("surface_roughness_z0", 0.1);
+
+    // Needed for initial conditions
+    {
+        amrex::ParmParse pp("incflo");
+        pp.add("ro_0", 1.0);   // Density
+        pp.add("ic_u", 20.0);  // Ux
+        pp.add("ic_v", 10.0);   // Uy
+        pp.add("ic_w", 0.0);   // Uw
+    }
+
+    // Adjust computational domain to be more like ABL mesh in the z direction
+    {
+        amrex::ParmParse pp("amr");
+        amrex::Vector<int> ncell{{8, 8, 64}};
+        pp.addarr("n_cell", ncell);
+    }
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<amrex::Real> probhi {{120.0, 120.0, 1000.0}};
+
+        pp.addarr("prob_hi", probhi);
+    }
+}
+
+} // namespace
+
+TEST_F(ABLTest, abl_initialization)
+{
+    populate_parameters();
+    populate_abl_params();
+
+    // For the first test disable velocity perturbations
+    {
+        amrex::ParmParse pp("abl");
+        bool perturb_velocity = false;
+        pp.add("perturb_velocity", static_cast<int>(perturb_velocity));
+    }
+
+    initialize_mesh();
+    auto velocity = mesh().declare_field("velocity", 3, 0);
+    auto density = mesh().declare_field("density");
+    auto temperature = mesh().declare_field("temperature");
+
+    amr_wind::ABLFieldInit ablinit;
+    run_algorithm(
+        mesh().num_levels(), density,
+        [&](const int lev, const amrex::MFIter& mfi) {
+            auto vel = velocity[lev]->array(mfi);
+            auto rho = density[lev]->array(mfi);
+            auto theta = temperature[lev]->array(mfi);
+
+            const auto& bx = mfi.validbox();
+            ablinit(bx, mesh().Geom(lev), vel, rho, theta);
+        });
+
+    const int nlevels = mesh().num_levels();
+    const amrex::Real tol = 1.0e-12;
+
+    // Test temperature
+    {
+        const amrex::Real dz = mesh().Geom(0).CellSize(2);
+        const amrex::Real min_temp_gold = 300.0;
+        const amrex::Real max_temp_gold = 308.75 - (308.75 - 308.0) / 250.0 * (0.5 * dz);
+        amrex::Real min_temp, max_temp;
+        utils::field_minmax(nlevels, temperature, min_temp, max_temp);
+        EXPECT_NEAR(min_temp, min_temp_gold, tol);
+        EXPECT_NEAR(max_temp, max_temp_gold, tol);
+    }
+
+    // Test density
+    {
+        amrex::Real min_rho, max_rho;
+        utils::field_minmax(nlevels, density, min_rho, max_rho);
+        EXPECT_NEAR(min_rho, 1.0, tol);
+        EXPECT_NEAR(max_rho, 1.0, tol);
+    }
+
+    // Test velocity
+    {
+        amrex::Vector<amrex::Real> min_vel(3), max_vel(3);
+        utils::field_minmax(nlevels, velocity, min_vel, max_vel);
+        EXPECT_NEAR(min_vel[0], 20.0, tol);
+        EXPECT_NEAR(min_vel[1], 10.0, tol);
+        EXPECT_NEAR(min_vel[2],  0.0, tol);
+        EXPECT_NEAR(max_vel[0], 20.0, tol);
+        EXPECT_NEAR(max_vel[1], 10.0, tol);
+        EXPECT_NEAR(max_vel[2],  0.0, tol);
+    }
+}
+
+} // namespace amr_wind_tests


### PR DESCRIPTION
- Create necessary test harness to create AMR grids for tests that require a valid mesh
- Create a placeholder data structure that can create/manage fields necessary for tests
- Add basic utilities for common actions within ABL unit tests
- Add a demonstration ABL unit test