### PR TITLE
Possible fixes for errors in tests on the GPU

### DIFF
--- a/src/diffusion/incflo_diffusion.cpp
+++ b/src/diffusion/incflo_diffusion.cpp
@@ -148,7 +148,7 @@ incflo::wall_model_bc(const int lev,
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(density,mfi_info); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
+        const Box& bx = mfi.tilebox();
         auto vel = velocity.array(mfi);
         auto den = density.array(mfi);
         auto bc_a = bc.array(mfi);
@@ -264,7 +264,7 @@ incflo::heat_flux_model_bc(const int lev, const int comp, amrex::MultiFab& bc) c
 #endif
     for (MFIter mfi(bc,mfi_info); mfi.isValid(); ++mfi) {
         
-        Box const& bx = mfi.validbox();
+        Box const& bx = mfi.tilebox();
         Array4<Real> const& bc_a = bc.array(mfi);
         
         int idim = 0;
@@ -272,20 +272,22 @@ incflo::heat_flux_model_bc(const int lev, const int comp, amrex::MultiFab& bc) c
         // fixme this assume periodic
         if (!gm.isPeriodic(idim)) {
             if (bx.smallEnd(idim) == domain.smallEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[0][comp];
                 amrex::ParallelFor(amrex::bdryLo(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdx
-                    bc_a(i-1,j,k) = m_bc_tracer_d[0][comp];
+                    bc_a(i-1,j,k) = captured_value;
                     
                 });
             }
             if (bx.bigEnd(idim) == domain.bigEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[3][comp];
                 amrex::ParallelFor(amrex::bdryHi(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdx
-                    bc_a(i,j,k) = m_bc_tracer_d[3][comp];
+                    bc_a(i,j,k) = captured_value;
                     
                 });
             }
@@ -294,20 +296,22 @@ incflo::heat_flux_model_bc(const int lev, const int comp, amrex::MultiFab& bc) c
         idim = 1;
         if (!gm.isPeriodic(idim)) {
             if (bx.smallEnd(idim) == domain.smallEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[1][comp];
                 amrex::ParallelFor(amrex::bdryLo(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdy
-                    bc_a(i,j-1,k) = m_bc_tracer_d[1][comp];
+                    bc_a(i,j-1,k) = captured_value;
                     
                 });
             }
             if (bx.bigEnd(idim) == domain.bigEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[4][comp];
                 amrex::ParallelFor(amrex::bdryHi(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdy
-                    bc_a(i,j,k) = m_bc_tracer_d[4][comp];
+                    bc_a(i,j,k) = captured_value;
                     
                 });
             }
@@ -316,20 +320,22 @@ incflo::heat_flux_model_bc(const int lev, const int comp, amrex::MultiFab& bc) c
         idim = 2;
         if (!gm.isPeriodic(idim)) {
             if (bx.smallEnd(idim) == domain.smallEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[2][comp];
                 amrex::ParallelFor(amrex::bdryLo(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdz
-                    bc_a(i,j,k-1) = m_bc_tracer_d[2][comp];
+                    bc_a(i,j,k-1) = captured_value;
                     
                 });
             }
             if (bx.bigEnd(idim) == domain.bigEnd(idim)) {
+                const Real captured_value = m_bc_tracer_d[5][comp];
                 amrex::ParallelFor(amrex::bdryHi(bx, idim),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // inhomogeneous Neumann BC's dTdz
-                    bc_a(i,j,k) = m_bc_tracer_d[5][comp];
+                    bc_a(i,j,k) = captured_value;
                 });
             }
         }

--- a/src/diffusion/incflo_diffusion.cpp
+++ b/src/diffusion/incflo_diffusion.cpp
@@ -148,7 +148,7 @@ incflo::wall_model_bc(const int lev,
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(density,mfi_info); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.tilebox();
+        const Box& bx = mfi.validbox();
         auto vel = velocity.array(mfi);
         auto den = density.array(mfi);
         auto bc_a = bc.array(mfi);
@@ -264,7 +264,7 @@ incflo::heat_flux_model_bc(const int lev, const int comp, amrex::MultiFab& bc) c
 #endif
     for (MFIter mfi(bc,mfi_info); mfi.isValid(); ++mfi) {
         
-        Box const& bx = mfi.tilebox();
+        Box const& bx = mfi.validbox();
         Array4<Real> const& bc_a = bc.array(mfi);
         
         int idim = 0;

--- a/unit_tests/derive/test_strainrate.cpp
+++ b/unit_tests/derive/test_strainrate.cpp
@@ -22,7 +22,7 @@ TEST_F(StrainrateTest, interior)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 2, j = 2, k = 2;
     amrex::Real dx = 0.1, dy = 0.2 + 0.01*amrex::Random(), dz = 0.3;
@@ -86,7 +86,7 @@ TEST_F(StrainrateTest, ilo)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 1, j = 2, k = 2;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();
@@ -153,7 +153,7 @@ TEST_F(StrainrateTest, ihi)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 1, j = 2, k = 2;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();
@@ -220,7 +220,7 @@ TEST_F(StrainrateTest, jlo)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 2, j = 1, k = 2;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();
@@ -286,7 +286,7 @@ TEST_F(StrainrateTest, jhi)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 2, j = 1, k = 2;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();
@@ -351,7 +351,7 @@ TEST_F(StrainrateTest, klo)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 2, j = 2, k = 1;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();
@@ -417,7 +417,7 @@ TEST_F(StrainrateTest, khi)
     amrex::FArrayBox velocity(bx, AMREX_SPACEDIM);
     amrex::FArrayBox strainrate(bx, 1);
 
-    velocity.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Host>(0.0);
 
     int i = 2, j = 2, k = 1;
     amrex::Real dx = 0.1, dy = 0.2, dz = 0.3 + 0.01*amrex::Random();

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -25,11 +25,11 @@ TEST_F(ABLTest, abl_forcing)
     amr_wind::ABLForcing abl_forcing(time);
 
     // During initialization ensure that the source terms are zero
-    vel_src.setVal(0.0);
+    vel_src.setVal<amrex::RunOn::Device>(0.0);
     abl_forcing(bx, vel_src.array());
     for (int i=0; i < AMREX_SPACEDIM; ++i) {
-        const auto min_src = vel_src.min(i);
-        const auto max_src = vel_src.max(i);
+        const auto min_src = vel_src.min<amrex::RunOn::Device>(i);
+        const auto max_src = vel_src.max<amrex::RunOn::Device>(i);
         // Ensure that the source term is zero for initialization
         EXPECT_NEAR(min_src, 0.0, tol);
         // Ensure that the source term is constant throughout the domain
@@ -42,7 +42,7 @@ TEST_F(ABLTest, abl_forcing)
         time.set_current_cfl(2.0);
         EXPECT_NEAR(time.deltaT(), 0.1, tol);
 
-        vel_src.setVal(0.0);
+        vel_src.setVal<amrex::RunOn::Device>(0.0);
         abl_forcing.set_mean_velocities(10.0, 5.0);
         abl_forcing(bx, vel_src.array());
 
@@ -51,8 +51,8 @@ TEST_F(ABLTest, abl_forcing)
         // deltaT (set above) dt = 0.1
         const amrex::Array<amrex::Real, AMREX_SPACEDIM> golds{{100.0, 50.0, 0.0}};
         for (int i=0; i < AMREX_SPACEDIM; ++i) {
-            const auto min_src = vel_src.min(i);
-            const auto max_src = vel_src.max(i);
+            const auto min_src = vel_src.min<amrex::RunOn::Device>(i);
+            const auto max_src = vel_src.max<amrex::RunOn::Device>(i);
             EXPECT_NEAR(min_src, golds[i], tol);
             // Ensure that the source term is constant throughout the domain
             EXPECT_NEAR(min_src, max_src, tol);
@@ -85,16 +85,16 @@ TEST_F(ABLTest, coriolis_const_vel)
         amrex::Real golds[AMREX_SPACEDIM] = {0.0, -corfac * latfac * vel_comp,
                                              corfac * latfac * vel_comp};
         // Reset fields
-        velocity.setVal(0.0);
-        vel_src.setVal(0.0);
+        velocity.setVal<amrex::RunOn::Device>(0.0);
+        vel_src.setVal<amrex::RunOn::Device>(0.0);
         // set x component
-        velocity.setVal(vel_comp, 0);
+        velocity.setVal<amrex::RunOn::Device>(vel_comp, 0);
 
         coriolis(bx, velocity.array(), vel_src.array());
 
         for (int i=0; i < AMREX_SPACEDIM; ++i) {
-            const auto min_src = vel_src.min(i);
-            const auto max_src = vel_src.max(i);
+            const auto min_src = vel_src.min<amrex::RunOn::Device>(i);
+            const auto max_src = vel_src.max<amrex::RunOn::Device>(i);
             EXPECT_NEAR(min_src, golds[i], tol);
             // Ensure that the source term is constant throughout the domain
             EXPECT_NEAR(min_src, max_src, tol);
@@ -105,16 +105,16 @@ TEST_F(ABLTest, coriolis_const_vel)
     {
         amrex::Real golds[AMREX_SPACEDIM] = {corfac * latfac * vel_comp, 0.0, 0.0};
         // Reset fields
-        velocity.setVal(0.0);
-        vel_src.setVal(0.0);
+        velocity.setVal<amrex::RunOn::Device>(0.0);
+        vel_src.setVal<amrex::RunOn::Device>(0.0);
         // Set y component
-        velocity.setVal(vel_comp, 1);
+        velocity.setVal<amrex::RunOn::Device>(vel_comp, 1);
 
         coriolis(bx, velocity.array(), vel_src.array());
 
         for (int i=0; i < AMREX_SPACEDIM; ++i) {
-            const auto min_src = vel_src.min(i);
-            const auto max_src = vel_src.max(i);
+            const auto min_src = vel_src.min<amrex::RunOn::Device>(i);
+            const auto max_src = vel_src.max<amrex::RunOn::Device>(i);
             EXPECT_NEAR(min_src, golds[i], tol);
             // Ensure that the source term is constant throughout the domain
             EXPECT_NEAR(min_src, max_src, tol);
@@ -155,18 +155,18 @@ TEST_F(ABLTest, coriolis_height_variation)
 
     amr_wind::CoriolisForcing coriolis;
 
-    velocity.setVal(0.0);
-    vel_src.setVal(0.0);
+    velocity.setVal<amrex::RunOn::Device>(0.0);
+    vel_src.setVal<amrex::RunOn::Device>(0.0);
     cor_height_init_vel_field(bx, velocity);
 
     coriolis(bx, velocity.array(), vel_src.array());
 
-    EXPECT_NEAR(vel_src.min(0), 0.0, tol);
-    EXPECT_NEAR(vel_src.max(0), corfac * latfac * kdim, tol);
+    EXPECT_NEAR(vel_src.min<amrex::RunOn::Device>(0), 0.0, tol);
+    EXPECT_NEAR(vel_src.max<amrex::RunOn::Device>(0), corfac * latfac * kdim, tol);
 
     for (int i=1; i < AMREX_SPACEDIM; ++i) {
-        const auto min_src = vel_src.min(i);
-        const auto max_src = vel_src.max(i);
+        const auto min_src = vel_src.min<amrex::RunOn::Device>(i);
+        const auto max_src = vel_src.max<amrex::RunOn::Device>(i);
         EXPECT_NEAR(min_src, 0.0, tol);
         EXPECT_NEAR(min_src, max_src, tol);
     }
@@ -215,21 +215,21 @@ TEST_F(ABLTest, boussinesq)
 
     amr_wind::BoussinesqBuoyancy bb;
     
-    temperature.setVal(0.0);
-    vel_src.setVal(0.0);
+    temperature.setVal<amrex::RunOn::Device>(0.0);
+    vel_src.setVal<amrex::RunOn::Device>(0.0);
     init_abl_temperature_field(kdim, bx, temperature);
 
     bb(bx, temperature.array(), vel_src.array());
 
     // should be no forcing in x and y directions
-    EXPECT_NEAR(vel_src.min(0), 0.0, tol);
-    EXPECT_NEAR(vel_src.max(0), 0.0, tol);
-    EXPECT_NEAR(vel_src.min(1), 0.0, tol);
-    EXPECT_NEAR(vel_src.max(1), 0.0, tol);
+    EXPECT_NEAR(vel_src.min<amrex::RunOn::Device>(0), 0.0, tol);
+    EXPECT_NEAR(vel_src.max<amrex::RunOn::Device>(0), 0.0, tol);
+    EXPECT_NEAR(vel_src.min<amrex::RunOn::Device>(1), 0.0, tol);
+    EXPECT_NEAR(vel_src.max<amrex::RunOn::Device>(1), 0.0, tol);
 
 //    f = beta * (T0 - T)*g
-    EXPECT_NEAR(vel_src.min(2), 0.0, tol);
-    EXPECT_NEAR(vel_src.max(2), -9.81*(300.0-308.0)/300.0, tol);
+    EXPECT_NEAR(vel_src.min<amrex::RunOn::Device>(2), 0.0, tol);
+    EXPECT_NEAR(vel_src.max<amrex::RunOn::Device>(2), -9.81*(300.0-308.0)/300.0, tol);
 
 }
 


### PR DESCRIPTION
I'm making this a draft because I'm not sure if this is the best way to solve this. Mainly I have created this PR to illustrate the errors with the tests currently occurring on the GPU. These changes allow all the tests to pass for me. I also updated the AMReX submodule to tag 20.04. I propose we update AMReX every month to their tags. You will notice some changes that had to occur for the AMReX update as well.

One note on how I found the cause of these errors on the GPU for developers new to AMReX GPU development. I saw an illegal memory access on device as the error. This usually means a global variable is trying to be read on the device. So I ran `cuda-memcheck` and it will point you to the location of the global read error. Typically I solve this by capturing the value before the `ParallelFor` and using that value in the `ParallelFor`.