### PR TITLE
Refactor predictor/corrector code to use equation system interface

### DIFF
--- a/src/core/FieldRepo.cpp
+++ b/src/core/FieldRepo.cpp
@@ -197,6 +197,8 @@ void FieldRepo::allocate_field_data(
         mfab_vec.emplace_back(
             ba1, dm, field->num_comp(), field->num_grow(), amrex::MFInfo(),
             factory);
+
+        mfab_vec.back().setVal(0.0);
     }
 }
 
@@ -214,6 +216,8 @@ void FieldRepo::allocate_field_data(
     mfab_vec.emplace_back(
         ba, m_mesh.DistributionMap(lev), field.num_comp(), field.num_grow(),
         amrex::MFInfo(), factory);
+
+    mfab_vec.back().setVal(0.0);
 }
 
 void FieldRepo::allocate_field_data(Field& field)

--- a/src/equation_systems/CompRHSOps.H
+++ b/src/equation_systems/CompRHSOps.H
@@ -1,0 +1,184 @@
+#ifndef COMPRHSOPS_H
+#define COMPRHSOPS_H
+
+#include "incflo_enums.H"
+#include "PDEOps.H"
+#include "SchemeTraits.H"
+
+namespace amr_wind {
+namespace pde {
+
+template<typename PDE, typename Scheme>
+struct ComputeRHSOp
+{
+    ComputeRHSOp(PDEFields& fields_in) : fields(fields_in) {}
+
+    void predictor_rhs(const DiffusionType difftype, const amrex::Real dt)
+    {
+        amrex::Real factor = 0.0;
+        switch (difftype) {
+        case DiffusionType::Explicit:
+            factor = 1.0;
+            break;
+
+        case DiffusionType::Crank_Nicolson:
+            factor = 0.5;
+            break;
+
+        case DiffusionType::Implicit:
+            factor = 0.0;
+            break;
+
+        default:
+            amrex::Abort("Invalid diffusion type");
+        }
+
+        // Field states for diffusion and advection terms. In Godunov scheme
+        // these terms only have one state.
+        auto fstate = std::is_same<Scheme, fvm::Godunov>::value
+                          ? FieldState::New
+                          : FieldState::Old;
+
+        const int nlevels = fields.repo.num_active_levels();
+        auto& field = fields.field;
+        auto& field_old = field.state(FieldState::Old);
+        auto& den_new = fields.repo.get_field("density");
+        auto& den_old = den_new.state(FieldState::Old);
+        auto& src_term = fields.src_term;
+        auto& diff_term = fields.diff_term.state(fstate);
+        auto& conv_term = fields.conv_term.state(fstate);
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                auto fld = field(lev).array(mfi);
+                const auto fld_o = field_old(lev).const_array(mfi);
+                const auto rho_o = den_old(lev).const_array(mfi);
+                const auto rho = den_new(lev).const_array(mfi);
+                const auto src = src_term(lev).const_array(mfi);
+                const auto diff = diff_term(lev).const_array(mfi);
+                const auto ddt_o = conv_term(lev).const_array(mfi);
+
+                if (PDE::multiply_rho) {
+                    // Remove multiplication by density as it will be added back
+                    // in solver
+                    amrex::ParallelFor(
+                        bx, PDE::ndim,
+                        [=] AMREX_GPU_DEVICE(
+                            int i, int j, int k, int n) noexcept {
+                            fld(i, j, k, n) =
+                                rho_o(i, j, k) * fld_o(i, j, k, n) +
+                                dt * (ddt_o(i, j, k, n) + src(i, j, k, n) +
+                                      factor * diff(i, j, k, n));
+
+                            fld(i, j, k, n) /= rho(i, j, k);
+                        });
+                } else {
+                    amrex::ParallelFor(
+                        bx, PDE::ndim,
+                        [=] AMREX_GPU_DEVICE(
+                            int i, int j, int k, int n) noexcept {
+                            fld(i, j, k, n) =
+                                fld_o(i, j, k, n) +
+                                dt * (ddt_o(i, j, k, n) + src(i, j, k, n) +
+                                      factor * diff(i, j, k, n));
+                        });
+                }
+            }
+        }
+    }
+
+    void corrector_rhs(const DiffusionType difftype, const amrex::Real dt)
+    {
+        amrex::Real ofac = 0.0;
+        amrex::Real nfac = 0.0;
+        switch (difftype) {
+        case DiffusionType::Explicit:
+            ofac = 0.5;
+            nfac = 0.5;
+            break;
+
+        case DiffusionType::Crank_Nicolson:
+            ofac = 0.5;
+            nfac = 0.0;
+            break;
+
+        case DiffusionType::Implicit:
+            ofac = 0.0;
+            nfac = 0.0;
+            break;
+
+        default:
+            amrex::Abort("Invalid diffusion type");
+        }
+
+        const int nlevels = fields.repo.num_active_levels();
+        auto& field = fields.field;
+        auto& field_old = field.state(FieldState::Old);
+        auto& den_new = fields.repo.get_field("density");
+        auto& den_old = den_new.state(FieldState::Old);
+        auto& src_term = fields.src_term;
+        auto& diff_term = fields.diff_term;
+        auto& conv_term = fields.conv_term;
+        auto& diff_term_old = fields.diff_term.state(FieldState::Old);
+        auto& conv_term_old = fields.conv_term.state(FieldState::Old);
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                auto fld = field(lev).array(mfi);
+                const auto fld_o = field_old(lev).const_array(mfi);
+                const auto rho_o = den_old(lev).const_array(mfi);
+                const auto rho = den_new(lev).const_array(mfi);
+                const auto src = src_term(lev).const_array(mfi);
+                const auto diff = diff_term(lev).const_array(mfi);
+                const auto ddt = conv_term(lev).const_array(mfi);
+                const auto diff_o = diff_term_old(lev).const_array(mfi);
+                const auto ddt_o = conv_term_old(lev).const_array(mfi);
+
+                if (PDE::multiply_rho) {
+                    // Remove multiplication by density as it will be added back
+                    // in solver
+                    amrex::ParallelFor(
+                        bx, PDE::ndim,
+                        [=] AMREX_GPU_DEVICE(
+                            int i, int j, int k, int n) noexcept {
+                            fld(i, j, k, n) =
+                                rho_o(i, j, k) * fld_o(i, j, k, n) +
+                                dt * (0.5 * (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
+                                      src(i, j, k, n) + nfac * diff(i, j, k, n) +
+                                      ofac * diff_o(i, j, k, n));
+
+                            fld(i, j, k, n) /= rho(i, j, k);
+                        });
+                } else {
+                    amrex::ParallelFor(
+                        bx, PDE::ndim,
+                        [=] AMREX_GPU_DEVICE(
+                            int i, int j, int k, int n) noexcept {
+                            fld(i, j, k, n) =
+                                fld_o(i, j, k, n) +
+                                dt * (0.5 * (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
+                                      src(i, j, k, n) + nfac * diff(i, j, k, n) +
+                                      ofac * diff_o(i, j, k, n));
+
+                        });
+                }
+            }
+        }
+    }
+
+    // data members
+    PDEFields& fields;
+};
+
+}
+}
+
+#endif /* COMPRHSOPS_H */

