### PR TITLE
variable viscosity CFL

### DIFF
--- a/src/core/SimTime.H
+++ b/src/core/SimTime.H
@@ -100,6 +100,9 @@ public:
     AMREX_FORCE_INLINE
     bool adaptive_timestep() const { return m_adaptive; }
 
+    AMREX_FORCE_INLINE
+    bool use_force_cfl() const { return m_use_force_cfl; }
+
     //! Read user defined options from input file
     void parse_parameters();
 
@@ -157,6 +160,10 @@ private:
 
     //! Flag indicating if this is initialization
     bool m_is_init{true};
+
+    //! Flag indicating if forcing should be included in CFL calculation
+    bool m_use_force_cfl{false};
+
 };
 
 } // namespace amr_wind

--- a/src/core/SimTime.cpp
+++ b/src/core/SimTime.cpp
@@ -23,6 +23,7 @@ void SimTime::parse_parameters()
     pp.query("regrid_interval", m_regrid_interval);
     pp.query("plot_interval", m_plt_interval);
     pp.query("checkpoint_interval", m_chkpt_interval);
+    pp.query("use_force_cfl", m_use_force_cfl);
 
     if (m_fixed_dt > 0.0) {
         m_dt[0] = m_fixed_dt;

--- a/src/incflo_compute_dt.cpp
+++ b/src/incflo_compute_dt.cpp
@@ -22,74 +22,103 @@ using namespace amrex;
 //
 // WARNING: We use a slightly modified version of C in the implementation below
 //
-void incflo::ComputeDt (bool explicit_diffusion)
+void incflo::ComputeDt(bool explicit_diffusion)
 {
     BL_PROFILE("amr-wind::incflo::ComputeDt")
 
     Real conv_cfl = 0.0;
     Real diff_cfl = 0.0;
-    for (int lev = 0; lev <= finest_level; ++lev)
-    {
+    Real force_cfl = 0.0;
+
+    const auto& den = density();
+
+    for (int lev = 0; lev <= finest_level; ++lev) {
         auto const dxinv = geom[lev].InvCellSizeArray();
-        MultiFab const& vel = velocity()(lev);
-        MultiFab const& rho = density()(lev);
+        MultiFab const& vel = icns().fields().field(lev);
+        MultiFab const& vel_force = icns().fields().src_term(lev);
+        MultiFab const& mu = icns().fields().mueff(lev);
+        MultiFab const& rho = den(lev);
+
         Real conv_lev = 0.0;
         Real diff_lev = 0.0;
+        Real force_lev = 0.0;
 
-        conv_lev = amrex::ReduceMax(vel, 0,
-                   [=] AMREX_GPU_HOST_DEVICE (Box const& b,
-                                              Array4<Real const> const& v) -> Real
-                   {
-                       Real mx = -1.0;
-                       amrex::Loop(b, [=,&mx] (int i, int j, int k) noexcept
-                       {
-                           mx = amrex::max(std::abs(v(i,j,k,0))*dxinv[0],
-                                           std::abs(v(i,j,k,1))*dxinv[1],
-                                           std::abs(v(i,j,k,2))*dxinv[2], mx);
-                       });
-                       return mx;
-                   });
+        conv_lev = amrex::ReduceMax(
+            vel, 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                Box const& b, Array4<Real const> const& v) -> Real {
+                Real mx = -1.0;
+                amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
+                    mx = amrex::max(
+                        std::abs(v(i, j, k, 0)) * dxinv[0],
+                        std::abs(v(i, j, k, 1)) * dxinv[1],
+                        std::abs(v(i, j, k, 2)) * dxinv[2], mx);
+                });
+                return mx;
+            });
+
         if (explicit_diffusion) {
-            diff_lev = amrex::ReduceMax(rho, 0,
-                       [=] AMREX_GPU_HOST_DEVICE (Box const& b,
-                                                  Array4<Real const> const& r) -> Real
-                       {
-                           Real mx = -1.0;
-                           amrex::Loop(b, [=,&mx] (int i, int j, int k) noexcept
-                           {
-                               mx = amrex::max(1.0/r(i,j,k), mx);
-                           });
-                           return mx;
-                       });
-            diff_lev *= m_mu;
+            diff_lev = amrex::ReduceMax(
+                rho, mu, 0,
+                [=] AMREX_GPU_HOST_DEVICE(
+                    Box const& b, Array4<Real const> const& rho_arr,
+                    Array4<Real const> const& mu_arr) -> Real {
+                    Real mx = -1.0;
+                    amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
+                        mx = amrex::max(
+                            2.0 * mu_arr(i, j, k) *
+                                (dxinv[0] * dxinv[0] + dxinv[1] * dxinv[1] +
+                                 dxinv[2] * dxinv[2]) /
+                                rho_arr(i, j, k),
+                            mx);
+                    });
+                    return mx;
+                });
         }
