### PR TITLE
MOL ext_dir bug fix

### DIFF
--- a/src/convection/MOL.H
+++ b/src/convection/MOL.H
@@ -19,7 +19,8 @@ void predict_vels_on_faces(
     amrex::Array4<amrex::Real> const& v,
     amrex::Array4<amrex::Real> const& w,
     amrex::Array4<amrex::Real const> const& vcc,
-    amrex::GpuArray<BC, AMREX_SPACEDIM*2> bctype,
+    amrex::Vector<amrex::BCRec> const& h_bcrec,
+    amrex::BCRec const* d_bcrec,
     amrex::Vector<amrex::Geometry> geom);
 
 

--- a/src/convection/incflo_godunov_plm.cpp
+++ b/src/convection/incflo_godunov_plm.cpp
@@ -1,19 +1,8 @@
 #include <incflo_convection_K.H>
 #include "Godunov.H"
+#include "bc_ops.H"
 
 using namespace amrex;
-
-namespace {
-std::pair<bool, bool> has_extdir(BCRec const* bcrec, int ncomp, int dir)
-{
-    std::pair<bool, bool> r{false, false};
-    for (int n = 0; n < ncomp; ++n) {
-        r.first = r.first or bcrec[n].lo(dir) == BCType::ext_dir;
-        r.second = r.second or bcrec[n].hi(dir) == BCType::ext_dir;
-    }
-    return r;
-}
-} // namespace
 
 void godunov::predict_plm_x(
     int lev,
@@ -40,8 +29,8 @@ void godunov::predict_plm_x(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi =
-        has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
+    auto extdir_lohi = amr_wind::utils::has_extdir(
+        h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
 
@@ -122,8 +111,8 @@ void godunov::predict_plm_y(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi =
-        has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
+    auto extdir_lohi = amr_wind::utils::has_extdir(
+        h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
 
@@ -205,8 +194,8 @@ void godunov::predict_plm_z(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi =
-        has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
+    auto extdir_lohi = amr_wind::utils::has_extdir(
+        h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
 

--- a/src/convection/incflo_mol_fluxes.cpp
+++ b/src/convection/incflo_mol_fluxes.cpp
@@ -1,7 +1,7 @@
-#include <AMReX_BCRec.H>
 #include <AMReX_Geometry.H>
 #include "incflo_convection_K.H"
 #include "MOL.H"
+#include "bc_ops.H"
 
 using namespace amrex;
 
@@ -20,18 +20,6 @@ void mol::compute_convective_rate (Box const& bx, int ncomp,
             +           dxinv[1] * (fy(i,j,k,n) - fy(i,j+1,k,n))
             +           dxinv[2] * (fz(i,j,k,n) - fz(i,j,k+1,n));
     });
-}
-
-namespace {
-    std::pair<bool,bool> has_extdir (BCRec const* bcrec, int ncomp, int dir)
-    {
-        std::pair<bool,bool> r{false,false};
-        for (int n = 0; n < ncomp; ++n) {
-            r.first = r.first or bcrec[n].lo(dir) == BCType::ext_dir;
-            r.second = r.second or bcrec[n].hi(dir) == BCType::ext_dir;
-        }
-        return r;
-    }
 }
 
 void
@@ -61,7 +49,7 @@ mol::compute_convective_fluxes (int lev, Box const& bx, int ncomp,
     Box const& zbx = amrex::surroundingNodes(bx,2);
 
     // At an ext_dir boundary, the boundary value is on the face, not cell center.
-    auto extdir_lohi = has_extdir(h_bcrec, ncomp, static_cast<int>(Direction::x));
+    auto extdir_lohi = amr_wind::utils::has_extdir(h_bcrec, ncomp, static_cast<int>(Direction::x));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
     if ((has_extdir_lo and domain_ilo >= xbx.smallEnd(0)-1) or
@@ -112,7 +100,7 @@ mol::compute_convective_fluxes (int lev, Box const& bx, int ncomp,
         });
     }
 
-    extdir_lohi = has_extdir(h_bcrec, ncomp,  static_cast<int>(Direction::y));
+    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec, ncomp,  static_cast<int>(Direction::y));
     has_extdir_lo = extdir_lohi.first;
     has_extdir_hi = extdir_lohi.second;
     if ((has_extdir_lo and domain_jlo >= ybx.smallEnd(1)-1) or
@@ -163,7 +151,7 @@ mol::compute_convective_fluxes (int lev, Box const& bx, int ncomp,
         });
     }
 
-    extdir_lohi = has_extdir(h_bcrec, ncomp, static_cast<int>(Direction::z));
+    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec, ncomp, static_cast<int>(Direction::z));
     has_extdir_lo = extdir_lohi.first;
     has_extdir_hi = extdir_lohi.second;
     if ((has_extdir_lo and domain_klo >= zbx.smallEnd(2)-1) or

--- a/src/convection/incflo_mol_predict.cpp
+++ b/src/convection/incflo_mol_predict.cpp
@@ -2,6 +2,7 @@
 #include <incflo_convection_K.H>
 #include <incflo_MAC_bcs.H>
 #include "MOL.H"
+#include "bc_ops.H"
 
 using namespace amrex;
 
@@ -9,10 +10,14 @@ using namespace amrex;
 void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box const& wbx,
                                  Array4<Real> const& u, Array4<Real> const& v, Array4<Real> const& w,
                                  Array4<Real const> const& vcc,
-                                 amrex::GpuArray<BC, AMREX_SPACEDIM*2> bctype,
+                                 Vector<BCRec> const& h_bcrec,
+                                 BCRec const* d_bcrec,
                                  Vector<Geometry> geom)
 {
     constexpr Real small_vel = 1.e-10;
+
+    const int ncomp = AMREX_SPACEDIM; // This is only used because h_bcrec and d_bcrec hold the
+                                      // bc's for all three velocity components
 
     const Box& domain_box = geom[lev].Domain();
     const int domain_ilo = domain_box.smallEnd(0);
@@ -22,29 +27,21 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
     const int domain_klo = domain_box.smallEnd(2);
     const int domain_khi = domain_box.bigEnd(2);
 
-    auto const bc_ilo = bctype[Orientation(Direction::x,Orientation::low)];
-    auto const bc_ihi = bctype[Orientation(Direction::x,Orientation::high)];
-    auto const bc_jlo = bctype[Orientation(Direction::y,Orientation::low)];
-    auto const bc_jhi = bctype[Orientation(Direction::y,Orientation::high)];
-    auto const bc_klo = bctype[Orientation(Direction::z,Orientation::low)];
-    auto const bc_khi = bctype[Orientation(Direction::z,Orientation::high)];
-
-    //fixme I think this should be using ext_dir directly look at how ppm does this
-    bool extdir_ilo = (bc_ilo == BC::mass_inflow) or (bc_ilo == BC::no_slip_wall);
-    bool extdir_ihi = (bc_ihi == BC::mass_inflow) or (bc_ihi == BC::no_slip_wall);
-    bool extdir_jlo = (bc_jlo == BC::mass_inflow) or (bc_jlo == BC::no_slip_wall);
-    bool extdir_jhi = (bc_jhi == BC::mass_inflow) or (bc_jhi == BC::no_slip_wall);
-    bool extdir_klo = (bc_klo == BC::mass_inflow) or (bc_klo == BC::no_slip_wall);
-    bool extdir_khi = (bc_khi == BC::mass_inflow) or (bc_khi == BC::no_slip_wall);
-
     // At an ext_dir boundary, the boundary value is on the face, not cell center.
 
-    if ((extdir_ilo and domain_ilo >= ubx.smallEnd(0)-1) or
-        (extdir_ihi and domain_ihi <= ubx.bigEnd(0)))
+    auto extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
+    bool has_extdir_lo = extdir_lohi.first;
+    bool has_extdir_hi = extdir_lohi.second;
+
+    if ((has_extdir_lo and domain_ilo >= ubx.smallEnd(0)-1) or
+        (has_extdir_hi and domain_ihi <= ubx.bigEnd(0)))
     {
-        amrex::ParallelFor(ubx, [vcc,extdir_ilo,extdir_ihi,domain_ilo,domain_ihi,u]
+        amrex::ParallelFor(ubx, [vcc,domain_ilo,domain_ihi,u,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
+            bool extdir_ilo = d_bcrec[0].lo(0) == BCType::ext_dir;
+            bool extdir_ihi = d_bcrec[0].hi(0) == BCType::ext_dir;
+
             Real upls = vcc(i,j,k,0) - 0.5 * incflo_xslope_extdir
                 (i,j,k,0,vcc, extdir_ilo, extdir_ihi, domain_ilo, domain_ihi);
             Real umns = vcc(i-1,j,k,0) + 0.5 * incflo_xslope_extdir
@@ -91,12 +88,19 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         });
     }
 
-    if ((extdir_jlo and domain_jlo >= vbx.smallEnd(1)-1) or
-        (extdir_jhi and domain_jhi <= vbx.bigEnd(1)))
+    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
+    has_extdir_lo = extdir_lohi.first;
+    has_extdir_hi = extdir_lohi.second;
+
+    if ((has_extdir_lo and domain_jlo >= vbx.smallEnd(1)-1) or
+        (has_extdir_hi and domain_jhi <= vbx.bigEnd(1)))
     {
-        amrex::ParallelFor(vbx, [vcc,extdir_jlo,extdir_jhi,domain_jlo,domain_jhi,v]
+        amrex::ParallelFor(vbx, [vcc,domain_jlo,domain_jhi,v,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
+            bool extdir_jlo = d_bcrec[1].lo(1) == BCType::ext_dir;
+            bool extdir_jhi = d_bcrec[1].hi(1) == BCType::ext_dir;
+
             Real vpls = vcc(i,j,k,1) - 0.5 * incflo_yslope_extdir
                 (i,j,k,1,vcc, extdir_jlo, extdir_jhi, domain_jlo, domain_jhi);
             Real vmns = vcc(i,j-1,k,1) + 0.5 * incflo_yslope_extdir
@@ -143,12 +147,19 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         });
     }
 
-    if ((extdir_klo and domain_klo >= wbx.smallEnd(2)-1) or
-        (extdir_khi and domain_khi <= wbx.bigEnd(2)))
+    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
+    has_extdir_lo = extdir_lohi.first;
+    has_extdir_hi = extdir_lohi.second;
+
+    if ((has_extdir_lo and domain_klo >= wbx.smallEnd(2)-1) or
+        (has_extdir_hi and domain_khi <= wbx.bigEnd(2)))
     {
-        amrex::ParallelFor(wbx, [vcc,extdir_klo,extdir_khi,domain_klo,domain_khi,w]
+        amrex::ParallelFor(wbx, [vcc,domain_klo,domain_khi,w,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
+            bool extdir_klo = d_bcrec[2].lo(2) == BCType::ext_dir;
+            bool extdir_khi = d_bcrec[2].hi(2) == BCType::ext_dir;
+
             Real wpls = vcc(i,j,k,2) - 0.5 * incflo_zslope_extdir
                 (i,j,k,2,vcc, extdir_klo, extdir_khi, domain_klo, domain_khi);
             Real wmns = vcc(i,j,k-1,2) + 0.5 * incflo_zslope_extdir(

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -371,7 +371,8 @@ struct AdvectionOp<ICNS, fvm::MOL>
                                                ubx, vbx, wbx,
                                                u, v, w,
                                                vcc,
-                                               dof_field.bc_type(),
+                                               dof_field.bcrec(),
+                                               dof_field.bcrec_device().data(),
                                                repo.mesh().Geom());
 
                     incflo_set_mac_bcs(domain,

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${amr_wind_lib_name}
       incflo_build_info.cpp
       io.cpp
       PlaneAveraging.cpp
+      bc_ops.cpp
    )
 
 target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/utilities/Make.package
+++ b/src/utilities/Make.package
@@ -2,4 +2,6 @@ CEXE_sources += diagnostics.cpp
 CEXE_sources += incflo_build_info.cpp
 CEXE_sources += io.cpp
 CEXE_sources += PlaneAveraging.cpp
+CEXE_sources += bc_ops.cpp
+CEXE_headers += bc_ops.H
 CEXE_headers += PlaneAveraging.H

--- a/src/utilities/bc_ops.H
+++ b/src/utilities/bc_ops.H
@@ -1,0 +1,21 @@
+#ifndef BC_OPS_H
+#define BC_OPS_H
+
+/** \file bc_ops.H
+ *
+ *  Boundary condition utilities
+ */
+
+#include <AMReX_BCRec.H>
+
+namespace amr_wind {
+namespace utils {
+
+//! Return a pair of bools,
+//! value is true if at least one boundary has an ext_dir specified
+std::pair<bool, bool> has_extdir(amrex::BCRec const* bcrec, int ncomp, int dir);
+
+} // namespace utils
+} // namespace amr_wind
+
+#endif /* BC_OPS_H */

--- a/src/utilities/bc_ops.cpp
+++ b/src/utilities/bc_ops.cpp
@@ -1,0 +1,12 @@
+#include "bc_ops.H"
+
+std::pair<bool, bool>
+amr_wind::utils::has_extdir(amrex::BCRec const* bcrec, int ncomp, int dir)
+{
+    std::pair<bool, bool> r{false, false};
+    for (int n = 0; n < ncomp; ++n) {
+        r.first = r.first or bcrec[n].lo(dir) == amrex::BCType::ext_dir;
+        r.second = r.second or bcrec[n].hi(dir) == amrex::BCType::ext_dir;
+    }
+    return r;
+}


### PR DESCRIPTION
- manual merge from incflo (thanks Ann!)
- moved has_extdir to its own file
- this will cause diffs in regression tests that use MOL and have an extdir bc: abl_mol, boussinesq_bubble_mol, rayleigh_taylor_mol, abl_mol_explicit, abl_mol_cn