--- a/src/equation_systems/CompRHSOps.H
+++ b/src/equation_systems/CompRHSOps.H
@@ -151,9 +151,11 @@ struct ComputeRHSOp
                             int i, int j, int k, int n) noexcept {
                             fld(i, j, k, n) =
                                 rho_o(i, j, k) * fld_o(i, j, k, n) +
-                                dt * (0.5 * (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
-                                      src(i, j, k, n) + nfac * diff(i, j, k, n) +
-                                      ofac * diff_o(i, j, k, n));
+                                dt *
+                                    (0.5 *
+                                         (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
+                                     ofac * diff_o(i, j, k, n) +
+                                     nfac * diff(i, j, k, n) + src(i, j, k, n));
 
                             fld(i, j, k, n) /= rho(i, j, k);
                         });
@@ -162,12 +164,12 @@ struct ComputeRHSOp
                         bx, PDE::ndim,
                         [=] AMREX_GPU_DEVICE(
                             int i, int j, int k, int n) noexcept {
-                            fld(i, j, k, n) =
-                                fld_o(i, j, k, n) +
-                                dt * (0.5 * (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
-                                      src(i, j, k, n) + nfac * diff(i, j, k, n) +
-                                      ofac * diff_o(i, j, k, n));
-
+                            fld(i, j, k, n) = fld_o(i, j, k, n) +
+                                              dt * (0.5 * (ddt_o(i, j, k, n) +
+                                                           ddt(i, j, k, n)) +
+                                                    ofac * diff_o(i, j, k, n) +
+                                                    nfac * diff(i, j, k, n) +
+                                                    src(i, j, k, n));
                         });
                 }
             }

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -3,9 +3,11 @@
 
 #include <string>
 
+#include "incflo_enums.H"
 #include "Factory.H"
 #include "PDEHelpers.H"
 #include "PDEOps.H"
+#include "CompRHSOps.H"
 #include "DiffusionOps.H"
 
 namespace amr_wind {
@@ -29,6 +31,10 @@ public:
     virtual void compute_diffusion_term(const FieldState fstate) = 0;
 
     virtual void compute_advection_term(const FieldState fstate) = 0;
+
+    virtual void compute_predictor_rhs(const DiffusionType difftype) = 0;
+
+    virtual void compute_corrector_rhs(const DiffusionType difftype) = 0;
 
     virtual void solve(const amrex::Real dt) = 0;
 
@@ -56,6 +62,7 @@ public:
         , m_fields(FieldRegOp<PDE, Scheme>(repo)(time, probtype))
         , m_src_op(m_fields)
         , m_adv_op(m_fields)
+        , m_rhs_op(m_fields)
     {}
 
     void initialize() override
@@ -93,6 +100,16 @@ public:
         m_adv_op(fstate, m_time.deltaT());
     }
 
+    virtual void compute_predictor_rhs(const DiffusionType difftype) override
+    {
+        m_rhs_op.predictor_rhs(difftype, m_time.deltaT());
+    }
+
+    virtual void compute_corrector_rhs(const DiffusionType difftype) override
+    {
+        m_rhs_op.corrector_rhs(difftype, m_time.deltaT());
+    }
+
     void solve(const amrex::Real dt) override
     {
         if (PDE::has_diffusion)
@@ -108,6 +125,7 @@ protected:
 
     SrcTermOp<PDE> m_src_op;
     AdvectionOp<PDE, Scheme> m_adv_op;
+    ComputeRHSOp<PDE, Scheme> m_rhs_op;
     std::unique_ptr<DiffusionOp<PDE, Scheme>> m_diff_op;
 };
 

--- a/src/equation_systems/PDETraits.H
+++ b/src/equation_systems/PDETraits.H
@@ -14,6 +14,7 @@ struct VectorTransport
     using MLDiffOp = amrex::MLABecLaplacian;
     static constexpr int ndim = AMREX_SPACEDIM;
 
+    static constexpr bool multiply_rho = true;
     static constexpr bool has_diffusion = true;
 };
 

--- a/src/equation_systems/density/density.cpp
+++ b/src/equation_systems/density/density.cpp
@@ -1,6 +1,7 @@
 #include "density/density.H"
 #include "AdvOp_Godunov.H"
 #include "AdvOp_MOL.H"
+#include "density/density_ops.H"
 
 namespace amr_wind {
 namespace pde {

--- a/src/equation_systems/density/density_ops.H
+++ b/src/equation_systems/density/density_ops.H
@@ -22,7 +22,6 @@ struct ComputeRHSOp<Density, Scheme>
         const int nlevels = fields.repo.num_active_levels();
         auto& field = fields.field;
         auto& field_old = field.state(FieldState::Old);
-        auto& den_nph = field.state(FieldState::NPH);
         auto& conv_term = fields.conv_term.state(fstate);
 
         for (int lev = 0; lev < nlevels; ++lev) {
@@ -32,7 +31,6 @@ struct ComputeRHSOp<Density, Scheme>
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
                 const auto& bx = mfi.tilebox();
                 auto rho = field(lev).array(mfi);
-                auto rho_nph = den_nph(lev).array(mfi);
                 const auto rho_o = field_old(lev).const_array(mfi);
                 const auto ddt_o = conv_term(lev).const_array(mfi);
 
@@ -40,7 +38,8 @@ struct ComputeRHSOp<Density, Scheme>
                     bx,
                     [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         rho(i, j, k) = rho_o(i, j, k) + dt * ddt_o(i, j, k);
-                        rho_nph(i, j, k) = 0.5 * (rho(i, j, k) + rho_o(i, j, k));
+                        // Defer n+1/2 update to the time-stepping algorithm
+                        // rho_nph(i, j, k) = 0.5 * (rho(i, j, k) + rho_o(i, j, k));
                     });
             }
         }
