### PR TITLE
Introduce Turbulence model and Transport model interface

### DIFF
--- a/make.incflo
+++ b/make.incflo
@@ -34,6 +34,9 @@ Bdirs += $(INCFLO_HOME)src/equation_systems
 Bdirs += $(INCFLO_HOME)src/equation_systems/icns
 Bdirs += $(INCFLO_HOME)src/equation_systems/temperature
 Bdirs += $(INCFLO_HOME)src/equation_systems/density
+Bdirs += $(INCFLO_HOME)src/turbulence
+Bdirs += $(INCFLO_HOME)src/turbulence/LES
+Bdirs += $(INCFLO_HOME)src/transport
 
 Bpack += $(foreach dir, $(Bdirs), $(TOP)/$(dir)/Make.package)
 Blocs += $(foreach dir, $(Bdirs), $(TOP)/$(dir))

--- a/make.incflo
+++ b/make.incflo
@@ -36,7 +36,7 @@ Bdirs += $(INCFLO_HOME)src/equation_systems/temperature
 Bdirs += $(INCFLO_HOME)src/equation_systems/density
 Bdirs += $(INCFLO_HOME)src/turbulence
 Bdirs += $(INCFLO_HOME)src/turbulence/LES
-Bdirs += $(INCFLO_HOME)src/transport
+Bdirs += $(INCFLO_HOME)src/transport_models
 
 Bpack += $(foreach dir, $(Bdirs), $(TOP)/$(dir)/Make.package)
 Blocs += $(foreach dir, $(Bdirs), $(TOP)/$(dir))

--- a/src/CFDSim.H
+++ b/src/CFDSim.H
@@ -1,0 +1,46 @@
+#ifndef CFDSIM_H
+#define CFDSIM_H
+
+#include "AMReX_AmrCore.H"
+#include "SimTime.H"
+#include "FieldRepo.H"
+#include "PDE.H"
+
+namespace amr_wind {
+
+/** Data structures for a CFD simulation
+ *
+ *  CFDSim is a thin wrapper that holds all the necessary objects for a CFD
+ *  simulation. The key data members within this object are:
+ *
+ *  - mesh (amrex::AmrCore) The AMR mesh hierarchy data structure
+ *  - time (SimTime)        The time object
+ *  - repo (FieldRepo)      The field repository
+ */
+class CFDSim
+{
+public:
+    CFDSim(amrex::AmrCore& mesh) : m_mesh(mesh), m_time(), m_repo(m_mesh) {}
+
+    ~CFDSim() = default;
+
+    amrex::AmrCore& mesh() { return m_mesh; }
+    const amrex::AmrCore& mesh() const { return m_mesh; }
+
+    SimTime& time() { return m_time; }
+    const SimTime& time() const { return m_time; }
+
+    FieldRepo& repo() { return m_repo; }
+    const FieldRepo& repo() const { return m_repo; }
+
+private:
+    amrex::AmrCore& m_mesh;
+
+    SimTime m_time;
+
+    FieldRepo m_repo;
+};
+
+}
+
+#endif /* CFDSIM_H */

--- a/src/CFDSim.H
+++ b/src/CFDSim.H
@@ -16,11 +16,14 @@ namespace amr_wind {
  *  - mesh (amrex::AmrCore) The AMR mesh hierarchy data structure
  *  - time (SimTime)        The time object
  *  - repo (FieldRepo)      The field repository
+ *  - pde_manager (PDEMgr)  PDE manager interface
  */
 class CFDSim
 {
 public:
-    CFDSim(amrex::AmrCore& mesh) : m_mesh(mesh), m_time(), m_repo(m_mesh) {}
+    CFDSim(amrex::AmrCore& mesh)
+        : m_mesh(mesh), m_time(), m_repo(m_mesh), m_pde_mgr(*this)
+    {}
 
     ~CFDSim() = default;
 
@@ -36,12 +39,17 @@ public:
     FieldRepo& repo() { return m_repo; }
     const FieldRepo& repo() const { return m_repo; }
 
+    pde::PDEMgr& pde_manager() { return m_pde_mgr; }
+    const pde::PDEMgr& pde_manager() const { return m_pde_mgr; }
+
 private:
     amrex::AmrCore& m_mesh;
 
     SimTime m_time;
 
     FieldRepo m_repo;
+
+    pde::PDEMgr m_pde_mgr;
 };
 
 }

