### PR TITLE
Prepare codebase for introduction of turbulence equations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,8 +37,8 @@ BraceWrapping:
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ set(amr_wind_exe_name "amr_wind")
 set(amr_wind_unit_test_exe_name "${amr_wind_exe_name}_unit_tests")
 
 #Create main target executable
-add_library(${amr_wind_lib_name})
+add_library(${amr_wind_lib_name} OBJECT)
 add_executable(${amr_wind_exe_name})
 
 include(${CMAKE_SOURCE_DIR}/cmake/set_compile_flags.cmake)

--- a/make.incflo
+++ b/make.incflo
@@ -30,6 +30,10 @@ Bdirs += $(INCFLO_HOME)src/utilities
 Bdirs += $(INCFLO_HOME)src/utilities/tagging
 Bdirs += $(INCFLO_HOME)src/core
 Bdirs += $(INCFLO_HOME)src/wind_energy
+Bdirs += $(INCFLO_HOME)src/equation_systems
+Bdirs += $(INCFLO_HOME)src/equation_systems/icns
+Bdirs += $(INCFLO_HOME)src/equation_systems/temperature
+Bdirs += $(INCFLO_HOME)src/equation_systems/density
 
 Bpack += $(foreach dir, $(Bdirs), $(TOP)/$(dir)/Make.package)
 Blocs += $(foreach dir, $(Bdirs), $(TOP)/$(dir))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(setup)
 add_subdirectory(utilities)
 add_subdirectory(prob)
 add_subdirectory(wind_energy)
+add_subdirectory(equation_systems)
 
 target_link_libraries_system(${amr_wind_lib_name} PUBLIC amrex)
 target_link_libraries(${amr_wind_exe_name} PRIVATE ${amr_wind_lib_name})