@@ -51,7 +50,6 @@ struct ComputeRHSOp<Density, Scheme>
         const int nlevels = fields.repo.num_active_levels();
         auto& field = fields.field;
         auto& field_old = field.state(FieldState::Old);
-        auto& den_nph = field.state(FieldState::NPH);
         auto& conv_term = fields.conv_term;
         auto& conv_term_old = fields.conv_term.state(FieldState::Old);
 
@@ -62,7 +60,6 @@ struct ComputeRHSOp<Density, Scheme>
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
                 const auto& bx = mfi.tilebox();
                 auto rho = field(lev).array(mfi);
-                auto rho_nph = den_nph(lev).array(mfi);
                 const auto rho_o = field_old(lev).const_array(mfi);
                 const auto ddt = conv_term(lev).const_array(mfi);
                 const auto ddt_o = conv_term_old(lev).const_array(mfi);
@@ -72,8 +69,9 @@ struct ComputeRHSOp<Density, Scheme>
                         rho(i, j, k) =
                             rho_o(i, j, k) +
                             dt * 0.5 * (ddt_o(i, j, k) + ddt(i, j, k));
-                        rho_nph(i, j, k) =
-                            0.5 * (rho(i, j, k) + rho_o(i, j, k));
+                        // Defer n+1/2 update to time-stepping algorithm
+                        // rho_nph(i, j, k) =
+                        //     0.5 * (rho(i, j, k) + rho_o(i, j, k));
                     });
             }
         }

--- a/src/equation_systems/density/density_ops.H
+++ b/src/equation_systems/density/density_ops.H
@@ -1,0 +1,88 @@
+#ifndef DENSITY_OPS_H
+#define DENSITY_OPS_H
+
+#include "density/density.H"
+
+namespace amr_wind {
+namespace pde {
+
+template<typename Scheme>
+struct ComputeRHSOp<Density, Scheme>
+{
+    ComputeRHSOp(PDEFields& fields_in) : fields(fields_in) {}
+
+    void predictor_rhs(const DiffusionType, const amrex::Real dt)
+    {
+        // Field states for diffusion and advection terms. In Godunov scheme
+        // these terms only have one state.
+        auto fstate = std::is_same<Scheme, fvm::Godunov>::value
+                          ? FieldState::New
+                          : FieldState::Old;
+
+        const int nlevels = fields.repo.num_active_levels();
+        auto& field = fields.field;
+        auto& field_old = field.state(FieldState::Old);
+        auto& den_nph = field.state(FieldState::NPH);
+        auto& conv_term = fields.conv_term.state(fstate);
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                auto rho = field(lev).array(mfi);
+                auto rho_nph = den_nph(lev).array(mfi);
+                const auto rho_o = field_old(lev).const_array(mfi);
+                const auto ddt_o = conv_term(lev).const_array(mfi);
+
+                amrex::ParallelFor(
+                    bx,
+                    [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        rho(i, j, k) = rho_o(i, j, k) + dt * ddt_o(i, j, k);
+                        rho_nph(i, j, k) = 0.5 * (rho(i, j, k) + rho_o(i, j, k));
+                    });
+            }
+        }
+    }
+
+    void corrector_rhs(const DiffusionType, const amrex::Real dt)
+    {
+        const int nlevels = fields.repo.num_active_levels();
+        auto& field = fields.field;
+        auto& field_old = field.state(FieldState::Old);
+        auto& den_nph = field.state(FieldState::NPH);
+        auto& conv_term = fields.conv_term;
+        auto& conv_term_old = fields.conv_term.state(FieldState::Old);
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                auto rho = field(lev).array(mfi);
+                auto rho_nph = den_nph(lev).array(mfi);
+                const auto rho_o = field_old(lev).const_array(mfi);
+                const auto ddt = conv_term(lev).const_array(mfi);
+                const auto ddt_o = conv_term_old(lev).const_array(mfi);
+
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        rho(i, j, k) =
+                            rho_o(i, j, k) +
+                            dt * 0.5 * (ddt_o(i, j, k) + ddt(i, j, k));
+                        rho_nph(i, j, k) =
+                            0.5 * (rho(i, j, k) + rho_o(i, j, k));
+                    });
+            }
+        }
+    }
+
+    // data members
+    PDEFields& fields;
+};
+}
+}
+
+#endif /* DENSITY_OPS_H */

--- a/src/equation_systems/icns/CMakeLists.txt
+++ b/src/equation_systems/icns/CMakeLists.txt
@@ -1,2 +1,3 @@
 target_sources(${amr_wind_lib_name} PRIVATE
+  icns_ops.cpp
   icns.cpp)

--- a/src/equation_systems/icns/Make.package
+++ b/src/equation_systems/icns/Make.package
@@ -1,4 +1,4 @@
 CEXE_headers += icns.H
 CEXE_headers += icns_ops.H
 
-CEXE_sources += icns.cpp
+CEXE_sources += icns.cpp icns_ops.cpp

--- a/src/equation_systems/icns/icns.H
+++ b/src/equation_systems/icns/icns.H
@@ -17,6 +17,9 @@ struct ICNS : VectorTransport
 
     static std::string pde_name() { return "ICNS"; }
     static std::string var_name() { return "velocity"; }
+
+    static constexpr bool multiply_rho = false;
+    static constexpr bool has_diffusion = true;
 };
 
 } // namespace pde

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -117,11 +117,15 @@ struct AdvectionOp<ICNS, fvm::Godunov>
 
         auto bcrec_device = dof_field.bcrec_device();
 
+        for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
+            u_mac(lev).setBndry(0.0);
+            v_mac(lev).setBndry(0.0);
+            w_mac(lev).setBndry(0.0);
+        }
 
         //
         // Predict
         //
-
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
             amrex::Box const& domain = geom[lev].Domain();
 

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -8,14 +8,13 @@
 #include "AdvOp_MOL.H"
 #include "DiffusionOps.H"
 #include "icns/icns.H"