--- a/src/CFDSim.H
+++ b/src/CFDSim.H
@@ -7,6 +7,9 @@
 #include "PDEBase.H"
 
 namespace amr_wind {
+namespace turbulence {
+class TurbulenceModel;
+}
 
 /** Data structures for a CFD simulation
  *
@@ -21,11 +24,9 @@ namespace amr_wind {
 class CFDSim
 {
 public:
-    CFDSim(amrex::AmrCore& mesh)
-        : m_mesh(mesh), m_time(), m_repo(m_mesh), m_pde_mgr(*this)
-    {}
+    CFDSim(amrex::AmrCore& mesh);
 
-    ~CFDSim() = default;
+    ~CFDSim();
 
     //! Return the AMR mesh hierarchy
     amrex::AmrCore& mesh() { return m_mesh; }
@@ -42,6 +43,12 @@ public:
     pde::PDEMgr& pde_manager() { return m_pde_mgr; }
     const pde::PDEMgr& pde_manager() const { return m_pde_mgr; }
 
+    turbulence::TurbulenceModel& turbulence_model() { return *m_turbulence; }
+    const turbulence::TurbulenceModel& turbulence_model() const
+    { return *m_turbulence; }
+
+    void create_turbulence_model();
+
 private:
     amrex::AmrCore& m_mesh;
 
@@ -50,6 +57,8 @@ private:
     FieldRepo m_repo;
 
     pde::PDEMgr m_pde_mgr;
+
+    std::unique_ptr<turbulence::TurbulenceModel> m_turbulence;
 };
 
 }

--- a/src/CFDSim.H
+++ b/src/CFDSim.H
@@ -4,7 +4,7 @@
 #include "AMReX_AmrCore.H"
 #include "SimTime.H"
 #include "FieldRepo.H"
-#include "PDE.H"
+#include "PDEBase.H"
 
 namespace amr_wind {
 
@@ -24,12 +24,15 @@ public:
 
     ~CFDSim() = default;
 
+    //! Return the AMR mesh hierarchy
     amrex::AmrCore& mesh() { return m_mesh; }
     const amrex::AmrCore& mesh() const { return m_mesh; }
 
+    //! Return simulation time control
     SimTime& time() { return m_time; }
     const SimTime& time() const { return m_time; }
 
+    //! Return the field repository
     FieldRepo& repo() { return m_repo; }
     const FieldRepo& repo() const { return m_repo; }
 

--- a/src/CFDSim.cpp
+++ b/src/CFDSim.cpp
@@ -1,0 +1,31 @@
+#include "CFDSim.H"
+#include "TurbulenceModel.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+
+CFDSim::CFDSim(amrex::AmrCore& mesh)
+    : m_mesh(mesh), m_time(), m_repo(m_mesh), m_pde_mgr(*this)
+{}
+
+CFDSim::~CFDSim() = default;
+
+void CFDSim::create_turbulence_model()
+{
+    std::string transport_model = "ConstTransport";
+    std::string turbulence_model = "Laminar";
+    {
+        amrex::ParmParse pp("transport");
+        pp.query("model", transport_model);
+    }
+    {
+        amrex::ParmParse pp("turbulence");
+        pp.query("model", turbulence_model);
+    }
+
+    const std::string identifier = turbulence_model + "-" + transport_model;
+    m_turbulence = turbulence::TurbulenceModel::create(identifier, *this);
+}
+
+} // namespace amr_wind

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${amr_wind_lib_name}
   incflo_regrid.cpp
   incflo_compute_forces.cpp
   incflo_field_repo.cpp
+
+  CFDSim.cpp
   )
 
 target_sources(${amr_wind_exe_name} PRIVATE main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,8 @@ add_subdirectory(utilities)
 add_subdirectory(prob)
 add_subdirectory(wind_energy)
 add_subdirectory(equation_systems)
+add_subdirectory(transport_models)
+add_subdirectory(turbulence)
 
 include(AMReXBuildInfo)
 generate_buildinfo(${amr_wind_lib_name} ${AMREX_SUBMOD_LOCATION})

--- a/src/Make.package
+++ b/src/Make.package
@@ -5,4 +5,4 @@ CEXE_sources += incflo_compute_forces.cpp
 CEXE_sources += incflo_tagging.cpp
 CEXE_sources += incflo_regrid.cpp
 CEXE_sources += main.cpp
-CEXE_sources += incflo_field_repo.cpp
+CEXE_sources += incflo_field_repo.cpp CFDSim.cpp

--- a/src/core/CollMgr.H
+++ b/src/core/CollMgr.H
@@ -1,0 +1,59 @@
+#ifndef COLLMGR_H
+#define COLLMGR_H
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include "AMReX_Vector.H"
+
+namespace amr_wind {
+
+template<typename Collection, typename Type>
+class CollMgr
+{
+public:
+    using TypePtr = std::unique_ptr<Type>;
+    using TypeVector = amrex::Vector<TypePtr>;
+
+    CollMgr() = default;
+
+    ~CollMgr() = default;
+
+    template<class ... Args>
+    Type& create(const std::string& key, Args ... args)
+    {
+        m_obj_vec.emplace_back(
+            Type::create(key, std::forward<Args>(args)...));
+        m_obj_map[key] = m_obj_vec.size();
+
+        return *m_obj_vec.back();
+    }
+
+    TypeVector& objects() { return m_obj_vec; }
+
+    bool contains(const std::string& key) const
+    {
+        auto it = m_obj_map.find(key);
+        return (it != m_obj_map.end());
+    }
+
+    Type& operator()(const std::string& key)
+    {
+        return *m_obj_vec[m_obj_map.at(key)];
+    }
+
+    template<typename T>
+    T& operator()(const std::string& key)
+    {
+        return dynamic_cast<T&>(operator()(key));
+    }
+
+protected:
+    TypeVector m_obj_vec;
+
+    std::unordered_map<std::string, int> m_obj_map;
+};
+
+}
+
+#endif /* COLLMGR_H */

--- a/src/core/CollMgr.H
+++ b/src/core/CollMgr.H
@@ -8,6 +8,11 @@
 
 namespace amr_wind {
 
+/** Interface to manage objects of sub-classes based on factory registration
+ *
+ *  Provides boiler-plate code to register a collection and then query using
+ *  lookup keywords
+ */
 template<typename Collection, typename Type>
 class CollMgr
 {
@@ -19,8 +24,10 @@ public:
 
     ~CollMgr() = default;
 
+    /** Create a new object and register it in the vector and setup lookup options
+     */
     template<class ... Args>
-    Type& create(const std::string& key, Args ... args)
+    Type& create(const std::string& key, Args&& ... args)
     {
         m_obj_vec.emplace_back(
             Type::create(key, std::forward<Args>(args)...));
@@ -29,19 +36,23 @@ public:
         return *m_obj_vec.back();
     }
 
+    //! Return a vector of the registered objects
     TypeVector& objects() { return m_obj_vec; }
 
+    //! Query if an object exists using the lookup key
     bool contains(const std::string& key) const
     {
         auto it = m_obj_map.find(key);
         return (it != m_obj_map.end());
     }
 
+    //! Return the object corresponding to a lookup key
     Type& operator()(const std::string& key)
     {
         return *m_obj_vec[m_obj_map.at(key)];
     }
 
+    //! Return object for a lookup key cast into its exact class definition
     template<typename T>
     T& operator()(const std::string& key)
     {
@@ -49,8 +60,10 @@ public:
     }
 
 protected:
+    //! Collection of objects registered so far
     TypeVector m_obj_vec;
 
+    //! Key word based lookup
     std::unordered_map<std::string, int> m_obj_map;
 };
 

--- a/src/diffusion/incflo_diffusion.cpp
+++ b/src/diffusion/incflo_diffusion.cpp
@@ -114,7 +114,7 @@ void wall_model_bc(
 {
     auto& repo = velocity.repo();
     auto& density = repo.get_field("density", fstate);
-    auto& viscosity = repo.get_field("velocity_nueff");
+    auto& viscosity = repo.get_field("velocity_mueff");
     const int nlevels = repo.num_active_levels();
 
     // Wall model hard coded to be only in the zlo direction

--- a/src/equation_systems/CMakeLists.txt
+++ b/src/equation_systems/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${amr_wind_lib_name} PRIVATE
+  PDEBase.cpp
   DiffusionOps.cpp
   )
 

--- a/src/equation_systems/DiffusionOps.H
+++ b/src/equation_systems/DiffusionOps.H
@@ -41,7 +41,7 @@ protected:
             std::is_same<L, amrex::MLTensorOp>::value>::type* = 0)
     {
         const int nlevels = m_pdefields.repo.num_active_levels();
-        auto& viscosity = m_pdefields.nueff;
+        auto& viscosity = m_pdefields.mueff;
         auto& geom = m_pdefields.repo.mesh().Geom();
         for (int lev = 0; lev < nlevels; ++lev) {
             auto b = diffusion::average_velocity_eta_to_faces(
@@ -57,7 +57,7 @@ protected:
             std::is_same<L, amrex::MLABecLaplacian>::value>::type* = 0)
     {
         const int nlevels = m_pdefields.repo.num_active_levels();
-        auto& viscosity = m_pdefields.nueff;
+        auto& viscosity = m_pdefields.mueff;
         auto& geom = m_pdefields.repo.mesh().Geom();
         for (int lev = 0; lev < nlevels; ++lev) {
             auto b = diffusion::average_velocity_eta_to_faces(

--- a/src/equation_systems/Make.package
+++ b/src/equation_systems/Make.package
@@ -4,4 +4,4 @@ CEXE_headers += PDEOps.H
 CEXE_headers += PDETraits.H
 CEXE_headers += SchemeTraits.H
 CEXE_headers += SourceTerm.H
-CEXE_sources += DiffusionOps.cpp
+CEXE_sources += DiffusionOps.cpp PDEBase.cpp

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -65,7 +65,7 @@ public:
         m_src_op(fstate);
     }
 
-    void compute_nueff(const FieldState ) override
+    void compute_mueff(const FieldState ) override
     {
         // TBD
     }

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -46,8 +46,10 @@ public:
     //! Perform initialization actions after the mesh is created
     void initialize() override
     {
-        if (PDE::has_diffusion)
+        if (PDE::has_diffusion) {
             m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields));
+            m_turb_op.reset(new TurbulenceOp<PDE>(m_sim.turbulence_model(), m_fields));
+        }
     }
 
     //! Perform update actions after a regrid is performed
@@ -67,7 +69,8 @@ public:
 
     void compute_mueff(const FieldState ) override
     {
-        // TBD
+        if (PDE::has_diffusion)
+            (*m_turb_op)();
     }
 
     void compute_diffusion_term(const FieldState fstate) override
@@ -120,6 +123,9 @@ protected:
 
     //! Diffusion term computation operator
     std::unique_ptr<DiffusionOp<PDE, Scheme>> m_diff_op;
+
+    //! Turbulence operator
+    std::unique_ptr<TurbulenceOp<PDE>> m_turb_op;
 };
 
 } // namespace pde

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -2,47 +2,14 @@
 #define PDE_H
 
 #include <string>
-
-#include "incflo_enums.H"
-#include "Factory.H"
-#include "PDEHelpers.H"
+#include "CFDSim.H"
+#include "PDEBase.H"
 #include "PDEOps.H"
 #include "CompRHSOps.H"
 #include "DiffusionOps.H"
 
 namespace amr_wind {
 namespace pde {
-
-class PDEBase : public Factory<PDEBase, const SimTime&, FieldRepo&, const int>
-{
-public:
-    virtual ~PDEBase() = default;
-
-    virtual PDEFields& fields() = 0;
-
-    virtual void initialize() = 0;
-
-    virtual void post_regrid_actions() = 0;
-
-    virtual void compute_source_term(const FieldState fstate) = 0;
-
-    virtual void compute_nueff(const FieldState fstate) = 0;
-
-    virtual void compute_diffusion_term(const FieldState fstate) = 0;
-
-    virtual void compute_advection_term(const FieldState fstate) = 0;
-
-    virtual void compute_predictor_rhs(const DiffusionType difftype) = 0;
-
-    virtual void compute_corrector_rhs(const DiffusionType difftype) = 0;
-
-    virtual void solve(const amrex::Real dt) = 0;
-
-    static std::string base_identifier()
-    {
-        return "PDESystem";
-    }
-};
 
 template<typename PDE, typename Scheme>
 class PDESystem : public PDEBase::Register<PDESystem<PDE, Scheme>>
@@ -56,10 +23,11 @@ public:
         return PDE::pde_name() + "-"  + Scheme::scheme_name();
     }
 
-    PDESystem(const SimTime& time, FieldRepo& repo, const int probtype)
-        : m_time(time)
-        , m_repo(repo)
-        , m_fields(FieldRegOp<PDE, Scheme>(repo)(time, probtype))
+    PDESystem(CFDSim& sim, const int probtype)
+        : m_sim(sim)
+        , m_time(sim.time())
+        , m_repo(sim.repo())
+        , m_fields(FieldRegOp<PDE, Scheme>(m_repo)(m_time, probtype))
         , m_src_op(m_fields)
         , m_adv_op(m_fields)
         , m_rhs_op(m_fields)
@@ -117,6 +85,8 @@ public:
     }
 
 protected:
+    CFDSim& m_sim;
+
     const SimTime& m_time;
 
     FieldRepo& m_repo;

--- a/src/equation_systems/PDE.H
+++ b/src/equation_systems/PDE.H
@@ -11,6 +11,14 @@
 namespace amr_wind {
 namespace pde {
 
+/** Implementation of the PDE interface for transport equations
+ *
+ *  This class takes two traits, one describing the PDE type and the other
+ *  describing the numerical scheme (e.g., Godunov, MOL) to generate a family of
+ *  PDE systems and its solution process. Each operation is performed by a
+ *  separate operator object that can be customized based on the different
+ *  traits as necessary.
+ */
 template<typename PDE, typename Scheme>
 class PDESystem : public PDEBase::Register<PDESystem<PDE, Scheme>>
 {
@@ -18,6 +26,8 @@ public:
     using PDEType = PDE;
     using SchemeType = Scheme;
 
+    //! Unique identifier used to register and create this instance on-demand
+    //! through the factor iterface
     static std::string identifier()
     {
         return PDE::pde_name() + "-"  + Scheme::scheme_name();
@@ -33,18 +43,21 @@ public:
         , m_rhs_op(m_fields)
     {}
 
+    //! Perform initialization actions after the mesh is created
     void initialize() override
     {
         if (PDE::has_diffusion)
             m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields));
     }
 
+    //! Perform update actions after a regrid is performed
     void post_regrid_actions() override
     {
         if (PDE::has_diffusion)
             m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields));
     }
 
+    //! Return the object holding the fields necessary for solving this PDE
     PDEFields& fields() override { return m_fields; }
 
     void compute_source_term(const FieldState fstate) override
@@ -85,17 +98,27 @@ public:
     }
 
 protected:
+    //! CFD simulation controller instance
     CFDSim& m_sim;
 
+    //! Time controls instance
     const SimTime& m_time;
 
+    //! Field repository
     FieldRepo& m_repo;
 
     PDEFields m_fields;
 
+    //! Source term computation operator
     SrcTermOp<PDE> m_src_op;
+
+    //! Advection term computation operator
     AdvectionOp<PDE, Scheme> m_adv_op;
+
+    //! RHS computation operator
     ComputeRHSOp<PDE, Scheme> m_rhs_op;
+
+    //! Diffusion term computation operator
     std::unique_ptr<DiffusionOp<PDE, Scheme>> m_diff_op;
 };
 

--- a/src/equation_systems/PDEBase.H
+++ b/src/equation_systems/PDEBase.H
@@ -1,0 +1,72 @@
+#ifndef PDEBASE_H
+#define PDEBASE_H
+
+#include <string>
+
+#include "Factory.H"
+#include "incflo_enums.H"
+#include "FieldDescTypes.H"
+#include "FieldRepo.H"
+#include "PDEHelpers.H"
+#include "SimTime.H"
+#include "CollMgr.H"
+
+namespace amr_wind {
+
+class CFDSim;
+
+namespace pde {
+
+class PDEBase : public Factory<PDEBase, CFDSim&, const int>
+{
+public:
+    virtual ~PDEBase() = default;
+
+    virtual PDEFields& fields() = 0;
+
+    virtual void initialize() = 0;
+
+    virtual void post_regrid_actions() = 0;
+
+    virtual void compute_source_term(const FieldState fstate) = 0;
+
+    virtual void compute_nueff(const FieldState fstate) = 0;
+
+    virtual void compute_diffusion_term(const FieldState fstate) = 0;
+
+    virtual void compute_advection_term(const FieldState fstate) = 0;
+
+    virtual void compute_predictor_rhs(const DiffusionType difftype) = 0;
+
+    virtual void compute_corrector_rhs(const DiffusionType difftype) = 0;
+
+    virtual void solve(const amrex::Real dt) = 0;
+
+    static std::string base_identifier() { return "PDESystem"; }
+};
+
+class PDEMgr : public CollMgr<PDEMgr, PDEBase>
+{
+public:
+    PDEMgr(CFDSim& sim);
+
+    ~PDEMgr() = default;
+
+    PDEBase& icns() { return *m_icns; }
+
+    PDEBase& register_icns();
+
+private:
+    CFDSim& m_sim;
+
+    std::unique_ptr<PDEBase> m_icns;
+
+    std::string m_scheme;
+
+    bool m_use_godunov{true};
+};
+
+} // namespace pde
+} // namespace amr_wind
+
+#endif /* PDEBASE_H */

--- a/src/equation_systems/PDEBase.H
+++ b/src/equation_systems/PDEBase.H
@@ -127,7 +127,7 @@ private:
     int m_probtype;
 
     //! Flag indicating whether Godunov scheme is active
-    bool m_use_godunov{true};
+    bool m_use_godunov{false};
 };
 
 } // namespace pde