--- a/src/convection/incflo_compute_advection_term.cpp
+++ b/src/convection/incflo_compute_advection_term.cpp
@@ -17,15 +17,15 @@ godunov::compute_convective_term (amr_wind::FieldRepo& repo,
     auto& v_mac = repo.get_field("v_mac");
     auto& w_mac = repo.get_field("w_mac");
     auto& vel_forces = repo.get_field("velocity_src_term");
-    auto& tra_forces = repo.get_field("tracer_forces");
+    auto& tra_forces = repo.get_field("temperature_src_term");
 
     // state dependent fields
     auto& vel = repo.get_field("velocity",fstate);//fixme this is godunov so always old state?
     auto& den = repo.get_field("density",fstate);
-    auto& tra = repo.get_field("tracer",fstate);
+    auto& tra = repo.get_field("temperature",fstate);
     auto& conv_u = repo.get_field("velocity_conv_term");
     auto& conv_r = repo.get_field("conv_density",fstate);
-    auto& conv_t = repo.get_field("conv_tracer",fstate);
+    auto& conv_t = repo.get_field("temperature_conv_term");
 
     const int ntrac = tra.num_comp();
     auto& geom = repo.mesh().Geom();
@@ -142,10 +142,10 @@ mol::compute_convective_term (amr_wind::FieldRepo& repo,
     // state dependent fields
     auto& vel = repo.get_field("velocity",fstate);//fixme this is godunov so always old state?
     auto& den = repo.get_field("density",fstate);
-    auto& tra = repo.get_field("tracer",fstate);
+    auto& tra = repo.get_field("temperature",fstate);
     auto& conv_u = repo.get_field("velocity_conv_term",fstate);
     auto& conv_r = repo.get_field("conv_density",fstate);
-    auto& conv_t = repo.get_field("conv_tracer",fstate);
+    auto& conv_t = repo.get_field("temperature_conv_term",fstate);
 
     const int ntrac = tra.num_comp();
     auto& geom = repo.mesh().Geom();

--- a/src/convection/incflo_compute_advection_term.cpp
+++ b/src/convection/incflo_compute_advection_term.cpp
@@ -16,14 +16,14 @@ godunov::compute_convective_term (amr_wind::FieldRepo& repo,
     auto& u_mac = repo.get_field("u_mac");
     auto& v_mac = repo.get_field("v_mac");
     auto& w_mac = repo.get_field("w_mac");
-    auto& vel_forces = repo.get_field("velocity_forces");
+    auto& vel_forces = repo.get_field("velocity_src_term");
     auto& tra_forces = repo.get_field("tracer_forces");
 
     // state dependent fields
     auto& vel = repo.get_field("velocity",fstate);//fixme this is godunov so always old state?
     auto& den = repo.get_field("density",fstate);
     auto& tra = repo.get_field("tracer",fstate);
-    auto& conv_u = repo.get_field("conv_velocity",fstate);
+    auto& conv_u = repo.get_field("velocity_conv_term");
     auto& conv_r = repo.get_field("conv_density",fstate);
     auto& conv_t = repo.get_field("conv_tracer",fstate);
 
@@ -143,7 +143,7 @@ mol::compute_convective_term (amr_wind::FieldRepo& repo,
     auto& vel = repo.get_field("velocity",fstate);//fixme this is godunov so always old state?
     auto& den = repo.get_field("density",fstate);
     auto& tra = repo.get_field("tracer",fstate);
-    auto& conv_u = repo.get_field("conv_velocity",fstate);
+    auto& conv_u = repo.get_field("velocity_conv_term",fstate);
     auto& conv_r = repo.get_field("conv_density",fstate);
     auto& conv_t = repo.get_field("conv_tracer",fstate);
 

--- a/src/convection/incflo_godunov_predict.cpp
+++ b/src/convection/incflo_godunov_predict.cpp
@@ -20,7 +20,7 @@ void godunov::predict_godunov (amr_wind::FieldRepo& repo,
     auto& u_mac = repo.get_field("u_mac");
     auto& v_mac = repo.get_field("v_mac");
     auto& w_mac = repo.get_field("w_mac");
-    auto& vel_forces = repo.get_field("velocity_forces");
+    auto& vel_forces = repo.get_field("velocity_src_term");
     auto& vel = repo.get_field("velocity",fstate);
     Vector<BCRec> const& h_bcrec = vel.bcrec();
     

--- a/src/core/Factory.H
+++ b/src/core/Factory.H
@@ -1,0 +1,75 @@
+#ifndef FACTORY_H
+#define FACTORY_H
+
+#include <memory>
+#include <unordered_map>
+#include <iostream>
+
+namespace amr_wind {
+
+template<class Base, class ... Args>
+struct Factory
+{
+    static std::unique_ptr<Base>
+    create(const std::string& key, Args... args)
+    {
+        // TODO: Add error diagnostics
+        return table().at(key)(std::forward<Args>(args)...);
+    }
+
+    static void print(std::ostream& os)
+    {
+        const auto& tbl = table();
+        os << Base::base_identifier() << " " << tbl.size() << std::endl;
+        for (const auto& it: tbl) {
+            os << " - " << it.first << std::endl;
+        }
+    }
+
+    template<class T>
+    struct Register : public Base
+    {
+        friend T;
+        static bool registered;
+
+        static bool add_sub_type()
+        {
+            // TODO: Add checks against multiple registration
+            Factory::table()[T::identifier()] =
+                [](Args... args) -> std::unique_ptr<Base> {
+                return std::unique_ptr<Base>(
+                    new T(std::forward<Args>(args)...));
+            };
+            return true;
+        }
+
+        virtual ~Register() = default;
+
+    private:
+        Register() { (void)registered; }
+    };
+
+    virtual ~Factory() = default;
+    friend Base;
+
+private:
+    using CreatorFunc = std::unique_ptr<Base> (*)(Args...);
+    using LookupTable = std::unordered_map<std::string, CreatorFunc>;
+
+    static LookupTable& table()
+    {
+        static LookupTable tbl;
+        return tbl;
+    }
+
+    Factory() = default;
+};
+
+template<class Base, class... Args>
+template<class T>
+bool Factory<Base, Args...>::Register<T>::registered =
+    Factory<Base, Args...>::Register<T>::add_sub_type();
+
+}
+
+#endif /* FACTORY_H */

--- a/src/core/FieldFillPatchOps.H
+++ b/src/core/FieldFillPatchOps.H
@@ -92,7 +92,7 @@ public:
      */
     FieldFillPatchOps(
         Field& field,
-        amrex::AmrCore& mesh,
+        const amrex::AmrCore& mesh,
         const SimTime& time,
         int probtype,
         FieldInterpolator itype = FieldInterpolator::CellConsLinear)

--- a/src/core/FieldUtils.H
+++ b/src/core/FieldUtils.H
@@ -97,6 +97,16 @@ get_interpolation_operator(const FieldInterpolator itype)
     return &amrex::cell_cons_interp;
 }
 
+inline FieldState dof_state(const FieldState fstate)
+{
+    return (fstate == FieldState::New) ? FieldState::New : FieldState::Old;
+}
+
+inline FieldState phi_state(const FieldState fstate)
+{
+    return (fstate == FieldState::Old) ? FieldState::Old : FieldState::NPH;
+}
+
 } // namespace field_impl
 } // namespace amr_wind
 

--- a/src/equation_systems/CMakeLists.txt
+++ b/src/equation_systems/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_subdirectory(icns)
+add_subdirectory(temperature)
+add_subdirectory(density)
+
+target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/equation_systems/Make.package
+++ b/src/equation_systems/Make.package
@@ -1,0 +1,6 @@
+CEXE_headers += PDE.H
+CEXE_headers += PDEHelpers.H
+CEXE_headers += PDEOps.H
+CEXE_headers += PDETraits.H
+CEXE_headers += SchemeTraits.H
+CEXE_headers += SourceTerm.H

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -1,0 +1,84 @@
+#ifndef PDE_H
+#define PDE_H
+
+#include <string>
+
+#include "PDEHelpers.H"
+#include "PDEOps.H"
+
+namespace amr_wind {
+namespace pde {
+
+class PDEBase
+{
+public:
+    virtual ~PDEBase() = default;
+
+    virtual void compute_source_term(const FieldState fstate) = 0;
+
+    virtual void compute_nueff(const FieldState fstate) = 0;
+
+    virtual void compute_diffusion_term(const FieldState fstate) = 0;
+
+    virtual void compute_advection_term(const FieldState fstate) = 0;
+
+    virtual void solve(const FieldState fstate) = 0;
+};
+
+template<typename PDE, typename Scheme>
+class PDESystem : public PDEBase
+{
+public:
+    using PDEType = PDE;
+    using SchemeType = Scheme;
+
+    PDESystem(const SimTime& time, FieldRepo& repo, const int probtype)
+        : m_time(time)
+        , m_repo(repo)
+        , m_fields(FieldRegOp<PDE, Scheme>(repo)(time, probtype))
+        , m_src_op(m_fields)
+    {}
+
+    void compute_source_term(const FieldState fstate) override
+    {
+        m_src_op(fstate);
+    }
+
+    void compute_nueff(const FieldState fstate) override
+    {
+        // TBD
+    }
+
+    void compute_diffusion_term(const FieldState fstate) override
+    {
+        // m_diff_op(fstate);
+    }
+
+    void compute_advection_term(const FieldState fstate) override
+    {
+        // m_adv_op(fstate);
+    }
+
+    void solve(const FieldState fstate) override
+    {
+        // m_linsys_solver(fstate);
+    }
+
+protected:
+    const SimTime& m_time;
+
+    FieldRepo& m_repo;
+
+    PDEFields m_fields;
+
+    SrcTermOp<PDE> m_src_op;
+    AdvectionOp<PDE, Scheme> m_adv_op;
+    DiffusionOp<PDE> m_diff_op;
+    LinSysSolve<PDE> m_linsys_solver;
+};
+
+} // namespace pde
+
+} // namespace amr_wind
+
+#endif /* PDE_H */

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -3,16 +3,19 @@
 
 #include <string>
 
+#include "Factory.H"
 #include "PDEHelpers.H"
 #include "PDEOps.H"
 
 namespace amr_wind {
 namespace pde {
 
-class PDEBase
+class PDEBase : public Factory<PDEBase, const SimTime&, FieldRepo&, const int>
 {
 public:
     virtual ~PDEBase() = default;
+
+    virtual PDEFields& fields() = 0;
 
     virtual void compute_source_term(const FieldState fstate) = 0;
 
@@ -23,14 +26,24 @@ public:
     virtual void compute_advection_term(const FieldState fstate) = 0;
 
     virtual void solve(const FieldState fstate) = 0;
+
+    static std::string base_identifier()
+    {
+        return "PDESystem";
+    }
 };
 
 template<typename PDE, typename Scheme>
-class PDESystem : public PDEBase
+class PDESystem : public PDEBase::Register<PDESystem<PDE, Scheme>>
 {
 public:
     using PDEType = PDE;
     using SchemeType = Scheme;
+
+    static std::string identifier()
+    {
+        return PDE::pde_name() + "-"  + Scheme::scheme_name();
+    }
 
     PDESystem(const SimTime& time, FieldRepo& repo, const int probtype)
         : m_time(time)
@@ -39,27 +52,29 @@ public:
         , m_src_op(m_fields)
     {}
 
+    PDEFields& fields() override { return m_fields; }
+
     void compute_source_term(const FieldState fstate) override
     {
         m_src_op(fstate);
     }
 
-    void compute_nueff(const FieldState fstate) override
+    void compute_nueff(const FieldState ) override
     {
         // TBD
     }
 
-    void compute_diffusion_term(const FieldState fstate) override
+    void compute_diffusion_term(const FieldState ) override
     {
         // m_diff_op(fstate);
     }
 
-    void compute_advection_term(const FieldState fstate) override
+    void compute_advection_term(const FieldState ) override
     {
         // m_adv_op(fstate);
     }
 
-    void solve(const FieldState fstate) override
+    void solve(const FieldState ) override
     {
         // m_linsys_solver(fstate);
     }
@@ -78,7 +93,6 @@ protected:
 };
 
 } // namespace pde
-
 } // namespace amr_wind
 
 #endif /* PDE_H */

--- a/src/equation_systems/PDEHelpers.H
+++ b/src/equation_systems/PDEHelpers.H
@@ -1,0 +1,89 @@
+#ifndef PDEHELPERS_H
+#define PDEHELPERS_H
+
+#include <string>
+
+#include "SimTime.H"
+#include "FieldRepo.H"
+#include "FieldFillPatchOps.H"
+#include "FieldBCOps.H"
+
+namespace amr_wind {
+namespace pde_impl {
+
+//! Field name that holds the convective term
+inline std::string conv_term_name(const std::string& var)
+{
+    return var + "_conv_term";
+}
+
+//! Field name that holds the diffusion term (divtau and laplacian for scalars)
+inline std::string diff_term_name(const std::string& var)
+{
+    return var + "_diff_term";
+}
+
+//! Field name for all the source terms
+inline std::string src_term_name(const std::string& var)
+{
+    return var + "_src_term";
+}
+
+//! Effective viscosity for the transport equation
+inline std::string nueff_name(const std::string& var) { return var + "_nueff"; }
+
+} // namespace pde_impl
+
+namespace pde {
+
+struct PDEFields
+{
+    PDEFields(FieldRepo& repo_in, const std::string& var_name)
+        : repo(repo_in)
+        , field(repo.get_field(var_name))
+        , nueff(repo.get_field(pde_impl::nueff_name(var_name)))
+        , src_term(repo.get_field(pde_impl::src_term_name(var_name)))
+        , diff_term(repo.get_field(pde_impl::diff_term_name(var_name)))
+        , conv_term(repo.get_field(pde_impl::conv_term_name(var_name)))
+    {}
+
+    FieldRepo& repo;
+    Field& field;
+    Field& nueff;
+
+    Field& src_term;
+    Field& diff_term;
+    Field& conv_term;
+};
+
+template<typename PDE, typename Scheme>
+PDEFields create_fields_instance(const SimTime& time, FieldRepo& repo, const int probtype)
+{
+    repo.declare_field(PDE::var_name(), PDE::ndim, Scheme::nghost_state, Scheme::num_states);
+    repo.declare_field(pde_impl::nueff_name(PDE::var_name()), 1, 1, 1);
+    repo.declare_field(
+        pde_impl::src_term_name(PDE::var_name()), PDE::ndim,
+        Scheme::nghost_src, 1);
+    repo.declare_field(
+        pde_impl::diff_term_name(PDE::var_name()), PDE::ndim, 0,
+        Scheme::num_diff_states);
+    repo.declare_field(
+        pde_impl::conv_term_name(PDE::var_name()), PDE::ndim, 0,
+        Scheme::num_conv_states);
+
+    PDEFields fields(repo, PDE::var_name());
+    fields.field.register_fill_patch_op<FieldFillPatchOps<FieldBCDirichlet>>(
+        repo.mesh(), time, probtype);
+    fields.src_term.register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
+        repo.mesh(), time, probtype, FieldInterpolator::PiecewiseConstant);
+
+    fields.field.fillpatch_on_regrid() = true;
+
+    return fields;
+}
+
+} // namespace pde
+} // namespace amr_wind
+
+
+#endif /* PDEHELPERS_H */

--- a/src/equation_systems/PDEOps.H
+++ b/src/equation_systems/PDEOps.H
@@ -25,11 +25,6 @@ struct SrcTermOpBase
 {
     SrcTermOpBase(PDEFields& fields_in) : fields(fields_in) {}
 
-    void zero_source_term()
-    {
-        fields.src_term.setVal(0.0);
-    }
-
     void multiply_rho(const FieldState fstate)
     {
         const auto rhostate = field_impl::phi_state(fstate);
@@ -67,8 +62,8 @@ struct SrcTermOp : SrcTermOpBase<PDE>
 
     void operator()(const FieldState fstate)
     {
-        // Zero out the source term
-        SrcTermOpBase<PDE>::zero_source_term();
+        // Zero out source term
+        this->fields.src_term.setVal(0.0);
 
         // Return early if there are no source terms to process
         if (this->sources.size() == 0) return;

--- a/src/equation_systems/PDEOps.H
+++ b/src/equation_systems/PDEOps.H
@@ -1,0 +1,112 @@
+#ifndef PDEOPS_H
+#define PDEOPS_H
+
+#include "FieldUtils.H"
+#include "PDEHelpers.H"
+
+namespace amr_wind {
+namespace pde {
+
+template<typename PDE, typename Scheme>
+struct FieldRegOp
+{
+    FieldRegOp(FieldRepo& repo_in) : repo(repo_in) {}
+
+    PDEFields operator()(const SimTime& time, const int probtype)
+    {
+        return create_fields_instance<PDE, Scheme>(time, repo, probtype);
+    }
+
+    FieldRepo& repo;
+};
+
+template<typename PDE>
+struct SrcTermOpBase
+{
+    SrcTermOpBase(PDEFields& fields_in) : fields(fields_in) {}
+
+    void zero_source_term()
+    {
+        fields.src_term.setVal(0.0);
+    }
+
+    void multiply_rho(const FieldState fstate)
+    {
+        const auto rhostate = field_impl::phi_state(fstate);
+        auto& density = fields.repo.get_field("density", rhostate);
+
+        const int nlevels = fields.repo.num_active_levels();
+        for (int lev=0; lev < nlevels; ++lev) {
+            auto& src_term = fields.src_term(lev);
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& vf = src_term.array(mfi);
+                const auto& rho = density(lev).array(mfi);
+
+                amrex::ParallelFor(
+                    bx, fields.src_term.num_comp(),
+                    [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+                        vf(i, j, k, n) *= rho(i, j, k);
+                    });
+            }
+        }
+    }
+
+    PDEFields& fields;
+    amrex::Vector<std::unique_ptr<typename PDE::SrcTerm>> sources;
+};
+
+template<typename PDE>
+struct SrcTermOp : SrcTermOpBase<PDE>
+{
+    SrcTermOp(PDEFields& fields_in) : SrcTermOpBase<PDE>(fields_in) {}
+
+    void operator()(const FieldState fstate)
+    {
+        // Zero out the source term
+        SrcTermOpBase<PDE>::zero_source_term();
+
+        // Return early if there are no source terms to process
+        if (this->sources.size() == 0) return;
+
+        const int nlevels = this->fields.repo.num_active_levels();
+        for (int lev=0; lev < nlevels; ++lev) {
+            auto& src_term = this->fields.src_term(lev);
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& vf = src_term.array(mfi);
+
+                for (auto& src: this->sources) {
+                    (*src)(lev, mfi, bx, fstate, vf);
+                }
+            }
+        }
+
+        if (PDE::multiply_rho) this->multiply_rho(fstate);
+    }
+};
+
+template<typename PDE, typename Scheme>
+struct AdvectionOp
+{};
+
+template<typename PDE>
+struct DiffusionOp
+{};
+
+template<typename PDE>
+struct LinSysSolve
+{};
+
+}
+}
+
+#endif /* PDEOPS_H */

--- a/src/equation_systems/PDETraits.H
+++ b/src/equation_systems/PDETraits.H
@@ -24,29 +24,6 @@ struct ScalarTransport
     static constexpr bool multiply_rho = true;
 };
 
-struct ICNS : VectorTransport
-{
-    using MLDiffOp = amrex::MLTensorOp;
-    using SrcTerm = MomentumSource;
-
-    static std::string pde_name() { return "ICNS"; }
-    static std::string var_name() { return "velocity"; }
-};
-
-struct Density : ScalarTransport
-{
-    static std::string pde_name() { return "Density"; }
-    static std::string var_name() { return "density"; }
-
-    static constexpr bool multiply_rho = false;
-};
-
-struct Temperature : ScalarTransport
-{
-    static std::string pde_name() { return "Temperature"; }
-    static std::string var_name() { return "temperature"; }
-};
-
 struct TKE : ScalarTransport
 {
     static std::string pde_name() { return "TKE"; }

--- a/src/equation_systems/PDETraits.H
+++ b/src/equation_systems/PDETraits.H
@@ -1,0 +1,65 @@
+#ifndef PDETRAITS_H
+#define PDETRAITS_H
+
+#include <string>
+#include "AMReX_MLTensorOp.H"
+
+#include "SourceTerm.H"
+
+namespace amr_wind {
+namespace pde {
+
+struct VectorTransport
+{
+    using MLDiffOp = amrex::MLABecLaplacian;
+    static constexpr int ndim = AMREX_SPACEDIM;
+};
+
+struct ScalarTransport
+{
+    using MLDiffOp = amrex::MLABecLaplacian;
+    using SrcTerm = SourceTerm;
+
+    static constexpr int ndim = 1;
+    static constexpr bool multiply_rho = true;
+};
+
+struct ICNS : VectorTransport
+{
+    using MLDiffOp = amrex::MLTensorOp;
+    using SrcTerm = MomentumSource;
+
+    static std::string pde_name() { return "ICNS"; }
+    static std::string var_name() { return "velocity"; }
+};
+
+struct Density : ScalarTransport
+{
+    static std::string pde_name() { return "Density"; }
+    static std::string var_name() { return "density"; }
+
+    static constexpr bool multiply_rho = false;
+};
+
+struct Temperature : ScalarTransport
+{
+    static std::string pde_name() { return "Temperature"; }
+    static std::string var_name() { return "temperature"; }
+};
+
+struct TKE : ScalarTransport
+{
+    static std::string pde_name() { return "TKE"; }
+    static std::string var_name() { return "tke"; }
+};
+
+struct SDR : ScalarTransport
+{
+    static std::string pde_name() { return "SDR"; }
+    static std::string var_name() { return "sdr"; }
+};
+
+}
+}
+
+#endif /* PDETRAITS_H */

--- a/src/equation_systems/PDETraits.H
+++ b/src/equation_systems/PDETraits.H
@@ -59,7 +59,7 @@ struct SDR : ScalarTransport
     static std::string var_name() { return "sdr"; }
 };
 
-}
-}
+} // namespace pde
+} // namespace amr_wind
 
 #endif /* PDETRAITS_H */