-#include <incflo_MAC_bcs.H>
-#include <AMReX_MultiFabUtil.H>
-#include <AMReX_MacProjector.H>
-#include <mac_projection.H>
-#include <MLMGOptions.H>
+#include "incflo_MAC_bcs.H"
+#include "AMReX_MultiFabUtil.H"
 
 namespace amr_wind {
 namespace pde {
+
+void advection_mac_project(FieldRepo& repo, FieldState fstate);
 
 template<typename Scheme>
 struct FieldRegOp<ICNS, Scheme>
@@ -100,12 +99,6 @@ struct AdvectionOp<ICNS, fvm::Godunov>
             pp.query("godunov_use_forces_in_trans", godunov_use_forces_in_trans);
         }
 
-        amr_wind::MLMGOptions options("mac_proj");
-
-        max_coarsen_level = options.max_coarsen_level;
-        rel_tol = options.rel_tol;
-        abs_tol = options.abs_tol;
-
         // TODO: Need iconserv flag to be adjusted???
         iconserv.resize(ICNS::ndim, 0);
     }
@@ -117,7 +110,6 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         auto& u_mac = repo.get_field("u_mac");
         auto& v_mac = repo.get_field("v_mac");
         auto& w_mac = repo.get_field("w_mac");
-        auto& density = repo.get_field("density", fstate);
 
         auto& src_term = fields.src_term;
         auto& conv_term = fields.conv_term;
@@ -130,143 +122,88 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         // Predict
         //
 
-        for(int lev = 0; lev < repo.num_active_levels(); ++lev){
-
+        for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
             amrex::Box const& domain = geom[lev].Domain();
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            {
-                amrex::FArrayBox scratch;
-                for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    amrex::Box const& bx = mfi.tilebox();
-                    amrex::Box const& bxg1 = amrex::grow(bx,1);
-                    amrex::Box const& xbx = mfi.nodaltilebox(0);
-                    amrex::Box const& ybx = mfi.nodaltilebox(1);
-                    amrex::Box const& zbx = mfi.nodaltilebox(2);
+            amrex::FArrayBox scratch;
+            for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                amrex::Box const& bx = mfi.tilebox();
+                amrex::Box const& bxg1 = amrex::grow(bx, 1);
+                amrex::Box const& xbx = mfi.nodaltilebox(0);
+                amrex::Box const& ybx = mfi.nodaltilebox(1);
+                amrex::Box const& zbx = mfi.nodaltilebox(2);
 
-                    amrex::Array4<amrex::Real> const& a_umac = u_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real> const& a_vmac = v_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real> const& a_wmac = w_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real const> const& a_vel = dof_field(lev).const_array(mfi);
-                    amrex::Array4<amrex::Real const> const& a_f = src_term(lev).const_array(mfi);
+                // clang-format off
+                amrex::Array4<amrex::Real> const& a_umac = u_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real> const& a_vmac = v_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real> const& a_wmac = w_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real const> const& a_vel = dof_field(lev).const_array(mfi);
+                amrex::Array4<amrex::Real const> const& a_f = src_term(lev).const_array(mfi);
 
-                    scratch.resize(bxg1, ICNS::ndim*12+3);
-    //                Elixir eli = scratch.elixir(); // not needed because of streamSynchronize later
-                    amrex::Real* p = scratch.dataPtr();
+                scratch.resize(bxg1, ICNS::ndim * 12 + 3);
+                // Elixir eli = scratch.elixir(); // not needed because of streamSynchronize later
+                amrex::Real* p = scratch.dataPtr();
 
-                    amrex::Array4<amrex::Real> Imx = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Imx.size();
-                    amrex::Array4<amrex::Real> Ipx = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Ipx.size();
-                    amrex::Array4<amrex::Real> Imy = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Imy.size();
-                    amrex::Array4<amrex::Real> Ipy = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Ipy.size();
-                    amrex::Array4<amrex::Real> Imz = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Imz.size();
-                    amrex::Array4<amrex::Real> Ipz = makeArray4(p,bxg1,ICNS::ndim);
-                    p +=         Ipz.size();
-                    amrex::Array4<amrex::Real> u_ad = makeArray4(p,amrex::Box(bx).grow(1,1).grow(2,1).surroundingNodes(0),1);
-                    p +=         u_ad.size();
-                    amrex::Array4<amrex::Real> v_ad = makeArray4(p,amrex::Box(bx).grow(0,1).grow(2,1).surroundingNodes(1),1);
-                    p +=         v_ad.size();
-                    amrex::Array4<amrex::Real> w_ad = makeArray4(p,amrex::Box(bx).grow(0,1).grow(1,1).surroundingNodes(2),1);
-                    p +=         w_ad.size();
+                amrex::Array4<amrex::Real> Imx = makeArray4(p, bxg1, ICNS::ndim);
+                p += Imx.size();
+                amrex::Array4<amrex::Real> Ipx = makeArray4(p, bxg1, ICNS::ndim);
+                p += Ipx.size();
+                amrex::Array4<amrex::Real> Imy = makeArray4(p, bxg1, ICNS::ndim);
+                p += Imy.size();
+                amrex::Array4<amrex::Real> Ipy = makeArray4(p, bxg1, ICNS::ndim);
+                p += Ipy.size();
+                amrex::Array4<amrex::Real> Imz = makeArray4(p, bxg1, ICNS::ndim);
+                p += Imz.size();
+                amrex::Array4<amrex::Real> Ipz = makeArray4(p, bxg1, ICNS::ndim);
+                p += Ipz.size();
+                amrex::Array4<amrex::Real> u_ad = makeArray4(p, amrex::Box(bx).grow(1, 1).grow(2, 1).surroundingNodes(0), 1);
+                p += u_ad.size();
+                amrex::Array4<amrex::Real> v_ad = makeArray4(p, amrex::Box(bx).grow(0, 1).grow(2, 1).surroundingNodes(1), 1);
+                p += v_ad.size();
+                amrex::Array4<amrex::Real> w_ad = makeArray4(p, amrex::Box(bx).grow(0, 1).grow(1, 1).surroundingNodes(2), 1);
+                p += w_ad.size();
+                // clang-format on
 
-                    if (godunov_ppm){
-                        godunov::predict_ppm (lev, bxg1, ICNS::ndim, Imx, Ipx, Imy, Ipy, Imz, Ipz, a_vel, a_vel,
-                                              geom, dt, bcrec_device);
-                    } else {
-                        godunov::predict_plm (lev, bxg1, ICNS::ndim, Imx, Ipx, Imy, Ipy, Imz, Ipz, a_vel, a_vel,
-                                     geom, dt, dof_field.bcrec(), bcrec_device);
-                    }
-
-                    godunov::make_trans_velocities(lev, amrex::Box(u_ad), amrex::Box(v_ad), amrex::Box(w_ad),
-                                                   u_ad, v_ad, w_ad,
-                                                   Imx, Ipx, Imy, Ipy, Imz, Ipz, a_vel, a_f,
-                                                   geom, dt, bcrec_device, godunov_use_forces_in_trans);
-
-                    godunov::predict_godunov(lev, bx, ICNS::ndim, xbx, ybx, zbx, a_umac, a_vmac, a_wmac,
-                                             a_vel, u_ad, v_ad, w_ad, Imx, Ipx, Imy, Ipy, Imz, Ipz, a_f, p,
-                                             geom, dt, bcrec_device, godunov_use_forces_in_trans);
-
-                    incflo_set_mac_bcs(domain, xbx, ybx, zbx, a_umac, a_vmac, a_wmac, a_vel, dof_field.bcrec());
-
-                    amrex::Gpu::streamSynchronize();  // otherwise we might be using too much memory
+                if (godunov_ppm) {
+                    godunov::predict_ppm(
+                        lev, bxg1, ICNS::ndim, Imx, Ipx, Imy, Ipy, Imz, Ipz,
+                        a_vel, a_vel, geom, dt, bcrec_device);
+                } else {
+                    godunov::predict_plm(
+                        lev, bxg1, ICNS::ndim, Imx, Ipx, Imy, Ipy, Imz, Ipz,
+                        a_vel, a_vel, geom, dt, dof_field.bcrec(),
+                        bcrec_device);
                 }
+
+                godunov::make_trans_velocities(
+                    lev, amrex::Box(u_ad), amrex::Box(v_ad), amrex::Box(w_ad),
+                    u_ad, v_ad, w_ad, Imx, Ipx, Imy, Ipy, Imz, Ipz, a_vel, a_f,
+                    geom, dt, bcrec_device, godunov_use_forces_in_trans);
+
+                godunov::predict_godunov(
+                    lev, bx, ICNS::ndim, xbx, ybx, zbx, a_umac, a_vmac, a_wmac,
+                    a_vel, u_ad, v_ad, w_ad, Imx, Ipx, Imy, Ipy, Imz, Ipz, a_f,
+                    p, geom, dt, bcrec_device, godunov_use_forces_in_trans);
+
+                incflo_set_mac_bcs(
+                    domain, xbx, ybx, zbx, a_umac, a_vmac, a_wmac, a_vel,
+                    dof_field.bcrec());
+
+                amrex::Gpu::streamSynchronize(); // otherwise we might be using
+                                                 // too much memory
             }
         }