--- a/src/equation_systems/PDEBase.H
+++ b/src/equation_systems/PDEBase.H
@@ -17,34 +17,79 @@ class CFDSim;
 
 namespace pde {
 
+/** Abstract interface defining a PDE and its solution process withn AMR-Wind
+ *
+ *  The exact behavior is implemented by subclass PDESystem that is specialized
+ *  using two traits: the PDE type trait, and the numerical scheme trait.
+ *  Currently, two numerical scheme traits are supported: Godunov and MOL.
+ *
+ *  Each PDESystem instance contains its own PDEFields object that holds fields
+ *  unique to the PDE. These fields are: the variable solved by the PDE (e.g.,
+ *  velocity, temperature, etc.), the effective dynamic viscosity, the source
+ *  terms, the diffusion term, and the convective term. A PDE may declare
+ *  additional fields that are not stored in this object, but can be queried
+ *  using the FieldRepo instance. For example, the incompressible Navier-Stokes
+ *  (ICNS) always declars density and pressure in addition to the velocity
+ *  fields.
+ *
+ */
 class PDEBase : public Factory<PDEBase, CFDSim&, const int>
 {
 public:
     virtual ~PDEBase() = default;
 
+    //! Return the object that holds references to fields for this PDE system
     virtual PDEFields& fields() = 0;
 
+    //! Perform initialization actions for a PDE after the mesh is generated
     virtual void initialize() = 0;
 
+    //! Preform updates specific to PDE after a regrid is performed
     virtual void post_regrid_actions() = 0;
 
+    //! Compute the source (forcing) terms for this PDE
     virtual void compute_source_term(const FieldState fstate) = 0;
 
+    //! Compute the effective dynamic viscosity for this PDE
     virtual void compute_nueff(const FieldState fstate) = 0;
 
+    //! Compute the diffusion term used in the RHS of the PDE system
     virtual void compute_diffusion_term(const FieldState fstate) = 0;
 
+    //! Compute the time derivative and advective term for the PDE system
     virtual void compute_advection_term(const FieldState fstate) = 0;
 
+    /** Combine the source, diffusion, and advection term to obtain RHS
+     *
+     *  This method behaves differently depending upon whether the diffusion
+     *  term is treated implicitly, with Crank-Nicolson scheme, or explicitly.
+     *  The predictor step only uses the "old" states for RHS computation.
+     */
     virtual void compute_predictor_rhs(const DiffusionType difftype) = 0;
 
+    /** Combine the source, diffusion, and advection term to obtain RHS
+     *
+     *  This method behaves differently depending upon whether the diffusion
+     *  term is treated implicitly, with Crank-Nicolson scheme, or explicitly.
+     *  The corrector step uses both "old" state as well as the updated "new"
+     *  state from predictor step to compute the RHS term.
+     */
     virtual void compute_corrector_rhs(const DiffusionType difftype) = 0;
 
+    //! Solve the diffusion linear system and update the field
     virtual void solve(const amrex::Real dt) = 0;
 
+    //! Base class identifier used for factory registration interface
     static std::string base_identifier() { return "PDESystem"; }
 };
 
+/** PDE systems manager
+ *
+ *  This class manages a collection of PDEs and provides an interface to
+ *  register PDEs. An incompressible N-S equation is always registered and
+ *  treated as a special case. The remaining PDEs are created on-demand and are
+ *  accessed through the equation systems vector.
+ */
 class PDEMgr : public CollMgr<PDEMgr, PDEBase>
 {
 public:
@@ -52,17 +97,36 @@ public:
 
     ~PDEMgr() = default;
 
+    //! Return the incompressible Navier-Stokes instance
     PDEBase& icns() { return *m_icns; }
 
+    //! Create the incompressible Navier-Stokes instance and return its reference
     PDEBase& register_icns();
 
+    //! Register a new PDE instance and return its reference
+    PDEBase& register_transport_pde(const std::string& pde_name);
+
+    /** Return the vector containing all registered PDE instances
+     *
+     *  Note that this does not contain the ICNS system as it is treated
+     *  separately for algorithmic reasons.
+     */
+    TypeVector& scalar_eqns() { return m_obj_vec; }
+
 private:
+    //! Instance of the CFD simulation controller
     CFDSim& m_sim;
 
+    //! ICNS instance
     std::unique_ptr<PDEBase> m_icns;
 
+    //! Unique identifier for the numerical scheme
     std::string m_scheme;
 
+    //! Unique integer for the problem type (to be deprecated)
+    int m_probtype;
+
+    //! Flag indicating whether Godunov scheme is active
     bool m_use_godunov{true};
 };
 

--- a/src/equation_systems/PDEBase.H
+++ b/src/equation_systems/PDEBase.H
@@ -51,7 +51,7 @@ public:
     virtual void compute_source_term(const FieldState fstate) = 0;
 
     //! Compute the effective dynamic viscosity for this PDE
-    virtual void compute_nueff(const FieldState fstate) = 0;
+    virtual void compute_mueff(const FieldState fstate) = 0;
 
     //! Compute the diffusion term used in the RHS of the PDE system
     virtual void compute_diffusion_term(const FieldState fstate) = 0;

--- a/src/equation_systems/PDEBase.cpp
+++ b/src/equation_systems/PDEBase.cpp
@@ -1,0 +1,39 @@
+#include "PDEBase.H"
+#include "SchemeTraits.H"
+#include "CFDSim.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace pde {
+
+PDEMgr::PDEMgr(CFDSim& sim)
+    : m_sim(sim)
+    , m_probtype(35)
+{
+    amrex::ParmParse pp("incflo");
+    pp.get("probtype", m_probtype);
+    pp.query("use_godunov", m_use_godunov);
+
+    m_scheme = m_use_godunov
+        ? fvm::Godunov::scheme_name()
+        : fvm::MOL::scheme_name();
+}
+
+PDEBase& PDEMgr::register_icns()
+{
+    const std::string name = "ICNS-" + m_scheme;
+
+    m_icns = amr_wind::pde::PDEBase::create(name, m_sim, m_probtype);
+    return *m_icns;
+}
+
+PDEBase& PDEMgr::register_transport_pde(const std::string& pde_name)
+{
+    const std::string name = pde_name + "-" + m_scheme;
+
+    return create(name, m_sim, m_probtype);
+}
+
+}
+}

--- a/src/equation_systems/PDEHelpers.H
+++ b/src/equation_systems/PDEHelpers.H
@@ -30,7 +30,7 @@ inline std::string src_term_name(const std::string& var)
 }
 
 //! Effective viscosity for the transport equation
-inline std::string nueff_name(const std::string& var) { return var + "_nueff"; }
+inline std::string mueff_name(const std::string& var) { return var + "_mueff"; }
 
 } // namespace pde_impl
 
@@ -41,7 +41,7 @@ struct PDEFields
     PDEFields(FieldRepo& repo_in, const std::string& var_name)
         : repo(repo_in)
         , field(repo.get_field(var_name))
-        , nueff(repo.get_field(pde_impl::nueff_name(var_name)))
+        , mueff(repo.get_field(pde_impl::mueff_name(var_name)))
         , src_term(repo.get_field(pde_impl::src_term_name(var_name)))
         , diff_term(repo.get_field(pde_impl::diff_term_name(var_name)))
         , conv_term(repo.get_field(pde_impl::conv_term_name(var_name)))
@@ -49,7 +49,7 @@ struct PDEFields
 
     FieldRepo& repo;
     Field& field;
-    Field& nueff;
+    Field& mueff;
 
     Field& src_term;
     Field& diff_term;
@@ -60,7 +60,7 @@ template<typename PDE, typename Scheme>
 PDEFields create_fields_instance(const SimTime& time, FieldRepo& repo, const int probtype)
 {
     repo.declare_field(PDE::var_name(), PDE::ndim, Scheme::nghost_state, Scheme::num_states);
-    repo.declare_field(pde_impl::nueff_name(PDE::var_name()), 1, 1, 1);
+    repo.declare_field(pde_impl::mueff_name(PDE::var_name()), 1, 1, 1);
     repo.declare_field(
         pde_impl::src_term_name(PDE::var_name()), PDE::ndim,
         Scheme::nghost_src, 1);

--- a/src/equation_systems/PDEOps.H
+++ b/src/equation_systems/PDEOps.H
@@ -3,6 +3,7 @@
 
 #include "FieldUtils.H"
 #include "PDEHelpers.H"
+#include "TurbulenceModel.H"
 
 namespace amr_wind {
 namespace pde {
@@ -96,6 +97,23 @@ struct AdvectionOp
 template<typename PDE, typename Scheme, typename = void>
 struct DiffusionOp
 {};
+
+template<typename PDE>
+struct TurbulenceOp
+{
+    TurbulenceOp(turbulence::TurbulenceModel& tmodel,
+                 PDEFields& fields)
+        : m_tmodel(tmodel), m_fields(fields)
+    {}
+
+    void operator()()
+    {
+        m_tmodel.update_scalar_diff(m_fields.mueff, m_fields.field.name());
+    }
+
+    turbulence::TurbulenceModel& m_tmodel;
+    PDEFields& m_fields;
+};
 
 }
 }

--- a/src/equation_systems/icns/icns_ops.H
+++ b/src/equation_systems/icns/icns_ops.H
@@ -349,6 +349,23 @@ struct AdvectionOp<ICNS, fvm::MOL>
     PDEFields& fields;
 };
 
+template<>
+struct TurbulenceOp<ICNS>
+{
+    TurbulenceOp(turbulence::TurbulenceModel& tmodel,
+                 PDEFields& fields)
+        : m_tmodel(tmodel), m_fields(fields)
+    {}
+
+    void operator()()
+    {
+        m_tmodel.update_mueff(m_fields.mueff);
+    }
+
+    turbulence::TurbulenceModel& m_tmodel;
+    PDEFields& m_fields;
+};
+
 }
 }
 

--- a/src/equation_systems/temperature/temperature.H
+++ b/src/equation_systems/temperature/temperature.H
@@ -15,6 +15,22 @@ struct Temperature : ScalarTransport
     static std::string var_name() { return "temperature"; }
 };
 
+template<>
+struct TurbulenceOp<Temperature>
+{
+    TurbulenceOp(turbulence::TurbulenceModel& tmodel,
+                 PDEFields& fields)
+        : m_tmodel(tmodel), m_fields(fields)
+    {}
+
+    void operator()()
+    {
+        m_tmodel.update_alphaeff(m_fields.mueff);
+    }
+
+    turbulence::TurbulenceModel& m_tmodel;
+    PDEFields& m_fields;
+};
 
 } // namespace pde
 } // namespace amr_wind

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -62,9 +62,15 @@ public:
         m_utau_mean_ground = ustar;
     }
 
+    amr_wind::CFDSim& sim() { return m_sim; }
     const amr_wind::SimTime& time() const { return m_time; }
     amr_wind::FieldRepo& repo() { return m_repo; }
     const amr_wind::FieldRepo& repo() const { return m_repo; }
+
+    amr_wind::pde::PDEBase& icns() { return m_sim.pde_manager().icns(); }
+    amr_wind::pde::PDEMgr::TypeVector& scalar_eqns()
+    { return m_sim.pde_manager().scalar_eqns(); }
+
     amr_wind::Field& velocity() const { return m_repo.get_field("velocity"); }
     amr_wind::Field& density() const { return m_repo.get_field("density"); }
     amr_wind::Field& tracer() const { return m_repo.get_field("temperature"); }
