### PR TITLE
Cartesian aligned nested refinement for wind farm simulations

### DIFF
--- a/src/incflo.H
+++ b/src/incflo.H
@@ -19,6 +19,7 @@
 
 namespace amr_wind {
 class Physics;
+class RefinementCriteria;
 }
 
 class incflo : public amrex::AmrCore
@@ -381,6 +382,7 @@ private:
     amr_wind::SimTime m_time;
 
     amrex::Vector<std::unique_ptr<amr_wind::Physics>> m_physics;
+    amrex::Vector<std::unique_ptr<amr_wind::RefinementCriteria>> m_refine_criteria;
 
     // Be verbose?
     int m_verbose = 0;
@@ -480,9 +482,6 @@ private:
 
     std::string m_check_file{"chk"};
     std::string m_restart_file{""};
-
-    amrex::Vector<amrex::Real> tag_region_lo;
-    amrex::Vector<amrex::Real> tag_region_hi;
 
     // Flags for saving fluid data in plot files
     int m_plt_velx        = 1;

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -2,6 +2,7 @@
 #include <incflo.H>
 
 #include "ABL.H"
+#include "RefinementCriteria.H"
 
 // Need this for TagCutCells
 #ifdef AMREX_USE_EB

--- a/src/incflo_tagging.cpp
+++ b/src/incflo_tagging.cpp
@@ -1,4 +1,5 @@
 #include <incflo.H>
+#include "RefinementCriteria.H"
 
 #ifdef AMREX_USE_EB
 #include <AMReX_EBAmrUtil.H>
@@ -8,14 +9,12 @@ using namespace amrex;
 
 // tag cells for refinement
 // overrides the pure virtual function in AmrCore
-void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int /* ngrow */)
+void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow)
 {
     BL_PROFILE("incflo::ErrorEst()");
 
     static bool first = true;
     static Vector<Real> rhoerr_v, gradrhoerr_v;
-
-    bool tag_region;
 
     if (first) {
         first = false;
@@ -32,15 +31,6 @@ void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int /* ngrow */)
             Real last = gradrhoerr_v.back();
             gradrhoerr_v.resize(max_level+1, last);
         }
-
-        tag_region_lo.resize(3);
-        tag_region_hi.resize(3);
-
-        tag_region = false;
-        pp.query("tag_region", tag_region);
-
-        pp.queryarr("tag_region_lo", tag_region_lo);
-        pp.queryarr("tag_region_hi", tag_region_hi);
     }
 
     const auto   tagval = TagBox::SET;
@@ -97,31 +87,10 @@ void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int /* ngrow */)
                 }
             });
         } 
- 
-        if (tag_region) {
+    }
 
-            Real xlo = tag_region_lo[0];
-            Real ylo = tag_region_lo[1];
-            Real zlo = tag_region_lo[2];
-            Real xhi = tag_region_hi[0];
-            Real yhi = tag_region_hi[1];
-            Real zhi = tag_region_hi[2];
-
-            amrex::ParallelFor(bx,
-            [xlo, xhi, ylo, yhi, zlo, zhi, l_dx, l_dy, l_dz,tagval, tag]
-            AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                 Real x = (i+0.5)*l_dx;
-                 Real y = (j+0.5)*l_dy;
-                 Real z = (k+0.5)*l_dz;
-
-                 // Tag if we are inside the specified box
-                 if (x >= xlo && x <= xhi && y >= ylo && y <= yhi && z >= zlo && z <= zhi)
-                 {
-                    tag(i,j,k) = tagval;
-                 }
-            });
-        } 
+    for (auto& rc: m_refine_criteria) {
+        (*rc)(lev, tags, time, ngrow);
     }
 
 #ifdef AMREX_USE_EB

--- a/src/setup/init.cpp
+++ b/src/setup/init.cpp
@@ -6,6 +6,8 @@
 
 #include "Physics.H"
 #include "ABL.H"
+#include "RefinementCriteria.H"
+#include "CartBoxRefinement.H"
 
 using namespace amrex;
 
@@ -124,6 +126,19 @@ void incflo::ReadParameters ()
         ReadABLParameters();
 
         m_physics.emplace_back(new amr_wind::ABL(m_time, this));