-        
 
-        //
-        // MAC
-        //
-
-        // This will hold (1/rho) on faces
-        auto rho_xf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::XFACE);
-        auto rho_yf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::YFACE);
-        auto rho_zf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::ZFACE);
-
-        amrex::Vector<amrex::Array<amrex::MultiFab*,ICNS::ndim>> rho_face(repo.num_active_levels());
-        amrex::Vector<amrex::Array<amrex::MultiFab*,ICNS::ndim>> mac_vec(repo.num_active_levels());
-
-        //fixme todo clean this up, this was done to replace GetVecOfArrOfConstPtrs() below
-        amrex::Vector<amrex::Array<amrex::MultiFab const*,ICNS::ndim>> rho_face_const;
-        rho_face_const.reserve(repo.num_active_levels());
-
-        for (int lev=0; lev < repo.num_active_levels(); ++lev)
-        {
-             rho_face[lev][0] = &(*rho_xf)(lev);
-             rho_face[lev][1] = &(*rho_yf)(lev);
-             rho_face[lev][2] = &(*rho_zf)(lev);
-
-             amrex::average_cellcenter_to_face(rho_face[lev], density(lev), geom[lev]);
-             for (int idim = 0; idim < ICNS::ndim; ++idim) {
-                 rho_face[lev][idim]->invert(1.0, 0);
-             }
-
-             rho_face_const.push_back(GetArrOfConstPtrs(rho_face[lev]));
-
-             mac_vec[lev][0] = &u_mac(lev);
-             mac_vec[lev][1] = &v_mac(lev);
-             mac_vec[lev][2] = &w_mac(lev);
-         }
-
-
-        amr_wind::MLMGOptions options("mac_proj");
-
-         // If we want to set max_coarsening_level we have to send it in to the constructor
-         amrex::LPInfo lp_info;
-         lp_info.setMaxCoarseningLevel(max_coarsen_level);
-
-
-         // Perform MAC projection
-         amrex::MacProjector macproj(mac_vec,
-                              rho_face_const,
-                              repo.mesh().Geom(0,repo.num_active_levels()-1),
-                              lp_info);
-
-         // get the bc types from pressure field
-         auto& bctype = repo.get_field("p").bc_type();
-
-         macproj.setDomainBC(mac::get_projection_bc(amrex::Orientation::low, bctype, repo.mesh().Geom()),
-                             mac::get_projection_bc(amrex::Orientation::high, bctype, repo.mesh().Geom()));
-
-         macproj.project(rel_tol,
-                         abs_tol,
-                         amrex::MLMG::Location::FaceCentroid);
-
-
-
-
+        // MAC projection
+        advection_mac_project(repo, fstate);
 
         //
         // Advect momentum eqns
         //
-
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
             u_mac(lev).FillBoundary(geom[lev].periodicity());
             v_mac(lev).FillBoundary(geom[lev].periodicity());