@@ -170,8 +176,8 @@ private:
     amr_wind::SimTime& m_time;
     amr_wind::FieldRepo& m_repo;
 
-    std::unique_ptr<amr_wind::pde::PDEBase> m_icns;
-    amrex::Vector<std::unique_ptr<amr_wind::pde::PDEBase>> m_scalar_eqns;
+    // std::unique_ptr<amr_wind::pde::PDEBase> m_icns;
+    // amrex::Vector<std::unique_ptr<amr_wind::pde::PDEBase>> m_scalar_eqns;
 
     amrex::Vector<std::unique_ptr<amr_wind::Physics>> m_physics;
     amrex::Vector<std::unique_ptr<amr_wind::RefinementCriteria>> m_refine_criteria;

--- a/src/incflo.H
+++ b/src/incflo.H
@@ -8,6 +8,7 @@
 #include <AMReX_NodalProjector.H>
 
 #include "incflo_enums.H"
+#include "CFDSim.H"
 #include "SimTime.H"
 #include "FieldRepo.H"
 
@@ -165,8 +166,9 @@ private:
     // member variables
     //
 
-    amr_wind::SimTime m_time;
-    amr_wind::FieldRepo m_repo;
+    amr_wind::CFDSim m_sim;
+    amr_wind::SimTime& m_time;
+    amr_wind::FieldRepo& m_repo;
 
     std::unique_ptr<amr_wind::pde::PDEBase> m_icns;
     amrex::Vector<std::unique_ptr<amr_wind::pde::PDEBase>> m_scalar_eqns;

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -8,7 +8,9 @@
 using namespace amrex;
 
 incflo::incflo ()
-    : m_repo(*this)
+    : m_sim(*this)
+    , m_time(m_sim.time())
+    , m_repo(m_sim.repo())
 {
     // NOTE: Geometry on all levels has just been defined in the AmrCore
     // constructor. No valid BoxArray and DistributionMapping have been defined.

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -3,7 +3,7 @@
 
 #include "ABL.H"
 #include "RefinementCriteria.H"
-#include "PDE.H"
+#include "PDEBase.H"
 
 using namespace amrex;
 
@@ -48,8 +48,8 @@ void incflo::InitData ()
         // This is an AmrCore member function which recursively makes new levels
         // with MakeNewLevelFromScratch.
         InitFromScratch(m_time.current_time());
-        m_icns->initialize();
-        for (auto& eqn: m_scalar_eqns) eqn->initialize();
+        icns().initialize();
+        for (auto& eqn: scalar_eqns()) eqn->initialize();
 
         if (m_do_initial_proj) {
             InitialProjection();
@@ -68,8 +68,8 @@ void incflo::InitData ()
         // Read starting configuration from chk file.
         ReadCheckpointFile();
 
-        m_icns->initialize();
-        for (auto& eqn: m_scalar_eqns) eqn->initialize();
+        icns().initialize();
+        for (auto& eqn: scalar_eqns()) eqn->initialize();
     }
 
     // Plot initial distribution
@@ -102,8 +102,8 @@ void incflo::Evolve()
             if (m_verbose > 0 and ParallelDescriptor::IOProcessor()) {
                 printGridSummary(amrex::OutStream(), 0, finest_level);
             }
-            m_icns->post_regrid_actions();
-            for (auto& eqn: m_scalar_eqns) eqn->post_regrid_actions();
+            icns().post_regrid_actions();
+            for (auto& eqn: scalar_eqns()) eqn->post_regrid_actions();
         }
 
         // Advance to time t + dt

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -5,7 +5,7 @@
 #include "field_ops.H"
 #include "Godunov.H"
 #include "MOL.H"
-#include "PDE.H"
+#include "PDEBase.H"
 #include "mac_projection.H"
 #include "diffusion.H"
 
@@ -137,7 +137,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
         PrintMaxValues(new_time);
     }
 
-    auto& icns_fields = m_icns->fields();
+    auto& icns_fields = icns().fields();
     auto& velocity_old = velocity().state(amr_wind::FieldState::Old);
     auto& velocity_new = velocity().state(amr_wind::FieldState::New);
     auto& density_old = density().state(amr_wind::FieldState::Old);
@@ -168,7 +168,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
                            density_old.vec_const_ptrs(),
                            tracer_old.vec_const_ptrs());
 
-        for (auto& seqn: m_scalar_eqns) {
+        for (auto& seqn: scalar_eqns()) {
             seqn->compute_source_term(amr_wind::FieldState::Old);
         }
     }
@@ -191,7 +191,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
                                      m_velocity_mean_ground,
                                      amr_wind::FieldState::Old);
         }
-        m_icns->compute_diffusion_term(amr_wind::FieldState::Old);
+        icns().compute_diffusion_term(amr_wind::FieldState::Old);
         if (m_use_godunov)
             amr_wind::field_ops::add(velocity_forces, divtau, 0, 0, AMREX_SPACEDIM, 0);
     }
@@ -202,7 +202,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // Compute explicit diffusive terms
     // *************************************************************************************
     if (need_divtau()) {
-        for (auto& eqn: m_scalar_eqns) {
+        for (auto& eqn: scalar_eqns()) {
             auto& field = eqn->fields().field;
             // Reuse existing buffer to avoid creating new multifabs
             amr_wind::field_ops::copy(field, field.state(amr_wind::FieldState::Old),
@@ -224,9 +224,9 @@ void incflo::ApplyPredictor (bool incremental_projection)
 
     if (m_use_godunov) {
        IntVect ng(nghost_force());
-       m_icns->fields().src_term.fillpatch(m_time.current_time(), ng);
+       icns().fields().src_term.fillpatch(m_time.current_time(), ng);
 
-       for (auto& eqn: m_scalar_eqns) {
+       for (auto& eqn: scalar_eqns()) {
            eqn->fields().src_term.fillpatch(m_time.current_time(), ng);
        }
     }
@@ -237,9 +237,9 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // Note that "get_conv_tracer_old" returns div(rho u tracer)
     // *************************************************************************************
 
-    m_icns->compute_advection_term(amr_wind::FieldState::Old);
+    icns().compute_advection_term(amr_wind::FieldState::Old);
 
-    for (auto& seqn: m_scalar_eqns) {
+    for (auto& seqn: scalar_eqns()) {
         seqn->compute_advection_term(amr_wind::FieldState::Old);
     }
 
@@ -254,7 +254,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // Perform scalar update one at a time. This is to allow an updated density
     // at `n+1/2` to be computed before other scalars use it when computing
     // their source terms.
-    for (auto& eqn: m_scalar_eqns) {
+    for (auto& eqn: scalar_eqns()) {
         // Compute (recompute for Godunov) the scalar forcing terms
         eqn->compute_source_term(amr_wind::FieldState::NPH);
 
@@ -296,7 +296,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
     // *************************************************************************************
     // Update the velocity
     // *************************************************************************************
-    m_icns->compute_predictor_rhs(m_diff_type);
+    icns().compute_predictor_rhs(m_diff_type);
 
     // *************************************************************************************
     // Solve diffusion equation for u* but using eta_old at old time
@@ -313,7 +313,7 @@ void incflo::ApplyPredictor (bool incremental_projection)
                                      m_velocity_mean_ground,
                                      amr_wind::FieldState::New);
         }
-        m_icns->solve(dt_diff);
+        icns().solve(dt_diff);
     }
 
     // **********************************************************************************************
@@ -420,9 +420,9 @@ void incflo::ApplyCorrector()
     // in constructing the advection term
     // *************************************************************************************
 
-    m_icns->compute_advection_term(amr_wind::FieldState::New);
+    icns().compute_advection_term(amr_wind::FieldState::New);
 
-    for (auto& seqn: m_scalar_eqns) {
+    for (auto& seqn: scalar_eqns()) {
         seqn->compute_advection_term(amr_wind::FieldState::New);
     }
 
@@ -441,9 +441,9 @@ void incflo::ApplyCorrector()
                                      m_velocity_mean_ground,
                                      amr_wind::FieldState::New);
         }
-        m_icns->compute_diffusion_term(amr_wind::FieldState::New);
+        icns().compute_diffusion_term(amr_wind::FieldState::New);
 
-        for (auto& eqns: m_scalar_eqns) {
+        for (auto& eqns: scalar_eqns()) {
             // FIXME: Hard-coded BC
             if (eqns->fields().field.name() == "temperature")
                 diffusion::heat_flux_bc(eqns->fields().field);
@@ -461,7 +461,7 @@ void incflo::ApplyCorrector()
     // Perform scalar update one at a time. This is to allow an updated density
     // at `n+1/2` to be computed before other scalars use it when computing
     // their source terms.
-    for (auto& eqn: m_scalar_eqns) {
+    for (auto& eqn: scalar_eqns()) {
         // Compute (recompute for Godunov) the scalar forcing terms
         // Note this is (rho * scalar) and not just scalar
         eqn->compute_source_term(amr_wind::FieldState::New);
@@ -504,7 +504,7 @@ void incflo::ApplyCorrector()
     // *************************************************************************************
     // Update velocity
     // *************************************************************************************
-    m_icns->compute_corrector_rhs(m_diff_type);
+    icns().compute_corrector_rhs(m_diff_type);
 
     // **********************************************************************************************
     //
@@ -524,7 +524,7 @@ void incflo::ApplyCorrector()
                                      m_velocity_mean_ground,
                                      amr_wind::FieldState::New);
         }
-        m_icns->solve(dt_diff);
+        icns().solve(dt_diff);
     }
 
     // **********************************************************************************************

--- a/src/incflo_advance.cpp
+++ b/src/incflo_advance.cpp
@@ -146,8 +146,8 @@ void incflo::ApplyPredictor (bool incremental_projection)
     auto& tracer_new = tracer().state(amr_wind::FieldState::New);
 
     auto& velocity_forces = icns_fields.src_term;
-    auto& vel_eta = icns_fields.nueff;
-    auto& tra_eta = m_repo.get_field("temperature_nueff");
+    auto& vel_eta = icns_fields.mueff;
+    auto& tra_eta = m_repo.get_field("temperature_mueff");
 
     // only the old states are used in predictor
     auto& divtau = m_use_godunov
@@ -406,8 +406,8 @@ void incflo::ApplyCorrector()
     auto& tracer_new = tracer().state(amr_wind::FieldState::New);
 
     auto& velocity_forces = m_repo.get_field("velocity_src_term");
-    auto& vel_eta = m_repo.get_field("velocity_nueff");
-    auto& tra_eta = m_repo.get_field("temperature_nueff");
+    auto& vel_eta = m_repo.get_field("velocity_mueff");
+    auto& tra_eta = m_repo.get_field("temperature_mueff");
 
     // Allocate scratch space for half time density and tracer
     auto& density_nph = density().state(amr_wind::FieldState::NPH);

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -24,6 +24,8 @@ void incflo::declare_fields()
 
     // TODO: This should be customized based on Physics
     pde_mgr.register_transport_pde("Temperature");
+
+    m_sim.create_turbulence_model();
 }
 
 void incflo::init_field_bcs ()

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -11,7 +11,7 @@ void incflo::declare_fields()
                                    ? amr_wind::fvm::Godunov::scheme_name()
                                    : amr_wind::fvm::MOL::scheme_name();
     m_icns = amr_wind::pde::PDEBase::create(
-        "ICNS-" + scheme, m_time, m_repo, m_probtype);
+        "ICNS-" + scheme, m_sim, m_probtype);
 
     // Register density first so that we can compute its `n+1/2` state before
     // other scalars attempt to use it in their computations.
@@ -21,11 +21,11 @@ void incflo::declare_fields()
                 "For non-constant density, it must be the first equation "
                 "registered for the scalar equations");
         m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
-            "Density-" + scheme, m_time, m_repo, m_probtype));
+            "Density-" + scheme, m_sim, m_probtype));
     }
 
     m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