+    }
+
+    {
+        // tagging options
+        ParmParse pp("tagging");
+        bool static_refine = false;
+        pp.query("static_refinement", static_refine);
+        if (static_refine) {
+            std::unique_ptr<amr_wind::CartBoxRefinement> obj(new amr_wind::CartBoxRefinement);
+            obj->initialize(*this);
+
+            m_refine_criteria.push_back(std::move(obj));
+        }
     }
 
 }

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -8,3 +8,5 @@ target_sources(${amr_wind_lib_name}
    )
 
 target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(tagging)

--- a/src/utilities/tagging/CMakeLists.txt
+++ b/src/utilities/tagging/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+
+  CartBoxRefinement.cpp
+  )
+
+target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utilities/tagging/CartBoxRefinement.H
+++ b/src/utilities/tagging/CartBoxRefinement.H
@@ -1,0 +1,52 @@
+#ifndef CARTBOXREFINEMENT_H
+#define CARTBOXREFINEMENT_H
+
+#include <iosfwd>
+
+#include "RefinementCriteria.H"
+#include "AMReX_RealBox.H"
+#include "AMReX_Vector.H"
+
+namespace amr_wind {
+
+/** Static refinement with Cartesian-aligned bounding boxes
+ *
+ *  Implements tagging functionality for nested refinement of meshes using
+ *  bounding box specifications. This class only allows nested refinement of
+ *  regions that are aligned with the coordinate directons.
+ */
+class CartBoxRefinement : public RefinementCriteria
+{
+public:
+    CartBoxRefinement() = default;
+
+    virtual ~CartBoxRefinement() = default;
+
+    //! Read input file and initialize boxarray used to refine each level
+    virtual void initialize(const amrex::AmrCore&) override;
+
+    virtual void
+    operator()(int level, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
+
+    //! Helper function to process inputs
+    //!
+    //! Created separate from initialize to allow unit testing
+    void read_inputs(const amrex::AmrCore&, std::istream&);
+
+    //! Vector of boxarrays that define refinement zones at each level
+    const amrex::Vector<amrex::BoxArray>& boxarray_vec() const { return m_boxarrays; }
+
+protected:
+    //! Domain bounding boxes where refinement is performed at each level
+    amrex::Vector<amrex::Vector<amrex::RealBox>> m_real_boxes;
+
+    //! Boxarrays for each level in AMR hierarchy
+    amrex::Vector<amrex::BoxArray> m_boxarrays;
+
+    //! Number of levels of fixed nested refinement
+    int m_nlevels{-1};
+};
+
+} // namespace amr_wind
+
+#endif /* CARTBOXREFINEMENT_H */

--- a/src/utilities/tagging/CartBoxRefinement.cpp
+++ b/src/utilities/tagging/CartBoxRefinement.cpp
@@ -1,0 +1,118 @@
+#include <iostream>
+#include <fstream>
+
+#include "CartBoxRefinement.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+
+namespace {
+
+/** Read refinement bounding box boxes for a single level from a text file
+ *
+ *  The file must contain entries per line. The first entry is the total number
+ *  of refinement boxes at the current level. This is followed by one entry per
+ *  bbox that contains six floating point values. Corresponding to the
+ *  coordinates of the min and max corners of the bounding box. The lines can
+ *  contain text after the values and are ignored till EOF. For example,
+ *
+ *  ```
+ *  4                               // Num. boxes in Lev 1
+ *  -10.0 75.0 0.0 10.0 85.0 250.0  // T001
+ *  -10.0 50.0 0.0 10.0 60.0 250.0  // T002
+ *  -10.0 25.0 0.0 10.0 30.0 250.0  // T003
+ *  -10.0 10.0 0.0 10.0 20.0 250.0  // T004
+ *  ```
+ *
+ *  @param is Valid open input stream
+ *  @return Vector containing RealBox instances for each bounding box
+ */
+amrex::Vector<amrex::RealBox> read_real_boxes(std::istream& is)
+{
+    amrex::Vector<amrex::RealBox> rbx_list;
+    int nboxes;
+
+    // Number of refinement regions at this level
+    is >> nboxes;
+    is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    // Read in the bounding boxes
+    for (int ib = 0; ib < nboxes; ++ib) {
+        amrex::Real xlo, ylo, zlo, xhi, yhi, zhi;
+        is >> xlo >> ylo >> zlo >> xhi >> yhi >> zhi;
+        is.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        rbx_list.emplace_back(xlo, ylo, zlo, xhi, yhi, zhi);
+    }
+
+    return rbx_list;
+}
+
+amrex::BoxArray realbox_to_boxarray(
+    const amrex::Vector<amrex::RealBox>& rbx, const amrex::Geometry& geom)
+{
+    amrex::BoxList bx_list;
+    const auto* problo = geom.ProbLo();
+    const auto* dx = geom.CellSize();
+
+    for (const auto& rb : rbx) {
+        amrex::IntVect lo, hi;
+
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+            amrex::Real rlo = std::floor((rb.lo()[i] - problo[i]) / dx[i]);
+            amrex::Real rhi = std::ceil((rb.hi()[i] - problo[i]) / dx[i]);
+            lo[i] = static_cast<int>(rlo);
+            hi[i] = static_cast<int>(rhi);
+        }
+        bx_list.push_back({lo, hi});
+    }
+
+    return amrex::BoxArray(std::move(bx_list));
+}
+
+} // namespace
+
+void CartBoxRefinement::initialize(const amrex::AmrCore& mesh)
+{
+    std::string defn_file = "static_refinement.txt";
+    {
+        amrex::ParmParse pp("tagging");
+        pp.query("static_refinement_def", defn_file);
+    }
+
+    std::ifstream ifh(defn_file, std::ios::in);
+    if (!ifh.good())
+        amrex::Abort("Cannot find input file: " + defn_file);
+
+    read_inputs(mesh, ifh);
+}
+
+void CartBoxRefinement::read_inputs(const amrex::AmrCore& mesh, std::istream& ifh)
+{
+    const auto& geom = mesh.Geom();
+    int max_lev = geom.size();
+
+    int nlev_in;
+    ifh >> nlev_in;
+    ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+    // Set the number of levels to the minimum of what is in the input file and
+    // the simulation
+    m_nlevels = std::min(max_lev, nlev_in);
+
+    if (m_nlevels < 1) return;
+
+    for (int lev = 0; lev < m_nlevels; ++lev) {
+        auto rbx_list = read_real_boxes(ifh);
+        auto ba = realbox_to_boxarray(rbx_list, geom[lev]);
+
+        m_real_boxes.push_back(std::move(rbx_list));
+        m_boxarrays.push_back(std::move(ba));
+    }
+}
+
+void CartBoxRefinement::operator()(
+    int level, amrex::TagBoxArray& tags, amrex::Real, int)
+{
+    if (level < m_nlevels) tags.setVal(m_boxarrays[level], amrex::TagBox::SET);
+}
+
+} // namespace amr_wind