--- a/src/equation_systems/SchemeTraits.H
+++ b/src/equation_systems/SchemeTraits.H
@@ -1,0 +1,32 @@
+#ifndef SCHEMETRAITS_H
+#define SCHEMETRAITS_H
+
+namespace amr_wind {
+namespace fvm {
+
+struct Godunov
+{
+    static constexpr int num_states = 2;
+    static constexpr int nghost_state = 3;
+    static constexpr int nghost_src = 1;
+    static constexpr int nghost_mac = 1;
+
+    static constexpr int num_diff_states = 1;
+    static constexpr int num_conv_states = 1;
+};
+
+struct MOL
+{
+    static constexpr int num_states = 2;
+    static constexpr int nghost_state = 2;
+    static constexpr int nghost_src = 0;
+    static constexpr int nghost_mac = 0;
+
+    static constexpr int num_diff_states = 2;
+    static constexpr int num_conv_states = 2;
+};
+
+}
+}
+
+#endif /* SCHEMETRAITS_H */

--- a/src/equation_systems/SchemeTraits.H
+++ b/src/equation_systems/SchemeTraits.H
@@ -1,11 +1,15 @@
 #ifndef SCHEMETRAITS_H
 #define SCHEMETRAITS_H
 
+#include <string>
+
 namespace amr_wind {
 namespace fvm {
 
 struct Godunov
 {
+    static std::string scheme_name() { return "Godunov"; }
+
     static constexpr int num_states = 2;
     static constexpr int nghost_state = 3;
     static constexpr int nghost_src = 1;
@@ -17,6 +21,8 @@ struct Godunov
 
 struct MOL
 {
+    static std::string scheme_name() { return "MOL"; }
+
     static constexpr int num_states = 2;
     static constexpr int nghost_state = 2;
     static constexpr int nghost_src = 0;

--- a/src/equation_systems/SourceTerm.H
+++ b/src/equation_systems/SourceTerm.H
@@ -1,0 +1,43 @@
+#ifndef SOURCETERM_H
+#define SOURCETERM_H
+
+#include "FieldDescTypes.H"
+#include "FieldUtils.H"
+#include "AMReX_MultiFab.H"
+
+namespace amr_wind {
+namespace pde {
+
+class SourceTerm
+{
+public:
+    virtual ~SourceTerm() = default;
+
+    virtual void operator()(
+        const int lev,
+        const amrex::MFIter& mfi,
+        const amrex::Box& bx,
+        const FieldState fstate,
+        const amrex::Array4<amrex::Real>& src_term
+    ) const = 0;
+};
+
+class MomentumSource
+{
+public:
+    virtual ~MomentumSource() = default;
+
+    virtual void operator()(
+        const int lev,
+        const amrex::MFIter& mfi,
+        const amrex::Box& bx,
+        const FieldState fstate,
+        const amrex::Array4<amrex::Real>& src_term
+    ) const = 0;
+};
+
+}
+}
+
+
+#endif /* SOURCETERM_H */

--- a/src/equation_systems/SourceTerm.H
+++ b/src/equation_systems/SourceTerm.H
@@ -1,8 +1,10 @@
 #ifndef SOURCETERM_H
 #define SOURCETERM_H
 
+#include "Factory.H"
 #include "FieldDescTypes.H"
 #include "FieldUtils.H"
+#include "FieldRepo.H"
 #include "AMReX_MultiFab.H"
 
 namespace amr_wind {
@@ -22,7 +24,7 @@ public:
     ) const = 0;
 };
 
-class MomentumSource
+class MomentumSource : public Factory<MomentumSource, FieldRepo&>
 {
 public:
     virtual ~MomentumSource() = default;

--- a/src/equation_systems/density/CMakeLists.txt
+++ b/src/equation_systems/density/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  density.cpp)

--- a/src/equation_systems/density/Make.package
+++ b/src/equation_systems/density/Make.package
@@ -1,0 +1,3 @@
+CEXE_headers += density.H
+
+CEXE_sources += density.cpp

--- a/src/equation_systems/density/density.H
+++ b/src/equation_systems/density/density.H
@@ -1,0 +1,23 @@
+#ifndef DENSITY_H
+#define DENSITY_H
+
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+
+namespace amr_wind {
+namespace pde {
+
+struct Density : ScalarTransport
+{
+    static std::string pde_name() { return "Density"; }
+    static std::string var_name() { return "density"; }
+
+    static constexpr bool multiply_rho = false;
+};
+
+} // namespace pde
+} // namespace amr_wind
+
+#endif /* DENSITY_H */

--- a/src/equation_systems/density/density.cpp
+++ b/src/equation_systems/density/density.cpp
@@ -1,7 +1,4 @@
-#include "PDETraits.H"
-#include "SchemeTraits.H"
-#include "PDEHelpers.H"
-#include "PDE.H"
+#include "density/density.H"
 
 namespace amr_wind {
 namespace pde {

--- a/src/equation_systems/density/density.cpp
+++ b/src/equation_systems/density/density.cpp
@@ -1,0 +1,13 @@
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+
+namespace amr_wind {
+namespace pde {
+
+template class PDESystem<Density, fvm::Godunov>;
+template class PDESystem<Density, fvm::MOL>;
+
+} // namespace pde
+} // namespace amr_wind

--- a/src/equation_systems/icns/CMakeLists.txt
+++ b/src/equation_systems/icns/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  icns.cpp)

--- a/src/equation_systems/icns/Make.package
+++ b/src/equation_systems/icns/Make.package
@@ -1,0 +1,4 @@
+CEXE_headers += icns.H
+CEXE_headers += icns_ops.H
+
+CEXE_sources += icns.cpp

--- a/src/equation_systems/icns/MomentumSource.H
+++ b/src/equation_systems/icns/MomentumSource.H
@@ -1,5 +1,5 @@
-#ifndef SOURCETERM_H
-#define SOURCETERM_H
+#ifndef MOMENTUMSOURCE_H
+#define MOMENTUMSOURCE_H
 
 #include "Factory.H"
 #include "FieldDescTypes.H"
@@ -10,22 +10,20 @@
 namespace amr_wind {
 namespace pde {
 
-class SourceTerm
+class MomentumSource : public Factory<MomentumSource, FieldRepo&>
 {
 public:
-    virtual ~SourceTerm() = default;
+    virtual ~MomentumSource() = default;
 
     virtual void operator()(
         const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
         const FieldState fstate,
-        const amrex::Array4<amrex::Real>& src_term
-    ) const = 0;
+        const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 
-}
-}
+} // namespace pde
+} // namespace amr_wind
 
-
-#endif /* SOURCETERM_H */
+#endif /* MOMENTUMSOURCE_H */

--- a/src/equation_systems/icns/icns.H
+++ b/src/equation_systems/icns/icns.H
@@ -1,0 +1,25 @@
+#ifndef ICNS_H
+#define ICNS_H
+
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+#include "icns/MomentumSource.H"
+
+namespace amr_wind {
+namespace pde {
+
+struct ICNS : VectorTransport
+{
+    using MLDiffOp = amrex::MLTensorOp;
+    using SrcTerm = MomentumSource;
+
+    static std::string pde_name() { return "ICNS"; }
+    static std::string var_name() { return "velocity"; }
+};
+
+} // namespace pde
+} // namespace amr_wind
+
+#endif /* ICNS_H */

--- a/src/equation_systems/icns/icns.cpp
+++ b/src/equation_systems/icns/icns.cpp
@@ -1,0 +1,14 @@
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+#include "icns/icns_ops.H"
+
+namespace amr_wind {
+namespace pde {
+
+template class PDESystem<ICNS, ::amr_wind::fvm::Godunov>;
+template class PDESystem<ICNS, ::amr_wind::fvm::MOL>;
+
+} // namespace pde
+} // namespace amr_wind

--- a/src/equation_systems/icns/icns.cpp
+++ b/src/equation_systems/icns/icns.cpp
@@ -1,7 +1,4 @@
-#include "PDETraits.H"
-#include "SchemeTraits.H"
-#include "PDEHelpers.H"
-#include "PDE.H"
+#include "icns/icns.H"
 #include "icns/icns_ops.H"
 
 namespace amr_wind {

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -4,6 +4,7 @@
 #include "PDETraits.H"
 #include "PDEOps.H"
 #include "PDEHelpers.H"
+#include "icns/icns.H"
 
 namespace amr_wind {
 namespace pde {

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -1,0 +1,85 @@
+#ifndef ICNS_OPS_H
+#define ICNS_OPS_H
+
+#include "PDETraits.H"
+#include "PDEOps.H"
+#include "PDEHelpers.H"
+
+namespace amr_wind {
+namespace pde {
+
+template<typename Scheme>
+struct FieldRegOp<ICNS, Scheme>
+{
+    FieldRegOp(FieldRepo& repo_in) : repo(repo_in) {}
+
+    PDEFields operator()(const SimTime& time, const int probtype)
+    {
+        auto fields = create_fields_instance<ICNS, Scheme>(time, repo, probtype);
+
+        auto& rho = repo.declare_cc_field(
+            "density", 1, Scheme::nghost_state, Scheme::num_states);
+        auto& grad_p = repo.declare_cc_field("gp", ICNS::ndim, 0, 1);
+        auto& pressure = repo.declare_nd_field("p", 1, 0, 1);
+        repo.declare_face_normal_field(
+            {"u_mac", "v_mac", "w_mac"}, 1, Scheme::nghost_mac, 1);
+
+        rho.template register_fill_patch_op<FieldFillPatchOps<FieldBCDirichlet>>(
+            repo.mesh(), time, probtype);
+        grad_p.template register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
+            repo.mesh(), time, probtype);
+        pressure.template register_fill_patch_op<FieldFillConstScalar>(0.0);
+
+        rho.fillpatch_on_regrid() = true;
+        grad_p.fillpatch_on_regrid() = true;
+
+        return fields;
+    }
+
+    FieldRepo& repo;
+};
+
+template<>
+struct SrcTermOp<ICNS> : SrcTermOpBase<ICNS>
+{
+    SrcTermOp(PDEFields& fields_in) : SrcTermOpBase<ICNS>(fields_in) {}
+
+    void operator()(const FieldState fstate)
+    {
+        const auto rhostate = field_impl::phi_state(fstate);
+        auto& density = fields.repo.get_field("density", rhostate);
+        auto& grad_p = fields.repo.get_field("gp");
+
+        const int nlevels = this->fields.repo.num_active_levels();
+        for (int lev=0; lev < nlevels; ++lev) {
+            auto& src_term = this->fields.src_term(lev);
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& vf = src_term.array(mfi);
+                const auto& rho = density(lev).const_array(mfi);
+                const auto& gp = grad_p(lev).const_array(mfi);
+
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                        amrex::Real rhoinv = 1.0 / rho(i, j, k);
+                        vf(i, j, k, 0) = -(gp(i, j, k, 0)) * rhoinv;
+                        vf(i, j, k, 1) = -(gp(i, j, k, 1)) * rhoinv;
+                        vf(i, j, k, 2) = -(gp(i, j, k, 2)) * rhoinv;
+                    });
+
+                for (auto& src : this->sources) {
+                    (*src)(lev, mfi, bx, fstate, vf);
+                }
+            }
+        }
+    }
+};
+
+}
+}
+
+#endif /* ICNS_OPS_H */

--- a/src/equation_systems/temperature/CMakeLists.txt
+++ b/src/equation_systems/temperature/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  temperature.cpp)

--- a/src/equation_systems/temperature/Make.package
+++ b/src/equation_systems/temperature/Make.package
@@ -1,0 +1,3 @@
+CEXE_headers += density.H
+
+CEXE_sources += density.cpp

--- a/src/equation_systems/temperature/Make.package
+++ b/src/equation_systems/temperature/Make.package
@@ -1,3 +1,3 @@
-CEXE_headers += density.H
+CEXE_headers += temperature.H
 
-CEXE_sources += density.cpp
+CEXE_sources += temperature.cpp

--- a/src/equation_systems/temperature/temperature.H
+++ b/src/equation_systems/temperature/temperature.H
@@ -1,0 +1,23 @@
+#ifndef TEMPERATURE_H
+#define TEMPERATURE_H
+
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+
+namespace amr_wind {
+namespace pde {
+
+struct Temperature : ScalarTransport
+{
+    static std::string pde_name() { return "Temperature"; }
+    static std::string var_name() { return "temperature"; }
+};
+
+
+} // namespace pde
+} // namespace amr_wind
+
+
+#endif /* TEMPERATURE_H */

--- a/src/equation_systems/temperature/temperature.cpp
+++ b/src/equation_systems/temperature/temperature.cpp
@@ -1,7 +1,4 @@
-#include "PDETraits.H"
-#include "SchemeTraits.H"
-#include "PDEHelpers.H"
-#include "PDE.H"
+#include "temperature/temperature.H"
 
 namespace amr_wind {
 namespace pde {

--- a/src/equation_systems/temperature/temperature.cpp
+++ b/src/equation_systems/temperature/temperature.cpp
@@ -1,0 +1,13 @@
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDEHelpers.H"
+#include "PDE.H"
+
+namespace amr_wind {
+namespace pde {
+
+template class PDESystem<Temperature, fvm::Godunov>;
+template class PDESystem<Temperature, fvm::MOL>;
+
+} // namespace pde
+} // namespace amr_wind

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -70,7 +70,7 @@ public:
 
     amr_wind::Field& velocity() const { return m_repo.get_field("velocity"); }
     amr_wind::Field& density() const { return m_repo.get_field("density"); }
-    amr_wind::Field& tracer() const { return m_repo.get_field("tracer"); }
+    amr_wind::Field& tracer() const { return m_repo.get_field("temperature"); }
     amr_wind::Field& temperature() const { return m_repo.get_field("temperature"); }
     amr_wind::Field& pressure() const { return m_repo.get_field("p"); }
     amr_wind::Field& grad_p() const { return m_repo.get_field("gp"); }

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -15,6 +15,9 @@
 #include "FieldRepo.H"
 
 namespace amr_wind {
+namespace pde {
+class PDEBase;
+}
 class Physics;
 class RefinementCriteria;
 }
@@ -221,6 +224,9 @@ private:
 
     amr_wind::SimTime m_time;
     amr_wind::FieldRepo m_repo;
+
+    std::unique_ptr<amr_wind::pde::PDEBase> m_icns;
+    amrex::Vector<std::unique_ptr<amr_wind::pde::PDEBase>> m_scalar_eqns;
 
     amrex::Vector<std::unique_ptr<amr_wind::Physics>> m_physics;
     amrex::Vector<std::unique_ptr<amr_wind::RefinementCriteria>> m_refine_criteria;

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -3,6 +3,7 @@
 
 #include "ABL.H"
 #include "RefinementCriteria.H"
+#include "PDE.H"
 
 using namespace amrex;
 

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -23,9 +23,9 @@ void incflo::Advance()
     density().advance_states();
     tracer().advance_states();
 
-    m_repo.get_field("velocity",amr_wind::FieldState::Old).fillpatch(m_time.current_time());
-    m_repo.get_field("density",amr_wind::FieldState::Old).fillpatch(m_time.current_time());
-    m_repo.get_field("tracer",amr_wind::FieldState::Old).fillpatch(m_time.current_time());
+    velocity().state(amr_wind::FieldState::Old).fillpatch(m_time.current_time());
+    density().state(amr_wind::FieldState::Old).fillpatch(m_time.current_time());
+    tracer().state(amr_wind::FieldState::Old).fillpatch(m_time.current_time());
 
     for (auto& pp: m_physics)
         pp->pre_advance_work();
@@ -34,9 +34,9 @@ void incflo::Advance()
 
     if (!m_use_godunov) {
 
-        m_repo.get_field("velocity",amr_wind::FieldState::New).fillpatch(m_time.new_time());
-        m_repo.get_field("density",amr_wind::FieldState::New).fillpatch(m_time.new_time());
-        m_repo.get_field("tracer",amr_wind::FieldState::New).fillpatch(m_time.new_time());
+        velocity().state(amr_wind::FieldState::New).fillpatch(m_time.new_time());
+        density().state(amr_wind::FieldState::New).fillpatch(m_time.new_time());
+        tracer().state(amr_wind::FieldState::New).fillpatch(m_time.new_time());
 
         ApplyCorrector();
     }
@@ -134,12 +134,12 @@ void incflo::ApplyPredictor (bool incremental_projection)
         PrintMaxValues(new_time);
     }
 
-    auto& velocity_old = m_repo.get_field("velocity", amr_wind::FieldState::Old);
-    auto& velocity_new = m_repo.get_field("velocity", amr_wind::FieldState::New);
-    auto& density_old = m_repo.get_field("density", amr_wind::FieldState::Old);
-    auto& density_new = m_repo.get_field("density", amr_wind::FieldState::New);
-    auto& tracer_old = m_repo.get_field("tracer", amr_wind::FieldState::Old);
-    auto& tracer_new = m_repo.get_field("tracer", amr_wind::FieldState::New);
+    auto& velocity_old = velocity().state(amr_wind::FieldState::Old);
+    auto& velocity_new = velocity().state(amr_wind::FieldState::New);
+    auto& density_old = density().state(amr_wind::FieldState::Old);
+    auto& density_new = density().state(amr_wind::FieldState::New);
+    auto& tracer_old = tracer().state(amr_wind::FieldState::Old);
+    auto& tracer_new = tracer().state(amr_wind::FieldState::New);
 
     auto& velocity_forces = m_repo.get_field("velocity_forces");
     auto& tracer_forces = m_repo.get_field("tracer_forces");
@@ -559,12 +559,12 @@ void incflo::ApplyCorrector()
         PrintMaxValues(new_time);
     }
 
-    auto& velocity_old = m_repo.get_field("velocity", amr_wind::FieldState::Old);
-    auto& velocity_new = m_repo.get_field("velocity", amr_wind::FieldState::New);
-    auto& density_old = m_repo.get_field("density", amr_wind::FieldState::Old);
-    auto& density_new = m_repo.get_field("density", amr_wind::FieldState::New);
-    auto& tracer_old = m_repo.get_field("tracer", amr_wind::FieldState::Old);
-    auto& tracer_new = m_repo.get_field("tracer", amr_wind::FieldState::New);
+    auto& velocity_old = velocity().state(amr_wind::FieldState::Old);
+    auto& velocity_new = velocity().state(amr_wind::FieldState::New);
+    auto& density_old = density().state(amr_wind::FieldState::Old);
+    auto& density_new = density().state(amr_wind::FieldState::New);
+    auto& tracer_old = tracer().state(amr_wind::FieldState::Old);
+    auto& tracer_new = tracer().state(amr_wind::FieldState::New);
 
     auto& velocity_forces = m_repo.get_field("velocity_forces");
     auto& tracer_forces = m_repo.get_field("tracer_forces");

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -12,27 +12,11 @@ void incflo::declare_fields()
                                    : amr_wind::fvm::MOL::scheme_name();
     m_icns = amr_wind::pde::PDEBase::create(
         "ICNS-" + scheme, m_time, m_repo, m_probtype);
+    m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
+        "Temperature-" + scheme, m_time, m_repo, m_probtype));
 
     const int nstates = 2;