-        "Temperature-" + scheme, m_time, m_repo, m_probtype));
+        "Temperature-" + scheme, m_sim, m_probtype));
 }
 
 void incflo::init_field_bcs ()

--- a/src/incflo_field_repo.cpp
+++ b/src/incflo_field_repo.cpp
@@ -7,25 +7,23 @@
 
 void incflo::declare_fields()
 {
-    const std::string scheme = m_use_godunov
-                                   ? amr_wind::fvm::Godunov::scheme_name()
-                                   : amr_wind::fvm::MOL::scheme_name();
-    m_icns = amr_wind::pde::PDEBase::create(
-        "ICNS-" + scheme, m_sim, m_probtype);
+    auto& pde_mgr = m_sim.pde_manager();
+
+    // Always register incompressible Navier-Stokes equation
+    pde_mgr.register_icns();
 
     // Register density first so that we can compute its `n+1/2` state before
     // other scalars attempt to use it in their computations.
     if (!m_constant_density) {
-        if (m_scalar_eqns.size() > 0)
+        if (pde_mgr.scalar_eqns().size() > 0)
             amrex::Abort(
                 "For non-constant density, it must be the first equation "
                 "registered for the scalar equations");
-        m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
-            "Density-" + scheme, m_sim, m_probtype));
+        pde_mgr.register_transport_pde("Density");
     }
 
-    m_scalar_eqns.emplace_back(amr_wind::pde::PDEBase::create(
-        "Temperature-" + scheme, m_sim, m_probtype));
+    // TODO: This should be customized based on Physics
+    pde_mgr.register_transport_pde("Temperature");
 }
 
 void incflo::init_field_bcs ()

--- a/src/transport_models/CMakeLists.txt
+++ b/src/transport_models/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/transport_models/ConstTransport.H
+++ b/src/transport_models/ConstTransport.H
@@ -1,0 +1,105 @@
+#ifndef CONSTTRANSPORT_H
+#define CONSTTRANSPORT_H
+
+#include "TransportModel.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace transport {
+
+class ConstTransport : public TransportModel
+{
+public:
+    static constexpr bool constant_properties = true;
+
+    static const std::string identifier() { return "ConstTransport"; }
+
+    ConstTransport(FieldRepo& repo) : m_repo(repo)
+    {
+        amrex::ParmParse pp("transport");
+        pp.get("viscosity", m_mu);
+        pp.query("laminar_prandtl", m_Pr);
+        pp.query("turbulent_prandtl", m_Prt);
+    }
+
+    virtual ~ConstTransport() = default;
+
+    inline amrex::Real viscosity() const { return m_mu; }
+
+    inline amrex::Real thermal_diffusivity() const
+    { return m_mu / m_Pr; }
+
+    inline amrex::Real laminar_prandtl() const { return m_Pr; }
+
+    inline amrex::Real turbulent_prandtl() const { return m_Prt; }
+
+    inline amrex::Real laminar_schmidt(const std::string& scalar_name) const
+    {
+        amrex::ParmParse pp("transport");
+        const std::string key = scalar_name + "_laminar_schmidt";
+        amrex::Real lam_schmidt = 1.0;
+        pp.query(key.c_str(), lam_schmidt);
+        return lam_schmidt;
+    }
+
+    inline amrex::Real turbulent_schmidt(const std::string& scalar_name) const
+    {
+        amrex::ParmParse pp("transport");
+        const std::string key = scalar_name + "_turbulent_schmidt";
+        amrex::Real turb_schmidt = 1.0;
+        pp.query(key.c_str(), turb_schmidt);
+        return turb_schmidt;
+    }
+
+    //! Return the dynamic visocity field
+    inline std::unique_ptr<ScratchField> mu()
+    {
+        auto mu = m_repo.create_scratch_field(1, 1);
+        for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+            (*mu)(lev).setVal(m_mu);
+        }
+        return mu;
+    }
+
+    //! Return the thermal diffusivity field
+    inline std::unique_ptr<ScratchField> alpha()
+    {
+        auto alpha = mu();
+        amrex::Real inv_Pr = 1.0 / m_Pr;
+        for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+            (*alpha)(lev).mult(inv_Pr);
+        }
+        return alpha;
+    }
+
+    inline std::unique_ptr<ScratchField> scalar_diffusivity(const std::string& scalar_name)
+    {
+        amrex::Real lam_schmidt = laminar_schmidt(scalar_name);
+
+        amrex::Real inv_schmidt = 1.0 / lam_schmidt;
+        auto diff = mu();
+        for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+            (*diff)(lev).mult(inv_schmidt);
+        }
+
+        return diff;
+    }
+
+private:
+    //! Reference to the field repository (for creating scratch fields)
+    FieldRepo& m_repo;
+
+    //! (Laminar) dynamic viscosity
+    amrex::Real m_mu{1.0e-5};
+
+    //! Prandtl number
+    amrex::Real m_Pr{1.0};
+
+    //! Turbulent Prandtl number
+    amrex::Real m_Prt{1.0};
+};
+
+}
+}
+
+#endif /* CONSTTRANSPORT_H */

--- a/src/transport_models/ConstTransport.H
+++ b/src/transport_models/ConstTransport.H
@@ -17,7 +17,7 @@ public:
     ConstTransport(FieldRepo& repo) : m_repo(repo)
     {
         amrex::ParmParse pp("transport");
-        pp.get("viscosity", m_mu);
+        pp.query("viscosity", m_mu);
         pp.query("laminar_prandtl", m_Pr);
         pp.query("turbulent_prandtl", m_Prt);
     }

--- a/src/transport_models/Make.package
+++ b/src/transport_models/Make.package
@@ -1,0 +1,1 @@
+CEXE_headers += TransportModel.H ConstTransport.H

--- a/src/transport_models/TransportModel.H
+++ b/src/transport_models/TransportModel.H
@@ -21,9 +21,9 @@ public:
     virtual std::unique_ptr<ScratchField> alpha() = 0;
 
     //! Scalar diffusivity based on Schmidt number
-    std::unique_ptr<ScratchField> scalar_diffusivity(const std::string& scalar_name);
+    virtual std::unique_ptr<ScratchField>
+    scalar_diffusivity(const std::string& scalar_name) = 0;
 };
-
 }
 }
 

--- a/src/transport_models/TransportModel.H
+++ b/src/transport_models/TransportModel.H
@@ -1,0 +1,30 @@
+#ifndef TRANSPORTMODEL_H
+#define TRANSPORTMODEL_H
+
+#include "Factory.H"
+#include "FieldRepo.H"
+
+namespace amr_wind {
+namespace transport {
+
+class TransportModel
+{
+public:
+    static constexpr bool constant_properties = false;
+
+    virtual ~TransportModel() = default;
+
+    //! Dynamic laminar viscosity (kg/m/s)
+    virtual std::unique_ptr<ScratchField> mu() = 0;
+
+    //! Thermal diffusivity
+    virtual std::unique_ptr<ScratchField> alpha() = 0;
+
+    //! Scalar diffusivity based on Schmidt number
+    std::unique_ptr<ScratchField> scalar_diffusivity(const std::string& scalar_name);
+};
+
+}
+}
+
+#endif /* TRANSPORTMODEL_H */

--- a/src/turbulence/CMakeLists.txt
+++ b/src/turbulence/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  LaminarModel.cpp
+  )
+
+target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/turbulence/CMakeLists.txt
+++ b/src/turbulence/CMakeLists.txt
@@ -2,4 +2,6 @@ target_sources(${amr_wind_lib_name} PRIVATE
   LaminarModel.cpp
   )
 
+add_subdirectory(LES)
+
 target_include_directories(${amr_wind_lib_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/turbulence/LES/CMakeLists.txt
+++ b/src/turbulence/LES/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  Smagorinsky.cpp
+  )

--- a/src/turbulence/LES/Make.package
+++ b/src/turbulence/LES/Make.package
@@ -1,0 +1,2 @@
+CEXE_headers += Smagorinsky.H
+CEXE_sources += Smagorinsky.cpp

--- a/src/turbulence/LES/Smagorinsky.H
+++ b/src/turbulence/LES/Smagorinsky.H
@@ -1,0 +1,35 @@
+#ifndef SMAGORINSKY_H
+#define SMAGORINSKY_H
+
+#include <string>
+#include "TurbModelBase.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+template <typename Transport>
+class Smagorinsky : public TurbModelBase<Transport>
+{
+public:
+    static std::string identifier()
+    {
+        return "Smagorinsky-" + Transport::identifier();
+    }
+
+    Smagorinsky(CFDSim& sim);
+
+    //! Model name for debugging purposes
+    virtual std::string model_name() override { return "Smagorinsky"; }
+
+    //! Update the turbulent viscosity field
+    virtual void update_turbulent_viscosity(const FieldState fstate) override;
+
+private:
+    //! Smagorinsky coefficient (default value set for ABL simulations)
+    amrex::Real m_Cs{0.135};
+};
+
+} // namespace turbulence
+} // namespace amr_wind
+
+#endif /* SMAGORINSKY_H */

