### PR TITLE
Init log law

### DIFF
--- a/src/wind_energy/ABL.cpp
+++ b/src/wind_energy/ABL.cpp
@@ -54,6 +54,12 @@ void ABL::post_init_actions()
 {
     m_abl_wall_func.init_log_law_height();
 
+    m_pa(
+        m_sim.mesh().Geom(), m_density.vec_ptrs(), m_velocity.vec_ptrs(),
+        m_mueff.vec_ptrs(), m_temperature->vec_ptrs());
+
+    m_abl_wall_func.update_umean(m_pa);
+
     // Register ABL wall function for velocity
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
 }

--- a/src/wind_energy/ABLWallFunction.cpp
+++ b/src/wind_energy/ABLWallFunction.cpp
@@ -32,20 +32,6 @@ void ABLWallFunction::init_log_law_height()
         const auto& geom = m_mesh.Geom(0);
         m_log_law_height = (geom.ProbLo(m_direction) + 0.5 * geom.CellSize(m_direction));
     }
-    {
-        // fixme keeping this around to maintain perfect
-        // machine zero reg tests
-        // eventually turn on pre_advance_work in InitialIterations() and delete this... or make a pre_timestep_work function?
-        auto geom = m_mesh.Geom();
-        amrex::ParmParse pp("incflo");
-        amrex::Vector<amrex::Real> vel{{0.0, 0.0, 0.0}};
-        pp.queryarr("velocity", vel);
-        m_umean[0] = vel[0];
-        m_umean[1] = vel[1];
-        m_umean[2] = vel[2];
-        const amrex::Real uground = utils::vec_mag(m_umean.data());
-        m_utau = m_kappa * uground / std::log(m_log_law_height / m_z0);
-    }
 }
 
 void ABLWallFunction::update_umean(const PlaneAveraging& pa)


### PR DESCRIPTION
- Removed freestream init and now use plane average to init umean and utau
- This will cause very small diffs (1e-15) in reg tests, coordinate with @jrood-nrel before merging