-    const int ng = nghost_state();
-
-    auto& trac = m_repo.declare_cc_field("tracer", m_ntrac, ng, nstates);
-    auto& tra_for = m_repo.declare_cc_field("tracer_forces", m_ntrac, nghost_force(), 1);
-
-    m_repo.declare_cc_field("tracer_viscosity", m_ntrac, 1, 1);
-
     m_repo.declare_cc_field("conv_density", 1, 0, nstates);
-    m_repo.declare_cc_field("conv_tracer", m_ntrac, 0, nstates);
-
-    m_repo.declare_cc_field("laps", m_ntrac, 0, nstates);
-
-    trac.register_fill_patch_op<amr_wind::FieldFillPatchOps<amr_wind::FieldBCDirichlet>>(
-        *this, m_time, m_probtype);
-    tra_for.register_fill_patch_op<amr_wind::FieldFillPatchOps<amr_wind::FieldBCNoOp>>(
-        *this, m_time, m_probtype, amr_wind::FieldInterpolator::PiecewiseConstant);
-
-    // Inform field repo which fields need fillpatch operations on regrid
-    trac.fillpatch_on_regrid() = true;
 }
 
 void incflo::init_field_bcs ()
@@ -40,9 +24,9 @@ void incflo::init_field_bcs ()
     using namespace amrex;
     auto& velocity = m_repo.get_field("velocity");
     auto& density = m_repo.get_field("density");