--- a/src/turbulence/LES/Smagorinsky.cpp
+++ b/src/turbulence/LES/Smagorinsky.cpp
@@ -1,0 +1,190 @@
+#include <cmath>
+
+#include "Smagorinsky.H"
+#include "TurbModelDefs.H"
+#include "derive_K.H"
+
+#include "AMReX_REAL.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+template<typename Transport>
+Smagorinsky<Transport>::Smagorinsky(CFDSim& sim)
+    : TurbModelBase<Transport>(sim)
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("Cs", m_Cs);
+}
+
+template <typename Transport>
+void Smagorinsky<Transport>::update_turbulent_viscosity(const FieldState fstate)
+{
+    BL_PROFILE(this->identifier() + "::update_turbulent_viscosity");
+
+    auto& mu_turb = this->mu_turb();
+    auto& repo = mu_turb.repo();
+    auto& vel = repo.get_field("velocity", fstate);
+    auto& den = repo.get_field("density", fstate);
+    auto& geom_vec = repo.mesh().Geom();
+    const amrex::Real Cs_sqr = this->m_Cs * this->m_Cs;
+
+    const int nlevels = repo.num_active_levels();
+    for (int lev=0; lev < nlevels; ++lev) {
+        const auto& geom = geom_vec[lev];
+        const auto& domain = geom.Domain();
+
+        const amrex::Real dx = geom.CellSize()[0];
+        const amrex::Real dy = geom.CellSize()[1];
+        const amrex::Real dz = geom.CellSize()[2];
+        const amrex::Real ds = std::cbrt(dx * dy * dz);
+        const amrex::Real ds_sqr = ds * ds;
+
+        const amrex::Real idx = 1.0 / dx;
+        const amrex::Real idy = 1.0 / dy;
+        const amrex::Real idz = 1.0 / dz;
+
+        for (amrex::MFIter mfi(mu_turb(lev)); mfi.isValid(); ++mfi) {
+            const auto& bx = mfi.growntilebox(mu_turb.num_grow());
+            const auto& mu_arr = mu_turb(lev).array(mfi);
+            const auto& vel_arr = vel(lev).const_array(mfi);
+            const auto& rho_arr = den(lev).const_array(mfi);
+
+            amrex::ParallelFor(
+                bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    const amrex::Real rho = rho_arr(i, j, k);
+                    const amrex::Real sr = incflo_strainrate<StencilInterior>(
+                        i, j, k, idx, idy, idz, vel_arr);
+                    mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                });
+
+            // TODO: Check if the following is correct for `foextrap` BC types
+            const auto& bxi = mfi.tilebox();
+            int idim = 0;
+            if (!geom.isPeriodic(idim)) {
+                if (bxi.smallEnd(idim) == domain.smallEnd(idim)) {
+                    amrex::IntVect low(bxi.smallEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxlo = amrex::Box(low, hi).grow({0, 1, 1});
+
+                    amrex::ParallelFor(
+                        bxlo, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilILO>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+
+                if (bxi.bigEnd(idim) == domain.bigEnd(idim)) {
+                    amrex::IntVect low(bxi.bigEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxhi = amrex::Box(low, hi).grow({0, 1, 1});
+
+                    amrex::ParallelFor(
+                        bxhi, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilIHI>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+            } // if (!geom.isPeriodic)
+
+            idim = 1;
+            if (!geom.isPeriodic(idim)) {
+                if (bxi.smallEnd(idim) == domain.smallEnd(idim)) {
+                    amrex::IntVect low(bxi.smallEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxlo = amrex::Box(low, hi).grow({1, 0, 1});
+
+                    amrex::ParallelFor(
+                        bxlo, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilJLO>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+
+                if (bxi.bigEnd(idim) == domain.bigEnd(idim)) {
+                    amrex::IntVect low(bxi.bigEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxhi = amrex::Box(low, hi).grow({1, 0, 1});
+
+                    amrex::ParallelFor(
+                        bxhi, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilJHI>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+            } // if (!geom.isPeriodic)
+
+            idim = 2;
+            if (!geom.isPeriodic(idim)) {
+                if (bxi.smallEnd(idim) == domain.smallEnd(idim)) {
+                    amrex::IntVect low(bxi.smallEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxlo = amrex::Box(low, hi).grow({1, 1, 0});
+
+                    amrex::ParallelFor(
+                        bxlo, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilKLO>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+
+                if (bxi.bigEnd(idim) == domain.bigEnd(idim)) {
+                    amrex::IntVect low(bxi.bigEnd());
+                    amrex::IntVect hi(bxi.bigEnd());
+                    int sm = low[idim];
+                    low.setVal(idim, sm);
+                    hi.setVal(idim, sm);
+
+                    auto bxhi = amrex::Box(low, hi).grow({1, 1, 0});
+
+                    amrex::ParallelFor(
+                        bxhi, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            const amrex::Real rho = rho_arr(i, j, k);
+                            const amrex::Real sr = incflo_strainrate<StencilKHI>(
+                                i, j, k, idx, idy, idz, vel_arr);
+                            mu_arr(i, j, k) = rho * Cs_sqr * ds_sqr * sr;
+                        });
+                }
+            } // if (!geom.isPeriodic)
+        }
+    }
+}
+
+} // namespace turbulence
+
+INSTANTIATE_TURBULENCE_MODEL(Smagorinsky);
+
+} // namespace amr_wind

--- a/src/turbulence/LaminarModel.H
+++ b/src/turbulence/LaminarModel.H
@@ -1,0 +1,39 @@
+#ifndef LAMINARMODEL_H
+#define LAMINARMODEL_H
+
+#include "TurbModel.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+template<typename Transport>
+class Laminar : public TurbModel<Transport>
+{
+public:
+    static std::string identifier() { return "Laminar-" + Transport::identifier(); }
+
+    Laminar(CFDSim& sim)
+        : TurbModel<Transport>(sim)
+    {}
+
+    virtual ~Laminar() = default;
+
+    virtual std::string model_name() { return "laminar"; }
+
+    //! Update the effective/turbulent viscosity field
+    virtual void update_turbulent_viscosity() override;
+
+    //! Return the turbulent viscosity field (just the same as the effective field)
+    virtual Field& mu_turb() override { return this->mueff(); }
+
+    //! Return the thermal diffusivity field (just the same as effective field)
+    virtual Field& alpha_turb() override { return this->alphaeff(); }
+
+    //! Indicate that this model is not a turbulent model type
+    virtual bool is_turbulent() const override { return false; }
+};
+
+}
+}
+
+#endif /* LAMINARMODEL_H */

--- a/src/turbulence/LaminarModel.H
+++ b/src/turbulence/LaminarModel.H
@@ -18,10 +18,10 @@ public:
 
     virtual ~Laminar() = default;
 
-    virtual std::string model_name() { return "laminar"; }
+    virtual std::string model_name() override { return "laminar"; }
 
     //! Update the effective/turbulent viscosity field
-    virtual void update_turbulent_viscosity() override;
+    virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! Return the turbulent viscosity field (just the same as the effective field)
     virtual Field& mu_turb() override { return this->mueff(); }
@@ -31,6 +31,15 @@ public:
 
     //! Indicate that this model is not a turbulent model type
     virtual bool is_turbulent() const override { return false; }
+
+    //! Interface to update effective viscosity (mu_eff = mu + mu_t)
+    virtual void update_mueff(Field& mueff) override;
+
+    //! Interface to update effective thermal diffusivity
+    virtual void update_alphaeff(Field& alphaeff) override;
+
+    //! Interface to update scalar diffusivity based on Schmidt number
+    virtual void update_scalar_diff(Field& deff, const std::string& name) override;
 };
 
 }

--- a/src/turbulence/LaminarModel.cpp
+++ b/src/turbulence/LaminarModel.cpp
@@ -1,0 +1,68 @@
+#include "LaminarModel.H"
+#include "TurbModelDefs.H"
+#include "field_ops.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+namespace {
+
+// For laminar models we just copy the dynamic viscosity and thermal diffusivity
+// into the effective/turbulent viscosity fields to satisfy the API. However, we
+// use template specializations on the transport models to bypass an extra field
+// creation/copy overhead when the properties are constant. The functions below
+// perform a direct update using setVal for constant properties, but a copy from
+// laminar field to effective field for non-constant transport properties.
+
+template <
+    typename Transport,
+    typename std::enable_if<Transport::constant_properties>::type* = nullptr>
+inline void
+laminar_visc_update(Field& evisc, ScratchField&, const Transport& transport)
+{
+    evisc.setVal(transport.viscosity());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<!Transport::constant_properties>::type* = nullptr>
+inline void laminar_visc_update(Field& evisc, ScratchField& visc)
+{
+    field_ops::copy(evisc, visc, 0, 0, evisc.num_comp(), evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<Transport::constant_properties>::type* = nullptr>
+inline void
+laminar_alpha_update(Field& evisc, ScratchField&, const Transport& transport)
+{
+    evisc.setVal(transport.thermal_diffusivity());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<!Transport::constant_properties>::type* = nullptr>
+inline void laminar_alpha_update(Field& evisc, ScratchField& visc)
+{
+    field_ops::copy(evisc, visc, 0, 0, evisc.num_comp(), evisc.num_grow());
+}
+
+} // namespace
+
+template <typename Transport>
+void Laminar<Transport>::update_turbulent_viscosity()
+{
+    AMREX_ASSERT(this->m_mueff != nullptr);
+    laminar_visc_update(*this->m_mueff, *this->mu(), this->m_transport);
+
+    if (this->m_alphaeff != nullptr)
+        laminar_alpha_update(
+            *this->m_alphaeff, *this->alpha(), this->m_transport);
+}
+
+} // namespace turbulence
+
+INSTANTIATE_TURBULENCE_MODEL(Laminar);
+
+} // namespace amr_wind

--- a/src/turbulence/Make.package
+++ b/src/turbulence/Make.package
@@ -1,0 +1,2 @@
+CEXE_headers += TurbulenceModel.H TurbModel.H TurbModelBase.H LaminarModel.H
+CEXE_sources += LaminarModel.cpp

--- a/src/turbulence/TurbModel.H
+++ b/src/turbulence/TurbModel.H
@@ -1,0 +1,73 @@
+#ifndef TURBMODEL_H
+#define TURBMODEL_H
+
+#include "TurbulenceModel.H"
+#include "CFDSim.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+template<typename Transport>
+class TurbModel : public TurbulenceModel
+{
+public:
+    using TransportType = Transport;
+
+    TurbModel(CFDSim& sim)
+        : m_sim(sim)
+        , m_transport(sim.repo())
+    {}
+
+    virtual void register_mueff_field(Field& mueff) override
+    {
+        m_mueff = &mueff;
+    }
+
+    virtual void register_alphaeff_field(Field& alphaeff) override
+    {
+        m_alphaeff = &alphaeff;
+    }
+
+    //! Return the dynamic viscosity field
+    virtual std::unique_ptr<ScratchField> mu() override
+    { return m_transport.mu(); }
+
+    //! Return the thermal diffusivity field
+    virtual std::unique_ptr<ScratchField> alpha() override
+    { return m_transport.alpha(); }
+
+    //! Return the scalar diffusivity field
+    virtual std::unique_ptr<ScratchField> scalar_diffusivity(const std::string& name) override
+    {
+        return m_transport.scalar_diffusivity(name);
+    }
+
+    virtual Field& mueff() override
+    {
+        AMREX_ASSERT(m_mueff != nullptr);
+        return *m_mueff;
+    }
+
+    virtual Field& alphaeff() override
+    {
+        AMREX_ASSERT(m_alphaeff != nullptr);
+        return *m_alphaeff;
+    }
+
+protected:
+    CFDSim& m_sim;
+
+    //! Transport properties instance
+    Transport m_transport;
+
+    //! Reference to the effective viscosity field
+    Field* m_mueff{nullptr};
+
+    //! Reference to the thermal diffusivity field
+    Field* m_alphaeff{nullptr};
+};
+
+}
+}
+
+#endif /* TURBMODEL_H */

--- a/src/turbulence/TurbModelBase.H
+++ b/src/turbulence/TurbModelBase.H
@@ -1,0 +1,135 @@
+#ifndef TURBMODELBASE_H
+#define TURBMODELBASE_H
+
+#include "TurbModel.H"
+#include "field_ops.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+namespace turb_base_impl {
+
+// For transport model with constant properties implement specializations that
+// avoid creation of an intermediate scratch buffer.
+
+template <
+    typename Transport,
+    typename std::enable_if<Transport::constant_properties>::type* = nullptr>
+inline void visc_update(Field& evisc, Field& tvisc, Transport& transport)
+{
+    evisc.setVal(transport.viscosity());
+    field_ops::saxpy(
+        evisc, 1.0, tvisc, 0, 0, evisc.num_comp(), evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<Transport::constant_properties>::type* = nullptr>
+inline void alpha_update(Field& evisc, Field& tvisc, Transport& transport)
+{
+    evisc.setVal(transport.thermal_diffusivity());
+    field_ops::saxpy(
+        evisc, 1.0 / transport.turbulent_prandtl(), tvisc, 0, 0,
+        evisc.num_comp(), evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<Transport::constant_properties>::type* = nullptr>
+inline void scal_diff_update(
+    Field& evisc, Field& tvisc, Transport& transport, const std::string& name)
+{
+    evisc.setVal(transport.viscosity() / transport.laminar_schmidt(name));
+    field_ops::saxpy(
+        evisc, 1.0 / transport.turbulent_schmidt(name), tvisc, 0, 0,
+        evisc.num_comp(), evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<!Transport::constant_properties>::type* = nullptr>
+inline void visc_update(Field& evisc, Field& tvisc, Transport& transport)
+{
+    auto lam_mu = transport.mu();
+    field_ops::lincomb(
+        evisc, 1.0, *lam_mu, 0, 1.0, tvisc, 0, 0, evisc.num_comp(),
+        evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<!Transport::constant_properties>::type* = nullptr>
+inline void alpha_update(Field& evisc, Field& tvisc, Transport& transport)
+{
+    auto lam_alpha = transport.alpha();
+    field_ops::lincomb(
+        evisc, 1.0, lam_alpha, 0, 1.0 / transport.turbulent_prandtl(),
+        tvisc, 0, 0, evisc.num_comp(), evisc.num_grow());
+}
+
+template <
+    typename Transport,
+    typename std::enable_if<!Transport::constant_properties>::type* = nullptr>
+inline void scal_diff_update(
+    Field& evisc, Field& tvisc, Transport& transport, const std::string& name)
+{
+    auto lam_mu = transport.mu();
+    field_ops::lincomb(
+        evisc, 1.0 / transport.laminar_schmidt(name), *lam_mu, 0,
+        1.0 / transport.turbulent_schmidt(), tvisc, 0, 0, evisc.num_comp(),
+        evisc.num_grow());
+}
+
+} // namespace turb_base_impl
+
+/** Turbulence model aspects common to both LES and RANS models
+ */
+template<typename Transport>
+class TurbModelBase : public TurbModel<Transport>
+{
+public:
+    TurbModelBase(CFDSim& sim)
+        : TurbModel<Transport>(sim)
+        , m_mu_turb(sim.repo().declare_field("mu_turb", 1, 1, 1))
+    {}
+
+    virtual Field& mu_turb() override { return m_mu_turb; }
+
+    virtual Field& alpha_turb() override
+    {
+        AMREX_ASSERT(m_alpha_turb != nullptr);
+        return *m_alpha_turb;
+    }
+
+    // clang-format off
+
+    //! Interface to update effective viscosity (mu_eff = mu + mu_t)
+    virtual void update_mueff(Field& mueff) override
+    {
+        turb_base_impl::visc_update(mueff, this->m_mu_turb, this->m_transport);
+    }
+
+    //! Interface to update effective thermal diffusivity
+    virtual void update_alphaeff(Field& alphaeff) override
+    {
+        turb_base_impl::alpha_update(alphaeff, this->m_mu_turb, this->m_transport);
+    }
+
+    //! Interface to update scalar diffusivity based on Schmidt number
+    virtual void update_scalar_diff(Field& deff, const std::string& name) override
+    {
+        turb_base_impl::scal_diff_update(deff, this->m_mu_turb, this->m_transport, name);
+    }
+
+    // clang-format on
+
+protected:
+    Field& m_mu_turb;
+
+    Field* m_alpha_turb{nullptr};
+};
+
+}
+}
+
+#endif /* TURBMODELBASE_H */

--- a/src/turbulence/TurbModelDefs.H
+++ b/src/turbulence/TurbModelDefs.H
@@ -1,0 +1,14 @@
+#ifndef TURBMODELDEFS_H
+#define TURBMODELDEFS_H
+
+#include "TurbulenceModel.H"
+#include "ConstTransport.H"
+
+namespace amr_wind {
+
+#define INSTANTIATE_TURBULENCE_MODEL(Model) \
+    template struct ::amr_wind::turbulence::TurbulenceModel::Register<::amr_wind::turbulence::Model<transport::ConstTransport>>
+
+}
+
+#endif /* TURBMODELDEFS_H */

--- a/src/turbulence/TurbulenceModel.H
+++ b/src/turbulence/TurbulenceModel.H
@@ -2,6 +2,7 @@
 #define TURBULENCEMODEL_H
 
 #include "Factory.H"
+#include "FieldDescTypes.H"
 
 namespace amr_wind {
 
@@ -18,7 +19,7 @@ public:
 
     virtual ~TurbulenceModel() = default;
 
-    virtual void update_turbulent_viscosity() = 0;
+    virtual void update_turbulent_viscosity(const FieldState fstate) = 0;
 
     virtual void register_mueff_field(Field& mueff) = 0;
 
@@ -49,6 +50,15 @@ public:
 
     //! Flag indicating whether the model is turbulent
     virtual bool is_turbulent() const { return true; }
+
+    //! Interface to update effective viscosity (mu_eff = mu + mu_t)
+    virtual void update_mueff(Field& mueff) = 0;
+
+    //! Interface to update effective thermal diffusivity
+    virtual void update_alphaeff(Field& alphaeff) = 0;
+
+    //! Interface to update scalar diffusivity based on Schmidt number
+    virtual void update_scalar_diff(Field& deff, const std::string& name) = 0;
 };
 
 }

--- a/src/turbulence/TurbulenceModel.H
+++ b/src/turbulence/TurbulenceModel.H
@@ -1,0 +1,57 @@
+#ifndef TURBULENCEMODEL_H
+#define TURBULENCEMODEL_H
+
+#include "Factory.H"
+
+namespace amr_wind {
+
+class CFDSim;
+class ScratchField;
+class Field;
+
+namespace turbulence {
+
+class TurbulenceModel : public Factory<TurbulenceModel, CFDSim&>
+{
+public:
+    static std::string base_identifier() { return "TurbulenceModel"; }
+
+    virtual ~TurbulenceModel() = default;
+
+    virtual void update_turbulent_viscosity() = 0;
+
+    virtual void register_mueff_field(Field& mueff) = 0;
+
+    virtual void register_alphaeff_field(Field& alphaeff) = 0;
+
+    virtual std::string model_name() = 0;
+
+    //! Return the dynamic viscosity (laminar) field
+    virtual std::unique_ptr<ScratchField> mu() = 0;
+
+    //! Return the thermal diffusivity (laminar) field for enthalpy/temperature
+    virtual std::unique_ptr<ScratchField> alpha() = 0;
+
+    //! Return the scalar diffusivity field
+    virtual std::unique_ptr<ScratchField> scalar_diffusivity(const std::string& name) = 0;
+
+    //! Return the turbulent dynamic viscosity field
+    virtual Field& mu_turb() = 0;
+
+    //! Return the turbulent dynamic viscosity field
+    virtual Field& alpha_turb() = 0;
+
+    //! Return the effective dynamic viscosity field
+    virtual Field& mueff() = 0;
+
+    //! Return the effective thermal diffusivity field
+    virtual Field& alphaeff() = 0;
+
+    //! Flag indicating whether the model is turbulent
+    virtual bool is_turbulent() const { return true; }
+};
+
+}
+}
+
+#endif /* TURBULENCEMODEL_H */

--- a/test/test_files/abl_godunov/abl_godunov.i
+++ b/test/test_files/abl_godunov/abl_godunov.i
@@ -32,6 +32,11 @@ incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.SmagorinskyLillyConstant = .135
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.use_godunov = 1
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
 
 abl.use_boussinesq = 1 
 abl.coriolis_effect = 1 

--- a/test/test_files/abl_godunov_cn/abl_godunov_cn.i
+++ b/test/test_files/abl_godunov_cn/abl_godunov_cn.i
@@ -32,6 +32,11 @@ incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.use_godunov = 1
 incflo.diffusion_type = 1
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
 
 abl.Smagorinsky_Lilly_SGS_constant = .135
 abl.use_boussinesq = 1 

--- a/test/test_files/abl_godunov_explicit/abl_godunov_explicit.i
+++ b/test/test_files/abl_godunov_explicit/abl_godunov_explicit.i
@@ -32,6 +32,12 @@ incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.use_godunov = 1
 incflo.diffusion_type = 0
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+
 
 abl.Smagorinsky_Lilly_SGS_constant = .135
 abl.use_boussinesq = 1 

--- a/test/test_files/abl_godunov_plm/abl_godunov_plm.i
+++ b/test/test_files/abl_godunov_plm/abl_godunov_plm.i
@@ -33,6 +33,12 @@ incflo.SmagorinskyLillyConstant = .135
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.use_godunov = 1
 incflo.use_ppm = 0
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+
 
 abl.use_boussinesq = 1 
 abl.coriolis_effect = 1 

--- a/test/test_files/abl_mol/abl_mol.i
+++ b/test/test_files/abl_mol/abl_mol.i
@@ -31,6 +31,11 @@ incflo.ro_0             = 1.0          # Reference density
 incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.SmagorinskyLillyConstant = .135
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
 
 abl.use_boussinesq = 1 
 abl.coriolis_effect = 1 

--- a/test/test_files/abl_mol_cn/abl_mol_cn.i
+++ b/test/test_files/abl_mol_cn/abl_mol_cn.i
@@ -31,6 +31,11 @@ incflo.ro_0             = 1.0          # Reference density
 incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.diffusion_type = 1
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
 
 abl.Smagorinsky_Lilly_SGS_constant = .135
 abl.use_boussinesq = 1 

--- a/test/test_files/abl_mol_explicit/abl_mol_explicit.i
+++ b/test/test_files/abl_mol_explicit/abl_mol_explicit.i
@@ -31,6 +31,11 @@ incflo.ro_0             = 1.0          # Reference density
 incflo.fluid_model      =   "SmagorinskyLillySGS" # Fluid model (rheology)
 incflo.mu               =   1.0e-5      # Dynamic viscosity coefficient
 incflo.diffusion_type = 0
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
 
 abl.Smagorinsky_Lilly_SGS_constant = .135
 abl.use_boussinesq = 1 

--- a/test/test_files/boussinesq_bubble_godunov/boussinesq_bubble_godunov.i
+++ b/test/test_files/boussinesq_bubble_godunov/boussinesq_bubble_godunov.i
@@ -14,6 +14,9 @@ time.checkpoint_interval           =  -100         # Steps between checkpoint fi
 
 incflo.mu               =   0.00001       # Dynamic viscosity coefficient
 incflo.mu_s = 0.00003
+transport.viscosity = 0.00001
+transport.laminar_prandtl = 0.33333333333333337
+turbulence.model = Laminar
 
 amr.max_level           =   1
 amr.n_cell              =   32 32 64     # Grid cells at coarsest AMRlevel

--- a/test/test_files/boussinesq_bubble_mol/boussinesq_bubble_mol.i
+++ b/test/test_files/boussinesq_bubble_mol/boussinesq_bubble_mol.i
@@ -12,6 +12,9 @@ time.checkpoint_interval           =  -100         # Steps between checkpoint fi
 
 incflo.mu               =   0.00001       # Dynamic viscosity coefficient
 incflo.mu_s = 0.00003
+transport.viscosity = 0.00001
+transport.laminar_prandtl = 0.33333333333333337
+turbulence.model = Laminar
 
 amr.max_level           =   1
 amr.n_cell              =   32 32 64     # Grid cells at coarsest AMRlevel

--- a/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
+++ b/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
@@ -9,7 +9,7 @@ time.checkpoint_interval           =  -100         # Steps between checkpoint fi
 incflo.mu               =   0.001       # Dynamic viscosity coefficient
 incflo.mu_s             =   0.001       # Scalar diffusion coefficient mu (mu = rho * nu)
 
-tranport.viscosity = 0.001
+transport.viscosity = 0.001
 transport.laminar_prandtl = 1.0
 transport.turbulent_prandtl = 1.0
 turbulence.model = Laminar

--- a/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
+++ b/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
@@ -9,6 +9,11 @@ time.checkpoint_interval           =  -100         # Steps between checkpoint fi
 incflo.mu               =   0.001       # Dynamic viscosity coefficient
 incflo.mu_s             =   0.001       # Scalar diffusion coefficient mu (mu = rho * nu)
 
+tranport.viscosity = 0.001
+transport.laminar_prandtl = 1.0
+transport.turbulent_prandtl = 1.0
+turbulence.model = Laminar
+
 amr.max_level           =   2
 time.regrid_interval          =   2
 

--- a/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.i
+++ b/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.i
@@ -9,6 +9,10 @@ time.checkpoint_interval           =  -100         # Steps between checkpoint fi
 incflo.mu               =   0.001       # Dynamic viscosity coefficient
 incflo.mu_s             =   0.001       # Scalar diffusion coefficient mu (mu = rho * nu)
 
+transport.viscosity = 0.001
+transport.laminar_prandtl = 1.0
+turbulence.model = Laminar
+
 amr.max_level           =   2
 time.regrid_interval          =   2
 

--- a/test/test_files/tgv_godunov/tgv_godunov.i
+++ b/test/test_files/tgv_godunov/tgv_godunov.i
@@ -25,6 +25,10 @@ incflo.gravity          = 0.  0.  0.  # Gravitational force (3D)
 incflo.ro_0             = 1.          # Reference density 
 incflo.mu               = 0.00009947183943        # Dynamic viscosity coefficient
 incflo.use_godunov      = 1
+transport.viscosity = 0.00009947183943 
+transport.laminar_prandtl = 1.0
+turbulence.model = Laminar
+
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#

--- a/test/test_files/tgv_godunov_plm/tgv_godunov_plm.i
+++ b/test/test_files/tgv_godunov_plm/tgv_godunov_plm.i
@@ -26,6 +26,11 @@ incflo.ro_0             = 1.          # Reference density
 incflo.mu               = 0.00009947183943        # Dynamic viscosity coefficient
 incflo.use_godunov      = 1
 incflo.use_ppm = 0
+transport.viscosity = 0.00009947183943
+transport.laminar_prandtl = 1.0
+turbulence.model = Laminar
+
+
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#

--- a/test/test_files/tgv_mol/tgv_mol.i
+++ b/test/test_files/tgv_mol/tgv_mol.i
@@ -24,6 +24,9 @@ amr.KE_int = 1        # calculate kinetic energy
 incflo.gravity          =   0.  0.  0.  # Gravitational force (3D)
 incflo.ro_0             =   1.          # Reference density 
 incflo.mu               =   0.00009947183943        # Dynamic viscosity coefficient
+transport.viscosity = 0.00009947183943
+transport.laminar_prandtl = 1.0
+turbulence.model = Laminar
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(wind_energy)
 add_subdirectory(derive)
 add_subdirectory(utilities)
 add_subdirectory(equation_systems)
+add_subdirectory(turbulence)
 
 target_include_directories(${amr_wind_unit_test_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/unit_tests/aw_test_utils/AmrTestMesh.H
+++ b/unit_tests/aw_test_utils/AmrTestMesh.H
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include "AMReX_AmrCore.H"
+#include "CFDSim.H"
 #include "FieldRepo.H"
 #include "Field.H"
 
@@ -28,6 +29,8 @@ public:
     //! Return the total number of existing levels in AMR hierarchy
     int num_levels() const { return finest_level + 1; }
 
+    amr_wind::CFDSim& sim() { return m_sim; }
+
     amr_wind::FieldRepo& field_repo() { return m_repo; }
 
 protected:
@@ -49,7 +52,8 @@ protected:
     ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
         override;
 
-    amr_wind::FieldRepo m_repo;
+    amr_wind::CFDSim m_sim;
+    amr_wind::FieldRepo& m_repo;
 };
 
 }

--- a/unit_tests/aw_test_utils/AmrTestMesh.cpp
+++ b/unit_tests/aw_test_utils/AmrTestMesh.cpp
@@ -5,7 +5,8 @@
 namespace amr_wind_tests {
 
 AmrTestMesh::AmrTestMesh()
-    : m_repo(*this)
+    : m_sim(*this)
+    , m_repo(m_sim.repo())
 {}
 
 void AmrTestMesh::initialize_mesh(amrex::Real current_time)

--- a/unit_tests/aw_test_utils/pp_utils.cpp
+++ b/unit_tests/aw_test_utils/pp_utils.cpp
@@ -39,6 +39,11 @@ void default_mesh_inputs()
         pp.addarr("prob_hi", probhi);
         pp.addarr("is_periodic", periodic);
     }
+
+    {
+        amrex::ParmParse pp("incflo");
+        pp.add("probtype", 35);
+    }
 }
 
 }

--- a/unit_tests/equation_systems/test_pde.cpp
+++ b/unit_tests/equation_systems/test_pde.cpp
@@ -17,9 +17,9 @@ TEST_F(PDETest, test_pde_create_godunov)
     amr_wind::SimTime time;
 
     auto lowmach = amr_wind::pde::PDEBase::create(
-        "ICNS-Godunov", time, mesh().field_repo(), 35);
+        "ICNS-Godunov", mesh().sim(), 35);
     auto theta = amr_wind::pde::PDEBase::create(
-        "Temperature-Godunov", time, mesh().field_repo(), 35);
+        "Temperature-Godunov", mesh().sim(), 35);
 
     EXPECT_EQ(mesh().field_repo().num_fields(), 19);
 }
@@ -30,9 +30,9 @@ TEST_F(PDETest, test_pde_create_mol)
     amr_wind::SimTime time;
 
     auto lowmach = amr_wind::pde::PDEBase::create(
-        "ICNS-MOL", time, mesh().field_repo(), 35);
+        "ICNS-MOL", mesh().sim(), 35);
     auto theta = amr_wind::pde::PDEBase::create(
-        "Temperature-MOL", time, mesh().field_repo(), 35);
+        "Temperature-MOL", mesh().sim(), 35);
 
     EXPECT_EQ(mesh().field_repo().num_fields(), 23);
 }

--- a/unit_tests/equation_systems/test_pde.cpp
+++ b/unit_tests/equation_systems/test_pde.cpp
@@ -1,11 +1,6 @@
 #include "gtest/gtest.h"
 #include "aw_test_utils/MeshTest.H"
 
-#include "PDETraits.H"
-#include "SchemeTraits.H"
-#include "PDE.H"
-#include "icns/icns_ops.H"
-
 namespace amr_wind_tests {
 
 class PDETest : public MeshTest
@@ -13,26 +8,32 @@ class PDETest : public MeshTest
 
 TEST_F(PDETest, test_pde_create_godunov)
 {
-    initialize_mesh();
-    amr_wind::SimTime time;
+    amrex::ParmParse pp("incflo");
+    pp.add("probtype", 35);
+    pp.add("use_godunov", 1);
 
-    auto lowmach = amr_wind::pde::PDEBase::create(
-        "ICNS-Godunov", mesh().sim(), 35);
-    auto theta = amr_wind::pde::PDEBase::create(
-        "Temperature-Godunov", mesh().sim(), 35);
+    initialize_mesh();
+    auto& pde_mgr = mesh().sim().pde_manager();
+    pde_mgr.register_icns();
+    pde_mgr.register_transport_pde("Temperature");
+
+    EXPECT_EQ(pde_mgr.scalar_eqns().size(), 1);
 
     EXPECT_EQ(mesh().field_repo().num_fields(), 19);
 }
 
 TEST_F(PDETest, test_pde_create_mol)
 {
-    initialize_mesh();
-    amr_wind::SimTime time;
+    amrex::ParmParse pp("incflo");
+    pp.add("probtype", 35);
+    pp.add("use_godunov", 0);
 
-    auto lowmach = amr_wind::pde::PDEBase::create(
-        "ICNS-MOL", mesh().sim(), 35);
-    auto theta = amr_wind::pde::PDEBase::create(
-        "Temperature-MOL", mesh().sim(), 35);
+    initialize_mesh();
+    auto& pde_mgr = mesh().sim().pde_manager();
+    pde_mgr.register_icns();
+    pde_mgr.register_transport_pde("Temperature");
+
+    EXPECT_EQ(pde_mgr.scalar_eqns().size(), 1);
 
     EXPECT_EQ(mesh().field_repo().num_fields(), 23);
 }

--- a/unit_tests/turbulence/CMakeLists.txt
+++ b/unit_tests/turbulence/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${amr_wind_unit_test_exe_name}
+  PRIVATE
+
+  test_turbulence_init.cpp
+  )

--- a/unit_tests/turbulence/test_turbulence_init.cpp
+++ b/unit_tests/turbulence/test_turbulence_init.cpp
@@ -1,0 +1,17 @@
+#include "gtest/gtest.h"
+#include "aw_test_utils/MeshTest.H"
+#include "TurbulenceModel.H"
+
+namespace amr_wind_tests {
+
+class TurbTest : public MeshTest
+{};
+
+TEST_F(TurbTest, test_turb_create)
+{
+    initialize_mesh();
+
+    amr_wind::turbulence::TurbulenceModel::print(std::cout);
+}
+
+}


### PR DESCRIPTION
This pull request includes a proposal for a design of turbulence model interface within `amr-wind`. This is in preparation for inclusion of k-sgs, k-omega SST/SAS models within AMR-wind codebase for wind applications. 

The turbulence API is declared by `TurbulenceModel` class. To allow for different fluid properties (and, in future, air-water interface with offshore applications), a TransportModel class is introduced that handles the fluid properties. All turbulence models are templated on the transport model for future extensions. Currently, only a constant transport model is implemented (constant viscosity and Prandtl number used to compute thermal diffusivity). A _laminar_ model is introduced to allow for same API to be used for simulations without any turbulence models. 

The base code has also been refactored to include a `CFDSim` object that can manage the interactions between PDE systems, turbulence model, and the physics models. 