--- a/src/utilities/tagging/RefinementCriteria.H
+++ b/src/utilities/tagging/RefinementCriteria.H
@@ -1,0 +1,34 @@
+#ifndef REFINEMENTCRITERIA_H
+#define REFINEMENTCRITERIA_H
+
+#include "AMReX_AmrCore.H"
+#include "AMReX_TagBox.H"
+
+namespace amr_wind {
+
+//! Abstract interface for refinement criteria
+class RefinementCriteria
+{
+public:
+    RefinementCriteria() = default;
+
+    virtual ~RefinementCriteria() = default;
+
+    //! Perform initialization tasks (e.g., read from file etc.). Called before
+    //! mesh is initialized
+    virtual void initialize(const amrex::AmrCore&) = 0;
+
+    /** Perform tagging operation based on refinement criteria
+     *
+     *  Interface is the same as amrex::AmrCore::ErrorEst
+     */
+    virtual void operator()(
+        int level,
+        amrex::TagBoxArray& tags,
+        amrex::Real time,
+        int ngrow) = 0;
+};
+
+}
+
+#endif /* REFINEMENTCRITERIA_H */

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(aw_test_utils)
 add_subdirectory(core)
 add_subdirectory(wind_energy)
 add_subdirectory(derive)
+add_subdirectory(utilities)
 
 target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/unit_tests/aw_test_utils/AmrTestMesh.cpp