-    auto& tracer = m_repo.get_field("tracer");
+    auto& tracer = m_repo.get_field("temperature");
     auto& vel_for = m_repo.get_field("velocity_src_term");
-    auto& tra_for = m_repo.get_field("tracer_forces");
+    auto& tra_for = m_repo.get_field("temperature_src_term");
 
     auto& bc_velocity = velocity.bc_values();
     auto& bcrec_velocity = velocity.bcrec();

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(core)
 add_subdirectory(wind_energy)
 add_subdirectory(derive)
 add_subdirectory(utilities)
+add_subdirectory(equation_systems)
 
 target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/unit_tests/equation_systems/CMakeLists.txt
+++ b/unit_tests/equation_systems/CMakeLists.txt
@@ -1,0 +1,8 @@
+target_sources(${amr_wind_unit_test_exe_name}
+  PRIVATE
+
+  test_pde.cpp
+  )
+
+target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE
+  ${CMAKE_SOURCE_DIR}/src/equation_systems)

--- a/unit_tests/equation_systems/test_pde.cpp
+++ b/unit_tests/equation_systems/test_pde.cpp
@@ -6,48 +6,12 @@
 #include "PDE.H"
 #include "icns/icns_ops.H"
 
-namespace amr_wind {
-namespace pde {
-
-template class PDESystem<ICNS, fvm::Godunov>;
-template class PDESystem<Temperature, fvm::Godunov>;
-
-}
-}
-
 namespace amr_wind_tests {
 
 class PDETest : public MeshTest
 {};
 
-TEST_F(PDETest, test_pde_impl)
-{
-    initialize_mesh();
-
-    amr_wind::SimTime time;
-
-    using ICNSGodunov =
-        amr_wind::pde::PDESystem<amr_wind::pde::ICNS, amr_wind::fvm::Godunov>;
-    using TemperatureGodunov =
-        amr_wind::pde::PDESystem<amr_wind::pde::Temperature, amr_wind::fvm::Godunov>;
-
-    ICNSGodunov lowmach(time, mesh().field_repo(), 35);
-    TemperatureGodunov theta(time, mesh().field_repo(), 35);
-
-    amrex::Print()
-        << "Num registered fields: "
-        << mesh().field_repo().num_fields() << std::endl;
-
-    for (auto& ff: mesh().field_repo().fields()) {
-        amrex::Print() << " - " << ff->name() << std::endl;
-    }
-
-    lowmach.compute_source_term(amr_wind::FieldState::Old);
-    theta.compute_source_term(amr_wind::FieldState::Old);
-
-}
-
-TEST_F(PDETest, test_pde_create)
+TEST_F(PDETest, test_pde_create_godunov)
 {
     initialize_mesh();
     amr_wind::SimTime time;
@@ -57,16 +21,20 @@ TEST_F(PDETest, test_pde_create)
     auto theta = amr_wind::pde::PDEBase::create(
         "Temperature-Godunov", time, mesh().field_repo(), 35);
 
-    amrex::Print()
-        << "Num registered fields: "
-        << mesh().field_repo().num_fields() << std::endl;
+    EXPECT_EQ(mesh().field_repo().num_fields(), 19);
+}
 
-    for (auto& ff: mesh().field_repo().fields()) {
-        amrex::Print() << " - " << ff->name() << std::endl;
-    }
+TEST_F(PDETest, test_pde_create_mol)
+{
+    initialize_mesh();
+    amr_wind::SimTime time;
 
-    lowmach->compute_source_term(amr_wind::FieldState::Old);
-    theta->compute_source_term(amr_wind::FieldState::Old);
+    auto lowmach = amr_wind::pde::PDEBase::create(
+        "ICNS-MOL", time, mesh().field_repo(), 35);
+    auto theta = amr_wind::pde::PDEBase::create(
+        "Temperature-MOL", time, mesh().field_repo(), 35);
+
+    EXPECT_EQ(mesh().field_repo().num_fields(), 23);
 }
 
 }