@@ -279,22 +216,19 @@ struct AdvectionOp<ICNS, fvm::Godunov>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            for (amrex::MFIter mfi(dof_field(lev),mfi_info); mfi.isValid(); ++mfi)
-            {
+            for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();
+                 ++mfi) {
                 const auto& bx = mfi.tilebox();
-                amrex::FArrayBox tmpfab(amrex::grow(bx, 1), ICNS::ndim * 14 + 1);
+                amrex::FArrayBox tmpfab(
+                    amrex::grow(bx, 1), ICNS::ndim * 14 + 1);
 
-                godunov::compute_advection(lev, bx, ICNS::ndim,
-                                           conv_term(lev).array(mfi),
-                                           dof_field(lev).const_array(mfi),
-                                           u_mac(lev).const_array(mfi),
-                                           v_mac(lev).const_array(mfi),
-                                           w_mac(lev).const_array(mfi),
-                                           src_term(lev).const_array(mfi),
-                                           dof_field.bcrec_device().data(),
-                                           iconserv.data(),
-                                           tmpfab.dataPtr(),
-                                           geom, dt, godunov_ppm);
+                godunov::compute_advection(
+                    lev, bx, ICNS::ndim, conv_term(lev).array(mfi),
+                    dof_field(lev).const_array(mfi),
+                    u_mac(lev).const_array(mfi), v_mac(lev).const_array(mfi),
+                    w_mac(lev).const_array(mfi), src_term(lev).const_array(mfi),
+                    dof_field.bcrec_device().data(), iconserv.data(),
+                    tmpfab.dataPtr(), geom, dt, godunov_ppm);
 
                 amrex::Gpu::streamSynchronize();
             }
@@ -306,35 +240,22 @@ struct AdvectionOp<ICNS, fvm::Godunov>
 
     bool godunov_ppm{true};
     bool godunov_use_forces_in_trans{false};
-
-    int max_coarsen_level;
-    amrex::Real rel_tol;
-    amrex::Real abs_tol;
-
-
-
 };
 
 template<>
 struct AdvectionOp<ICNS, fvm::MOL>
 {
     AdvectionOp(PDEFields& fields_in) : fields(fields_in)
-    {
-        amr_wind::MLMGOptions options("mac_proj");
-
-        max_coarsen_level = options.max_coarsen_level;
-        rel_tol = options.rel_tol;
-        abs_tol = options.abs_tol;
-    }
+    {}
 
     void operator()(const FieldState fstate, const amrex::Real )
     {
 
         auto& repo = fields.repo;
+        auto& geom = repo.mesh().Geom();
         auto& u_mac = repo.get_field("u_mac");
         auto& v_mac = repo.get_field("v_mac");
         auto& w_mac = repo.get_field("w_mac");
-        auto& density = repo.get_field("density", fstate);
 
         auto& conv_term = fields.conv_term.state(fstate);
         auto& dof_field = fields.field.state(fstate);
@@ -344,159 +265,77 @@ struct AdvectionOp<ICNS, fvm::MOL>
         //
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
-
             amrex::Box const& domain = repo.mesh().Geom(lev).Domain();
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            {
-                for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    amrex::Box const& ubx = mfi.nodaltilebox(0);
-                    amrex::Box const& vbx = mfi.nodaltilebox(1);
-                    amrex::Box const& wbx = mfi.nodaltilebox(2);
-                    amrex::Array4<amrex::Real> const& u = u_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real> const& v = v_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real> const& w = w_mac(lev).array(mfi);
-                    amrex::Array4<amrex::Real const> const& vcc = dof_field(lev).const_array(mfi);
+            for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU());
+                 mfi.isValid(); ++mfi) {
+                amrex::Box const& ubx = mfi.nodaltilebox(0);
+                amrex::Box const& vbx = mfi.nodaltilebox(1);
+                amrex::Box const& wbx = mfi.nodaltilebox(2);
+                amrex::Array4<amrex::Real> const& u = u_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real> const& v = v_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real> const& w = w_mac(lev).array(mfi);
+                amrex::Array4<amrex::Real const> const& vcc =
+                    dof_field(lev).const_array(mfi);
 
-                    mol::predict_vels_on_faces(lev,
-                                               ubx, vbx, wbx,
-                                               u, v, w,
-                                               vcc,
-                                               dof_field.bc_type(),
-                                               repo.mesh().Geom());
+                mol::predict_vels_on_faces(
+                    lev, ubx, vbx, wbx, u, v, w, vcc, dof_field.bc_type(),
+                    repo.mesh().Geom());
 
-                    incflo_set_mac_bcs(domain,
-                                       ubx, vbx, wbx,
-                                       u, v, w,
-                                       vcc,
-                                       dof_field.bcrec());
-                }
+                incflo_set_mac_bcs(
+                    domain, ubx, vbx, wbx, u, v, w, vcc, dof_field.bcrec());
             }
         }
 
-
-        //
-        // MAC fixme there is duplication with godunov in mac projection below
-        //
-
-        // This will hold (1/rho) on faces
-        auto rho_xf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::XFACE);
-        auto rho_yf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::YFACE);
-        auto rho_zf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::ZFACE);
-
-        amrex::Vector<amrex::Array<amrex::MultiFab*,ICNS::ndim>> rho_face(repo.num_active_levels());
-        amrex::Vector<amrex::Array<amrex::MultiFab*,ICNS::ndim>> mac_vec(repo.num_active_levels());
-
-        //fixme todo clean this up, this was done to replace GetVecOfArrOfConstPtrs() below
-        amrex::Vector<amrex::Array<amrex::MultiFab const*,ICNS::ndim>> rho_face_const;
-        rho_face_const.reserve(repo.num_active_levels());
-        auto geom = repo.mesh().Geom();
-
-        for (int lev=0; lev < repo.num_active_levels(); ++lev)
-        {
-            rho_face[lev][0] = &(*rho_xf)(lev);
-            rho_face[lev][1] = &(*rho_yf)(lev);
-            rho_face[lev][2] = &(*rho_zf)(lev);
-
-            amrex::average_cellcenter_to_face(rho_face[lev], density(lev), geom[lev]);
-            for (int idim = 0; idim < ICNS::ndim; ++idim) {
-                rho_face[lev][idim]->invert(1.0, 0);
-            }
-
-            rho_face_const.push_back(GetArrOfConstPtrs(rho_face[lev]));
-
-            mac_vec[lev][0] = &u_mac(lev);
-            mac_vec[lev][1] = &v_mac(lev);
-            mac_vec[lev][2] = &w_mac(lev);
-
-        }
-
-
-        // If we want to set max_coarsening_level we have to send it in to the constructor
-        amrex::LPInfo lp_info;
-        lp_info.setMaxCoarseningLevel(max_coarsen_level);
-
-
-        // Perform MAC projection
-        amrex::MacProjector macproj(mac_vec,
-                                    rho_face_const,
-                                    repo.mesh().Geom(0,repo.num_active_levels()-1),
-                                    lp_info);
-
-        // get the bc types from pressure field
-        auto& bctype = repo.get_field("p").bc_type();
-
-        macproj.setDomainBC(mac::get_projection_bc(amrex::Orientation::low, bctype, repo.mesh().Geom()),
-                            mac::get_projection_bc(amrex::Orientation::high, bctype, repo.mesh().Geom()));
-
-        macproj.project(rel_tol,
-                        abs_tol,
-                        amrex::MLMG::Location::FaceCentroid);
-
-
+        advection_mac_project(repo, fstate);
 
         //
         // Advect velocity
         //
 
         int nmaxcomp = AMREX_SPACEDIM;
