### PR TITLE
Launch CI workflow only on code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: AMR-Wind-CI
 on:
   push:
     branches: [ development ]
+    paths:
+      - 'cmake/**'
+      - 'src/**'
+      - 'submods/**'
+      - 'test/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ development ]
+    paths:
+      - 'cmake/**'
+      - 'src/**'
+      - 'submods/**'
+      - 'test/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/**'
 
 env:
   CXX_COMPILER: mpicxx


### PR DESCRIPTION
This pull request changes the GitHub CI workflow rules to only launch CI builds when the actual code has changed, i.e., don't launch a build when someone modifies a documentation ReST files or `README.md` for example. These are not checked by the CI build anyway, and we can avoid useless CI launches. 

Documentation would be checked by either the RTD or a separate GitHub docs workflow. 