-        
+
+        if (m_time.use_force_cfl()) {
+            force_lev = amrex::ReduceMax(
+                vel_force, 0,
+                [=] AMREX_GPU_HOST_DEVICE(
+                    Box const& b, Array4<Real const> const& vf) -> Real {
+                    Real mx = -1.0;
+                    amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
+                        mx = amrex::max(
+                            std::abs(vf(i, j, k, 0)) * dxinv[0],
+                            std::abs(vf(i, j, k, 1)) * dxinv[1],
+                            std::abs(vf(i, j, k, 2)) * dxinv[2], mx);
+                    });
+                    return mx;
+                });
+        }
+
         conv_cfl = std::max(conv_cfl, conv_lev);
-        diff_cfl = std::max(diff_cfl, diff_lev*2.*(dxinv[0]*dxinv[0]+dxinv[1]*dxinv[1]+
-                                                   dxinv[2]*dxinv[2]));
+        diff_cfl = std::max(diff_cfl, diff_lev);
+        force_cfl = std::max(force_cfl, force_lev);
     }
 
-    Real cd_cfl;
+    ParallelAllReduce::Max<Real>(conv_cfl, ParallelContext::CommunicatorSub());
     if (explicit_diffusion) {
-        ParallelAllReduce::Max<Real>({conv_cfl,diff_cfl},
-                                     ParallelContext::CommunicatorSub());
-        cd_cfl = conv_cfl + diff_cfl;
-    } else {
-        ParallelAllReduce::Max<Real>(conv_cfl,
-                                     ParallelContext::CommunicatorSub());
-        cd_cfl = conv_cfl;
+        ParallelAllReduce::Max<Real>(
+            diff_cfl, ParallelContext::CommunicatorSub());
+    }
+    if (m_time.use_force_cfl()) {
+        ParallelAllReduce::Max<Real>(
+            force_cfl, ParallelContext::CommunicatorSub());
     }
 
-    // Forcing term
-    const auto dxinv_finest = Geom(finest_level).InvCellSizeArray();
-    // fixme should we use forces in our dt estimate?
-    // abl_godunov_explicit regression test will fail if this is deleted
-    Real forc_cfl = std::abs(m_gravity[0] - std::abs(m_gp0[0])) * dxinv_finest[0]
-                  + std::abs(m_gravity[1] - std::abs(m_gp0[1])) * dxinv_finest[1]
-                  + std::abs(m_gravity[2] - std::abs(m_gp0[2])) * dxinv_finest[2];
+    const Real cd_cfl = conv_cfl + diff_cfl;
 
     // Combined CFL conditioner
-    Real comb_cfl = cd_cfl + std::sqrt(cd_cfl*cd_cfl + 4.0 * forc_cfl);
+    const Real comb_cfl =
+        2.0 * cd_cfl + std::sqrt(cd_cfl * cd_cfl + 4.0 * force_cfl);
+
+    if (m_verbose > 2)
+    {
+        amrex::Print() << "conv_cfl: " << conv_cfl << " diff_cfl: " << diff_cfl
+                       << " force_cfl: " << force_cfl
+                       << " comb_cfl: " << comb_cfl << std::endl;
+    }
 
     m_time.set_current_cfl(comb_cfl);
 }


### PR DESCRIPTION
- modified the CFL to account for variable viscosity
- added an input that turns on/off using variable forcing in CFL calculation
- preliminary testing looks like with explicit diffusion we can run at a max CFL=2 and with implicit diffusion at a max CFL=5, just because we can doesn't mean we should since Godunov is probably robust enough to go beyond what we want for accuracy. So currently we still require CFL <= 1, unless further testing is done. 
- warning this will tweak the abl_godunov_explicit regression test since it does not use a fixed dt, need to rebless gold files and time this with @jrood-nrel 