-
-        for (int lev = 0; lev < repo.num_active_levels(); ++lev)
-        {
+        for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
             amrex::MFItInfo mfi_info;
-            // if (amrex::Gpu::notInLaunchRegion()) mfi_info.EnableTiling(amrex::IntVect(1024,16,16)).SetDynamic(true);
-            if (amrex::Gpu::notInLaunchRegion()) mfi_info.EnableTiling(amrex::IntVect(1024,1024,1024)).SetDynamic(true);
+            // if (amrex::Gpu::notInLaunchRegion())
+            // mfi_info.EnableTiling(amrex::IntVect(1024,16,16)).SetDynamic(true);
+            if (amrex::Gpu::notInLaunchRegion())
+                mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
+                    .SetDynamic(true);
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            for (amrex::MFIter mfi(dof_field(lev),mfi_info); mfi.isValid(); ++mfi)
-            {
-
+            for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();
+                 ++mfi) {
                 amrex::Box const& bx = mfi.tilebox();
 
-                {
-                    amrex::Box tmpbox = amrex::surroundingNodes(bx);
-                    const int tmpcomp = nmaxcomp*AMREX_SPACEDIM;
+                amrex::Box tmpbox = amrex::surroundingNodes(bx);
+                const int tmpcomp = nmaxcomp * AMREX_SPACEDIM;
 
-                    amrex::FArrayBox tmpfab(tmpbox, tmpcomp);
-                    amrex::Elixir eli = tmpfab.elixir();
+                amrex::FArrayBox tmpfab(tmpbox, tmpcomp);
+                amrex::Elixir eli = tmpfab.elixir();
 
-                    amrex::Array4<amrex::Real> fx = tmpfab.array(nmaxcomp*0);
-                    amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp*1);
-                    amrex::Array4<amrex::Real> fz = tmpfab.array(nmaxcomp*2);
+                amrex::Array4<amrex::Real> fx = tmpfab.array(nmaxcomp * 0);
+                amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp * 1);
+                amrex::Array4<amrex::Real> fz = tmpfab.array(nmaxcomp * 2);
 
-                    mol::compute_convective_fluxes(lev, bx, AMREX_SPACEDIM,
-                                                   fx, fy, fz,
-                                                   dof_field(lev).const_array(mfi),
-                                                   u_mac(lev).const_array(mfi),
-                                                   v_mac(lev).const_array(mfi),
-                                                   w_mac(lev).const_array(mfi),
-                                                   dof_field.bcrec().data(),
-                                                   dof_field.bcrec_device().data(),geom);
+                mol::compute_convective_fluxes(
+                    lev, bx, AMREX_SPACEDIM, fx, fy, fz,
+                    dof_field(lev).const_array(mfi),
+                    u_mac(lev).const_array(mfi), v_mac(lev).const_array(mfi),
+                    w_mac(lev).const_array(mfi), dof_field.bcrec().data(),
+                    dof_field.bcrec_device().data(), geom);
 
-                    mol::compute_convective_rate(bx, AMREX_SPACEDIM,
-                                                 conv_term(lev).array(mfi),
-                                                 fx, fy, fz,
-                                                 geom[lev].InvCellSizeArray());
-
-
-                }
-
+                mol::compute_convective_rate(
+                    bx, AMREX_SPACEDIM, conv_term(lev).array(mfi), fx, fy, fz,
+                    geom[lev].InvCellSizeArray());
             }
         }
-
-
     }
 
     PDEFields& fields;
-
-    int max_coarsen_level;
-    amrex::Real rel_tol;
-    amrex::Real abs_tol;
-
 };
 
 }

--- a/src/equation_systems/icns/icns_ops.cpp
+++ b/src/equation_systems/icns/icns_ops.cpp
@@ -1,0 +1,77 @@
+#include "icns_ops.H"
+#include "incflo_MAC_bcs.H"
+#include "AMReX_MacProjector.H"
+#include "mac_projection.H"
+#include "MLMGOptions.H"
+
+namespace amr_wind {
+namespace pde {
+
+void advection_mac_project(FieldRepo& repo, const FieldState fstate)
+{
+    auto& geom = repo.mesh().Geom();
+    auto& u_mac = repo.get_field("u_mac");
+    auto& v_mac = repo.get_field("v_mac");
+    auto& w_mac = repo.get_field("w_mac");
+    auto& density = repo.get_field("density", fstate);
+
+    // This will hold (1/rho) on faces
+    auto rho_xf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::XFACE);
+    auto rho_yf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::YFACE);
+    auto rho_zf = repo.create_scratch_field(1, 0, amr_wind::FieldLoc::ZFACE);
+
+    amrex::Vector<amrex::Array<amrex::MultiFab*, ICNS::ndim>> rho_face(
+        repo.num_active_levels());
+    amrex::Vector<amrex::Array<amrex::MultiFab*, ICNS::ndim>> mac_vec(
+        repo.num_active_levels());
+
+    // fixme todo clean this up, this was done to replace
+    // GetVecOfArrOfConstPtrs() below
+    amrex::Vector<amrex::Array<amrex::MultiFab const*, ICNS::ndim>>
+        rho_face_const;
+    rho_face_const.reserve(repo.num_active_levels());
+
+    for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
+        rho_face[lev][0] = &(*rho_xf)(lev);
+        rho_face[lev][1] = &(*rho_yf)(lev);
+        rho_face[lev][2] = &(*rho_zf)(lev);
+
+        amrex::average_cellcenter_to_face(
+            rho_face[lev], density(lev), geom[lev]);
+        for (int idim = 0; idim < ICNS::ndim; ++idim) {
+            rho_face[lev][idim]->invert(1.0, 0);
+        }
+
+        rho_face_const.push_back(GetArrOfConstPtrs(rho_face[lev]));
+
+        mac_vec[lev][0] = &u_mac(lev);
+        mac_vec[lev][1] = &v_mac(lev);
+        mac_vec[lev][2] = &w_mac(lev);
+    }
+
+    amr_wind::MLMGOptions options("mac_proj");
+
+    // If we want to set max_coarsening_level we have to send it in to the
+    // constructor
+    amrex::LPInfo lp_info;
+    lp_info.setMaxCoarseningLevel(options.max_coarsen_level);
+
+    // Perform MAC projection
+    amrex::MacProjector macproj(
+        mac_vec, rho_face_const,
+        repo.mesh().Geom(0, repo.num_active_levels() - 1), lp_info);
+
+    // get the bc types from pressure field
+    auto& bctype = repo.get_field("p").bc_type();
+
+    macproj.setDomainBC(
+        mac::get_projection_bc(
+            amrex::Orientation::low, bctype, repo.mesh().Geom()),
+        mac::get_projection_bc(
+            amrex::Orientation::high, bctype, repo.mesh().Geom()));
+
+    macproj.project(options.rel_tol, options.abs_tol, amrex::MLMG::Location::FaceCentroid);
+}
+
+} // namespace pde
+} // namespace amr_wind

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -162,18 +162,6 @@ void incflo::ApplyPredictor (bool incremental_projection)
     auto& conv_density = m_repo.get_field("density_conv_term", pred_state);
     auto& conv_tracer = m_repo.get_field("temperature_conv_term", pred_state);
 