+++ b/unit_tests/aw_test_utils/AmrTestMesh.cpp
@@ -81,7 +81,8 @@ void AmrTestMesh::MakeNewLevelFromCoarse(
     SetBoxArray(lev, ba);
     SetDistributionMap(lev, dm);
 
-    amrex::Abort("Not implemented");
+    // Concrete test fixtures must override and initialize field data if
+    // necessary
 }
 
 void AmrTestMesh::RemakeLevel(

--- a/unit_tests/aw_test_utils/MeshTest.H
+++ b/unit_tests/aw_test_utils/MeshTest.H
@@ -26,8 +26,20 @@ public:
     //! Create the mesh instance
     virtual void create_mesh_instance();
 
+    template<typename T>
+    void create_mesh_instance()
+    {
+        if (!m_mesh) {
+            reset_prob_domain();
+            m_mesh.reset(new T());
+        }
+    }
+
     //! Perform initialization actions
     virtual void initialize_mesh();
+
+    //! Reset the problem domain for this test
+    virtual void reset_prob_domain();
 
     amr_wind::SimTime& time()
     {

--- a/unit_tests/aw_test_utils/MeshTest.H
+++ b/unit_tests/aw_test_utils/MeshTest.H
@@ -39,9 +39,9 @@ public:
     AmrTestMesh& mesh() { return *m_mesh; }
 
     template <typename T>
-    T& mesh()
+    T* mesh()
     {
-        return dynamic_cast<T*>(*m_mesh);
+        return dynamic_cast<T*>(m_mesh.get());
     }
 
 protected:

--- a/unit_tests/aw_test_utils/MeshTest.cpp
+++ b/unit_tests/aw_test_utils/MeshTest.cpp
@@ -5,7 +5,10 @@ namespace amr_wind_tests {
 
 void MeshTest::create_mesh_instance()
 {
-    if (!m_mesh) m_mesh.reset(new AmrTestMesh());
+    if (!m_mesh) {
+        reset_prob_domain();
+        m_mesh.reset(new AmrTestMesh());
+    }
 }
 
 void MeshTest::initialize_mesh()
@@ -14,6 +17,22 @@ void MeshTest::initialize_mesh()
     create_mesh_instance();
 
     m_mesh->initialize_mesh(0.0);
+}
+
+void MeshTest::reset_prob_domain()
+{
+    amrex::Vector<amrex::Real> problo(3), probhi(3);
+
+    amrex::ParmParse pp("geometry");
+    pp.getarr("prob_lo",problo,0,AMREX_SPACEDIM);
+    pp.getarr("prob_hi",probhi,0,AMREX_SPACEDIM);
+
+    amrex::RealBox rb(problo.data(), probhi.data());
+    amrex::Geometry* gg = amrex::AMReX::top()->getDefaultGeometry();
+
+    if (gg != nullptr) {
+        gg->ResetDefaultProbDomain(rb);
+    }
 }
 
 void MeshTest::populate_parameters()

--- a/unit_tests/utilities/CMakeLists.txt
+++ b/unit_tests/utilities/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(${amr_wind_unit_test_exe_name} PRIVATE
+
+  test_refinement.cpp
+  )

--- a/unit_tests/utilities/test_refinement.cpp
+++ b/unit_tests/utilities/test_refinement.cpp
@@ -1,0 +1,94 @@
+#include <sstream>
+
+#include "aw_test_utils/AmrexTest.H"
+#include "aw_test_utils/MeshTest.H"
+
+#include "AMReX_Box.H"
+#include "AMReX_BoxArray.H"
+#include "AMReX_BoxList.H"
+#include "AMReX_Geometry.H"
+#include "AMReX_RealBox.H"
+#include "AMReX_Vector.H"
+
+#include "CartBoxRefinement.H"
+
+namespace amr_wind_tests {
+
+//! Custom mesh class to provide error estimator based on refinement criteria
+class NestRefineMesh : public AmrTestMesh
+{
+public:
+    amrex::Vector<std::unique_ptr<amr_wind::RefinementCriteria>>&
+    refine_criteria_vec()
+    {
+        return m_refine_crit;
+    }
+
+protected:
+    virtual void
+    ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override
+    {
+        for (auto& ref: m_refine_crit)
+            (*ref)(lev, tags, time, ngrow);
+    }
+
+private:
+    amrex::Vector<std::unique_ptr<amr_wind::RefinementCriteria>> m_refine_crit;
+};
+
+//! Custom test fixture for Cartesian Box refinement
+class NestRefineTest : public MeshTest
+{
+public:
+    void create_mesh_instance() override
+    {
+        if (!m_mesh) m_mesh.reset(new NestRefineMesh());
+    }
+};
+
+TEST_F(NestRefineTest, box_refine)
+{
+    populate_parameters();
+
+    {
+        amrex::ParmParse pp("amr");
+        amrex::Vector<int> ncell{{16, 128, 16}};
+
+        pp.add("max_level", 1);
+        pp.addarr("n_cell", ncell);
+    }
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<amrex::Real> problo {{-20.0, -100.0, 0.0}};
+        amrex::Vector<amrex::Real> probhi {{20.0, 100.0, 30.0}};
+
+        pp.addarr("prob_lo", problo);
+        pp.addarr("prob_hi", probhi);
+    }
+
+    // Create the "input file"
+    std::stringstream ss;
+    ss << "1 // Number of levels" << std::endl;
+    ss << "4 // Number of boxes at this level" << std::endl;
+    ss << "-10.0 -75.0 0.0 15.0 -65.0 20.0" << std::endl;
+    ss << "-10.0 -55.0 0.0 15.0 -45.0 20.0" << std::endl;
+    ss << "-10.0  25.0 0.0 15.0  35.0 20.0" << std::endl;
+    ss << "-10.0  65.0 0.0 15.0  75.0 20.0" << std::endl;
+
+    create_mesh_instance();
+    std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(new amr_wind::CartBoxRefinement);
+    box_refine->read_inputs(mesh(), ss);
+
+    // Store the target boxarray for future tests
+    auto targets = box_refine->boxarray_vec();
+
+    mesh<NestRefineMesh>()->refine_criteria_vec().push_back(std::move(box_refine));
+    initialize_mesh();
+
+    auto ba1 = mesh().boxArray(1);
+    // NOTE: Box definitions were based on Level 0 to tag cells
+    auto ba2 = targets[0].refine(2);
+    EXPECT_TRUE(ba1.contains(ba2));
+}
+
+}  // amr_wind_tests

--- a/unit_tests/utilities/test_refinement.cpp
+++ b/unit_tests/utilities/test_refinement.cpp
@@ -38,13 +38,7 @@ private:
 
 //! Custom test fixture for Cartesian Box refinement
 class NestRefineTest : public MeshTest
-{
-public:
-    void create_mesh_instance() override
-    {
-        if (!m_mesh) m_mesh.reset(new NestRefineMesh());
-    }
-};
+{};
 
 TEST_F(NestRefineTest, box_refine)
 {
@@ -75,7 +69,7 @@ TEST_F(NestRefineTest, box_refine)
     ss << "-10.0  25.0 0.0 15.0  35.0 20.0" << std::endl;
     ss << "-10.0  65.0 0.0 15.0  75.0 20.0" << std::endl;
 
-    create_mesh_instance();
+    create_mesh_instance<NestRefineMesh>();
     std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(new amr_wind::CartBoxRefinement);
     box_refine->read_inputs(mesh(), ss);
 


### PR DESCRIPTION
This pull-request introduces the capability to perform static refinements of user-defined Cartesian-aligned boxes at specified levels to mimic wind farm LES refinement used in SOWFA and nalu-wind. 

**input file parameters**
``` 
tagging.static_refinement = 1
tagging.static_refinement_def = "static_refinement.txt"
```

**refinement definition file**
```
2                                  // Number of levels of static refinement
2                                  // Number of regions in level 0
90.0 90.0 0.0 390.0 795.0 600.0    // T001
600.0 90.0 0.0 795.0 795.0 600.0   // T002
2                                  // number of regions in level 1
180.0 300.0 0.0 300.0 690.0 300.0  // T001
690.0 300.0 0.0 795.0 690.0 300.0  // T002
```