--- a/unit_tests/equation_systems/test_pde.cpp
+++ b/unit_tests/equation_systems/test_pde.cpp
@@ -1,0 +1,40 @@
+#include "gtest/gtest.h"
+#include "aw_test_utils/MeshTest.H"
+
+#include "PDETraits.H"
+#include "SchemeTraits.H"
+#include "PDE.H"
+#include "icns/icns_ops.H"
+
+namespace amr_wind_tests {
+
+class PDETest : public MeshTest
+{};
+
+TEST_F(PDETest, test_pde_impl)
+{
+    initialize_mesh();
+
+    amr_wind::SimTime time;
+
+    using ICNSGodunov =
+        amr_wind::pde::PDESystem<amr_wind::pde::ICNS, amr_wind::fvm::Godunov>;
+    using TemperatureGodunov =
+        amr_wind::pde::PDESystem<amr_wind::pde::Temperature, amr_wind::fvm::Godunov>;
+
+    ICNSGodunov lowmach(time, mesh().field_repo(), 35);
+    TemperatureGodunov theta(time, mesh().field_repo(), 35);
+
+    amrex::Print()
+        << "Num registered fields: "
+        << mesh().field_repo().num_fields() << std::endl;
+
+    for (auto& ff: mesh().field_repo().fields()) {
+        amrex::Print() << " - " << ff->name() << std::endl;
+    }
+
+    lowmach.compute_source_term(amr_wind::FieldState::Old);
+    theta.compute_source_term(amr_wind::FieldState::Old);
+}
+
+}