-    auto& u_mac = m_repo.get_field("u_mac");
-    auto& v_mac = m_repo.get_field("v_mac");
-    auto& w_mac = m_repo.get_field("w_mac");
-
-    if (nghost_mac() > 0) {
-        for (int lev = 0; lev <= finest_level; ++lev) {
-            u_mac(lev).setBndry(0.0);
-            v_mac(lev).setBndry(0.0);
-            w_mac(lev).setBndry(0.0);
-        }
-    }
-
     // Ensure that density and tracer exists at half time
     auto& density_nph = density_new.create_state(amr_wind::FieldState::NPH);
     auto& tracer_nph = tracer_new.create_state(amr_wind::FieldState::NPH);

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -156,11 +156,6 @@ void incflo::ApplyPredictor (bool incremental_projection)
                        : icns_fields.diff_term.state(amr_wind::FieldState::Old);
     auto pred_state = m_use_godunov ? amr_wind::FieldState::New : amr_wind::FieldState::Old;
     auto& laps = m_repo.get_field("temperature_diff_term", pred_state);
-    auto& conv_velocity =
-        m_use_godunov ? icns_fields.conv_term
-                      : icns_fields.conv_term.state(amr_wind::FieldState::Old);
-    auto& conv_density = m_repo.get_field("density_conv_term", pred_state);
-    auto& conv_tracer = m_repo.get_field("temperature_conv_term", pred_state);
 
     // Ensure that density and tracer exists at half time
     auto& density_nph = density_new.create_state(amr_wind::FieldState::NPH);
@@ -254,9 +249,10 @@ void incflo::ApplyPredictor (bool incremental_projection)
     {
         amr_wind::field_ops::copy(density_nph, density_old, 0, 0, 1, 1);
     }
+#if 0
     else
     {
-
+        auto& conv_density = m_repo.get_field("density_conv_term", pred_state);
         for (int lev = 0; lev <= finest_level; lev++)
         {
 
@@ -280,6 +276,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
         } // lev
 
     } // not constant density
+#endif
 
     // *************************************************************************************
     // Compute (or if Godunov, re-compute) the tracer forcing terms (forcing for (rho s), not for s)
@@ -291,6 +288,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // *************************************************************************************
     // Update the tracer next
     // *************************************************************************************
+#if 0
     int l_ntrac = (m_advect_tracer) ? m_ntrac : 0;
 
     if (m_advect_tracer)
@@ -357,6 +355,10 @@ void incflo::ApplyPredictor (bool incremental_projection)
             } // mfi
         } // lev
     } // if (m_advect_tracer)
+#endif
+
+    for (auto& eqn: m_scalar_eqns)
+        eqn->compute_predictor_rhs(m_diff_type);
 
     // *************************************************************************************
     // Solve diffusion equation for tracer
@@ -396,6 +398,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // *************************************************************************************
     // Update the velocity
     // *************************************************************************************
+#if 0
     for (int lev = 0; lev <= finest_level; lev++)
     {
 
@@ -441,6 +444,8 @@ void incflo::ApplyPredictor (bool incremental_projection)
             }
         } // mfi
     } // lev
+#endif
+    m_icns->compute_predictor_rhs(m_diff_type);
 
     // *************************************************************************************
     // Solve diffusion equation for u* but using eta_old at old time

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -12,9 +12,17 @@ void incflo::declare_fields()
                                    : amr_wind::fvm::MOL::scheme_name();
     m_icns = amr_wind::pde::PDEBase::create(
         "ICNS-" + scheme, m_time, m_repo, m_probtype);
-    if (!m_constant_density)
+
+    // Register density first so that we can compute its `n+1/2` state before
+    // other scalars attempt to use it in their computations.
+    if (!m_constant_density) {
+        if (m_scalar_eqns.size() > 0)
+            amrex::Abort(
+                "For non-constant density, it must be the first equation "
+                "registered for the scalar equations");
         m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
             "Density-" + scheme, m_time, m_repo, m_probtype));
+    }
 
     m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
         "Temperature-" + scheme, m_time, m_repo, m_probtype));

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -12,10 +12,12 @@ void incflo::declare_fields()
                                    : amr_wind::fvm::MOL::scheme_name();
     m_icns = amr_wind::pde::PDEBase::create(
         "ICNS-" + scheme, m_time, m_repo, m_probtype);
+    if (!m_constant_density)
+        m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
+            "Density-" + scheme, m_time, m_repo, m_probtype));
+
     m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
         "Temperature-" + scheme, m_time, m_repo, m_probtype));
-    m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
-        "Density-" + scheme, m_time, m_repo, m_probtype));
 }
 
 void incflo::init_field_bcs ()


### PR DESCRIPTION
- Refactor MAC projection code to eliminate duplication in Godunov/MOL advection operators

- Create an RHS computation operator to deal with update (for explicit) and RHS terms for implicit/Crank-Nicolson, update Predictor/Corrector with the new functions

- Convert calls to `tracer` update with loops of scalar equations. 