--- a/unit_tests/equation_systems/test_pde.cpp
+++ b/unit_tests/equation_systems/test_pde.cpp
@@ -6,6 +6,15 @@
 #include "PDE.H"
 #include "icns/icns_ops.H"
 
+namespace amr_wind {
+namespace pde {
+
+template class PDESystem<ICNS, fvm::Godunov>;
+template class PDESystem<Temperature, fvm::Godunov>;
+
+}
+}
+
 namespace amr_wind_tests {
 
 class PDETest : public MeshTest
@@ -35,6 +44,29 @@ TEST_F(PDETest, test_pde_impl)
 
     lowmach.compute_source_term(amr_wind::FieldState::Old);
     theta.compute_source_term(amr_wind::FieldState::Old);
+
+}
+
+TEST_F(PDETest, test_pde_create)
+{
+    initialize_mesh();
+    amr_wind::SimTime time;
+
+    auto lowmach = amr_wind::pde::PDEBase::create(
+        "ICNS-Godunov", time, mesh().field_repo(), 35);
+    auto theta = amr_wind::pde::PDEBase::create(
+        "Temperature-Godunov", time, mesh().field_repo(), 35);
+
+    amrex::Print()
+        << "Num registered fields: "
+        << mesh().field_repo().num_fields() << std::endl;
+
+    for (auto& ff: mesh().field_repo().fields()) {
+        amrex::Print() << " - " << ff->name() << std::endl;
+    }
+
+    lowmach->compute_source_term(amr_wind::FieldState::Old);
+    theta->compute_source_term(amr_wind::FieldState::Old);
 }
 
 }


### PR DESCRIPTION
Introduce the notion of PDE systems so that we can enable/disable different equation systems for wind relevant problems. Motivation is to be able to run just momentum with k-omega SST turbulence model for certain applications, while being able to run ABL simulations with 1-eqn k-sgs model and the temperature equation. 

This pull request introduces the basic skeleton and replaces all field creation logic and tracer source terms as an example. More work is needed to start replacing bits of `Apply{Predictor,Corrector}` with this interface. 