### PR TITLE
Overset: Prepare FieldRepo for overset - iblank field handling

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${amr_wind_lib_name}
   SimTime.cpp
 
   Field.cpp
+  IntField.cpp
   FieldRepo.cpp
   )
 

--- a/src/core/FieldRepo.H
+++ b/src/core/FieldRepo.H
@@ -7,10 +7,12 @@
 #include "FieldDescTypes.H"
 #include "FieldUtils.H"
 #include "Field.H"
+#include "IntField.H"
 #include "ScratchField.H"
 
 #include "AMReX_AmrCore.H"
 #include "AMReX_MultiFab.H"
+#include "AMReX_iMultiFab.H"
 
 namespace amr_wind {
 
@@ -20,8 +22,14 @@ struct LevelDataHolder
 {
     LevelDataHolder();
 
+    //! real multifabs for all the known fields at this level
     amrex::Vector<amrex::MultiFab> m_mfabs;
+    //! Factory for creating new FABs
     std::unique_ptr<amrex::FabFactory<amrex::FArrayBox>> m_factory;
+
+    //! int fabs for all known fields at this level
+    amrex::Vector<amrex::iMultiFab> m_int_fabs;
+    std::unique_ptr<amrex::FabFactory<amrex::IArrayBox>> m_int_fact;
 };
 
 /** Field Repository
@@ -60,8 +68,7 @@ class FieldRepo
 {
 public:
     friend class Field;
-
-    using FieldMap = std::unordered_map<std::string, std::unique_ptr<Field>>;
+    friend class IntField;
 
     FieldRepo(const amrex::AmrCore& mesh)
         : m_mesh(mesh)
@@ -208,6 +215,19 @@ public:
     bool field_exists(
         const std::string& name, const FieldState fstate = FieldState::New) const;
 
+    IntField& declare_int_field(
+        const std::string& name,
+        const int ncomp = 1,
+        const int ngrow = 0,
+        const int nstates = 1,
+        const FieldLoc floc = FieldLoc::CELL);
+
+    IntField& get_int_field(
+        const std::string& name, const FieldState fstate = FieldState::New) const;
+
+    bool int_field_exists(
+        const std::string& name, const FieldState fstate = FieldState::New) const;
+
     std::unique_ptr<ScratchField> create_scratch_field(
         const std::string& name,
         const int ncomp = 1,
@@ -249,6 +269,12 @@ protected:
         return m_leveldata[lev]->m_mfabs[fid];
     }
 
+    inline amrex::iMultiFab& get_int_fab(const unsigned fid, const int lev) noexcept
+    {
+        BL_ASSERT(lev <= m_mesh.finestLevel());
+        return m_leveldata[lev]->m_int_fabs[fid];
+    }
+
     Field& create_state(Field& field, const FieldState fstate) noexcept;
 
     //! Allocate field data for a single level outside of regrid
@@ -268,6 +294,16 @@ protected:
         LevelDataHolder& fdata,
         const amrex::FabFactory<amrex::FArrayBox>& factory);
 
+    void allocate_field_data(int lev, IntField& field, LevelDataHolder& fdata);
+
+    void allocate_field_data(IntField& field);
+
+    void allocate_field_data(
+        const amrex::BoxArray& ba,
+        const amrex::DistributionMapping& dm,
+        LevelDataHolder& fdata,
+        const amrex::FabFactory<amrex::IArrayBox>& factory);
+
     //! Reference to the mesh instance
     const amrex::AmrCore& m_mesh;
 
@@ -278,8 +314,14 @@ protected:
     //! References to field instances identified by unique integer
     mutable amrex::Vector<std::unique_ptr<Field>> m_field_vec;
 
+    //! Reference to integer field instances identified by unique integer
+    mutable amrex::Vector<std::unique_ptr<IntField>> m_int_field_vec;
+
     //! Map of field name to unique integer ID for lookups
     std::unordered_map<std::string, size_t> m_fid_map;
+
+    //! Map of integer field name to unique integer ID for lookups
+    std::unordered_map<std::string, size_t> m_int_fid_map;
 
     //! Flag indicating if mesh is available to allocate field data
     bool m_is_initialized{false};

--- a/src/core/FieldRepo.H
+++ b/src/core/FieldRepo.H
@@ -18,7 +18,10 @@ namespace amr_wind {
  */
 struct LevelDataHolder
 {
+    LevelDataHolder();
+
     amrex::Vector<amrex::MultiFab> m_mfabs;
+    std::unique_ptr<amrex::FabFactory<amrex::FArrayBox>> m_factory;
 };
 
 /** Field Repository
@@ -63,7 +66,6 @@ public:
     FieldRepo(const amrex::AmrCore& mesh)
         : m_mesh(mesh)
         , m_leveldata(mesh.maxLevel() + 1)
-        , m_factory(mesh.maxLevel() + 1)
     {}
 
     FieldRepo(const FieldRepo&) = delete;
@@ -233,7 +235,7 @@ public:
 
     //! Return factory instance at a given level
     inline const amrex::FabFactory<amrex::FArrayBox>&
-    factory(int lev) const noexcept { return *m_factory[lev]; }
+    factory(int lev) const noexcept { return *m_leveldata[lev]->m_factory; }
 
 protected:
     /** Return the amrex::MultiFab instance for a field at a given level
@@ -272,9 +274,6 @@ protected:
     //! Array (size: nlevels) of data holder that contains another array of
     //! MultiFabs for all fields at that level.
     amrex::Vector<std::unique_ptr<LevelDataHolder>> m_leveldata;
-
-    //! Array of Factory objects at all levels
-    amrex::Vector<std::unique_ptr<amrex::FabFactory<amrex::FArrayBox>>> m_factory;
 
     //! References to field instances identified by unique integer
     mutable amrex::Vector<std::unique_ptr<Field>> m_field_vec;

--- a/src/core/FieldRepo.cpp
+++ b/src/core/FieldRepo.cpp
@@ -4,6 +4,7 @@ namespace amr_wind {
 
 LevelDataHolder::LevelDataHolder()
     : m_factory(new amrex::FArrayBoxFactory())
+    , m_int_fact(new amrex::DefaultFabFactory<amrex::IArrayBox>())
 {}
 
 void FieldRepo::make_new_level_from_scratch(
@@ -15,6 +16,7 @@ void FieldRepo::make_new_level_from_scratch(
     m_leveldata[lev].reset(new LevelDataHolder());
 
     allocate_field_data(ba, dm, *m_leveldata[lev], *(m_leveldata[lev]->m_factory));
+    allocate_field_data(ba, dm, *m_leveldata[lev], *(m_leveldata[lev]->m_int_fact));
 
     m_is_initialized = true;
 }
@@ -28,6 +30,7 @@ void FieldRepo::make_new_level_from_coarse(
     std::unique_ptr<LevelDataHolder> ldata(new LevelDataHolder());
 
     allocate_field_data(ba, dm, *ldata, *(ldata->m_factory));
+    allocate_field_data(ba, dm, *ldata, *(ldata->m_int_fact));
 
     for (auto& field: m_field_vec) {
         if (!field->fillpatch_on_regrid()) continue;
@@ -48,6 +51,7 @@ void FieldRepo::remake_level(
     std::unique_ptr<LevelDataHolder> ldata(new LevelDataHolder());
 
     allocate_field_data(ba, dm, *ldata, *(ldata->m_factory));
+    allocate_field_data(ba, dm, *ldata, *(ldata->m_int_fact));
 
     for (auto& field: m_field_vec) {
         if (!field->fillpatch_on_regrid()) continue;
@@ -147,6 +151,81 @@ bool FieldRepo::field_exists(
     return (found != m_fid_map.end());
 }
 
+IntField& FieldRepo::declare_int_field(
+    const std::string& name,
+    const int ncomp,
+    const int ngrow,
+    const int nstates,
+    const FieldLoc floc)
+{
+    BL_PROFILE("amr-wind::FieldRepo::declare_int_field")
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        nstates == 1,
+        "Multiple states not supported for integer fields"
+    );
+
+    // If the field is already registered check and return the fields
+    {
+        auto found = m_int_fid_map.find(name);
+        if (found != m_int_fid_map.end()) {
+            auto& field = *m_int_field_vec[found->second];
+
+            if ((ncomp != field.num_comp()) ||
+                (floc != field.field_location())) {
+                amrex::Abort("Attempt to reregister field with inconsistent parameters: "
+                             + name);
+            }
+            return field;
+        }
+    }
+
+    if (!field_impl::is_valid_field_name(name)) {
+        amrex::Abort("Attempt to use reserved field name: " + name);
+    }
+
+    {
+        const FieldState fstate = FieldState::New;
+        const std::string fname =
+            field_impl::field_name_with_state(name, fstate);
+        const int fid = m_int_field_vec.size();
+
+        std::unique_ptr<IntField> field(
+            new IntField(*this, fname, fid, ncomp, ngrow, floc));
+
+        if (m_is_initialized)
+            allocate_field_data(*field);
+
+        m_int_field_vec.emplace_back(std::move(field));
+        m_int_fid_map[fname] = fid;
+    }
+
+    return *m_int_field_vec[m_int_fid_map[name]];
+}
+
+IntField& FieldRepo::get_int_field(
+    const std::string& name, const FieldState fstate) const
+{
+    BL_PROFILE("amr-wind::FieldRepo::get_int_field")
+    AMREX_ALWAYS_ASSERT(fstate == FieldState::New);
+    const auto fname = field_impl::field_name_with_state(name, fstate);
+    const auto found = m_int_fid_map.find(fname);
+    if (found == m_int_fid_map.end()) {
+        amrex::Abort("Cannot find field: " + name);
+    }
+
+    AMREX_ASSERT(found->second < static_cast<unsigned>(m_int_field_vec.size()));
+    return *m_int_field_vec[found->second];
+}
+
+bool FieldRepo::int_field_exists(
+    const std::string& name, const FieldState fstate) const
+{
+    AMREX_ALWAYS_ASSERT(fstate == FieldState::New);
+    const auto fname = field_impl::field_name_with_state(name, fstate);
+    const auto found = m_int_fid_map.find(fname);
+    return (found != m_int_fid_map.end());
+}
+
 std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
     const std::string& name, const int ncomp, const int nghost, const FieldLoc floc) const
 {
@@ -223,6 +302,48 @@ void FieldRepo::allocate_field_data(Field& field)
 {
     for (int lev=0; lev <= m_mesh.finestLevel(); ++lev) {
         allocate_field_data(lev, field, *m_leveldata[lev], *(m_leveldata[lev]->m_factory));
+    }
+}
+
+void FieldRepo::allocate_field_data(
+    const amrex::BoxArray& ba,
+    const amrex::DistributionMapping& dm,
+    LevelDataHolder& level_data,
+    const amrex::FabFactory<amrex::IArrayBox>& factory)
+{
+    auto& fab_vec = level_data.m_int_fabs;
+
+    for (auto& field : m_int_field_vec) {
+        auto ba1 =
+            amrex::convert(ba, field_impl::index_type(field->field_location()));
+
+        fab_vec.emplace_back(
+            ba1, dm, field->num_comp(), field->num_grow(), amrex::MFInfo(),
+            factory);
+    }
+}
+
+
+void FieldRepo::allocate_field_data(
+    int lev,
+    IntField& field,
+    LevelDataHolder& level_data)
+{
+    auto& fab_vec = level_data.m_int_fabs;
+    AMREX_ASSERT(fab_vec.size() == field.id());
+
+    const auto ba = amrex::convert(
+        m_mesh.boxArray(lev), field_impl::index_type(field.field_location()));
+
+    fab_vec.emplace_back(
+        ba, m_mesh.DistributionMap(lev), field.num_comp(), field.num_grow(),
+        amrex::MFInfo(), *level_data.m_int_fact);
+}
+
+void FieldRepo::allocate_field_data(IntField& field)
+{
+    for (int lev=0; lev <= m_mesh.finestLevel(); ++lev) {
+        allocate_field_data(lev, field, *m_leveldata[lev]);
     }
 }
 

--- a/src/core/IntField.H
+++ b/src/core/IntField.H
@@ -1,0 +1,72 @@
+#ifndef INTFIELD_H
+#define INTFIELD_H
+
+#include <string>
+
+#include "FieldDescTypes.H"
+
+#include "AMReX_iMultiFab.H"
+
+namespace amr_wind {
+
+class FieldRepo;
+
+class IntField
+{
+public:
+    friend class FieldRepo;
+
+    IntField(const IntField&) = delete;
+    IntField& operator=(const IntField&) = delete;
+
+    //! Name of the field
+    inline const std::string& name() const { return m_name; }
+
+    //! Unique integer ID for this field
+    inline unsigned id() const { return m_id; }
+
+    //! Number of components for this field
+    inline int num_comp() const { return m_ncomp; }
+
+    //! Number of ghost cells
+    inline const amrex::IntVect& num_grow() const { return m_ngrow; }
+
+    //! Location of the field
+    inline FieldLoc field_location() const { return m_floc; }
+
+    //! Reference to the FieldRepo that holds the fabs
+    const FieldRepo& repo() const { return m_repo; }
+
+    //! Access the FAB at a given level
+    amrex::iMultiFab& operator()(int lev) noexcept;
+    const amrex::iMultiFab& operator()(int lev) const noexcept;
+
+    amrex::Vector<amrex::iMultiFab*> vec_ptrs() noexcept;
+
+    amrex::Vector<const amrex::iMultiFab*> vec_const_ptrs() const noexcept;
+
+protected:
+    IntField(
+        FieldRepo& repo,
+        const std::string& name,
+        const unsigned fid,
+        const int ncomp = 1,
+        const int ngrow = 1,
+        const FieldLoc floc = FieldLoc::CELL);
+
+    FieldRepo& m_repo;
+
+    std::string m_name;
+
+    const unsigned m_id;
+
+    int m_ncomp;
+
+    amrex::IntVect m_ngrow;
+
+    FieldLoc m_floc;
+};
+
+} // namespace amr_wind
+
+#endif /* INTFIELD_H */

--- a/src/core/IntField.H
+++ b/src/core/IntField.H
@@ -45,6 +45,12 @@ public:
 
     amrex::Vector<const amrex::iMultiFab*> vec_const_ptrs() const noexcept;
 
+    void setVal(int value) noexcept;
+
+    void setVal(int value, int start_comp, int num_comp=1, int nghost=0) noexcept;
+
+    void setVal(const amrex::Vector<int>& values, int nghost=0) noexcept;
+
 protected:
     IntField(
         FieldRepo& repo,

--- a/src/core/IntField.cpp
+++ b/src/core/IntField.cpp
@@ -1,0 +1,56 @@
+#include "IntField.H"
+#include "FieldRepo.H"
+
+namespace amr_wind {
+
+IntField::IntField(
+    FieldRepo& repo,
+    const std::string& name,
+    const unsigned fid,
+    const int ncomp,
+    const int ngrow,
+    const FieldLoc floc)
+    : m_repo(repo)
+    , m_name(name)
+    , m_id(fid)
+    , m_ncomp(ncomp)
+    , m_ngrow(ngrow)
+    , m_floc(floc)
+{}
+
+amrex::iMultiFab& IntField::operator()(int lev) noexcept
+{
+    AMREX_ASSERT(lev < m_repo.num_active_levels());
+    return m_repo.get_int_fab(m_id, lev);
+}
+
+const amrex::iMultiFab& IntField::operator()(int lev) const noexcept
+{
+    AMREX_ASSERT(lev < m_repo.num_active_levels());
+    return m_repo.get_int_fab(m_id, lev);
+}
+
+amrex::Vector<amrex::iMultiFab*> IntField::vec_ptrs() noexcept
+{
+    const int nlevels = m_repo.num_active_levels();
+    amrex::Vector<amrex::iMultiFab*> ret;
+    ret.reserve(nlevels);
+    for (int lev = 0; lev < nlevels; ++lev) {
+        ret.push_back(&m_repo.get_int_fab(m_id, lev));
+    }
+    return ret;
+}
+
+amrex::Vector<const amrex::iMultiFab*> IntField::vec_const_ptrs() const noexcept
+{
+    const int nlevels = m_repo.num_active_levels();
+    amrex::Vector<const amrex::iMultiFab*> ret;
+    ret.reserve(nlevels);
+    for (int lev = 0; lev < nlevels; ++lev) {
+        ret.push_back(static_cast<const amrex::iMultiFab*>(
+                          &m_repo.get_int_fab(m_id, lev)));
+    }
+    return ret;
+}
+
+} // namespace amr_wind

--- a/src/core/IntField.cpp
+++ b/src/core/IntField.cpp
@@ -53,4 +53,36 @@ amrex::Vector<const amrex::iMultiFab*> IntField::vec_const_ptrs() const noexcept
     return ret;
 }
 
+void IntField::setVal(int value) noexcept
+{
+    BL_PROFILE("amr-wind::IntField::setVal 1")
+    for (int lev=0; lev < m_repo.num_active_levels(); ++lev) {
+        operator()(lev).setVal(value);
+    }
+}
+
+void IntField::setVal(int value, int start_comp, int num_comp, int nghost) noexcept
+{
+    BL_PROFILE("amr-wind::IntField::setVal 2")
+    for (int lev=0; lev < m_repo.num_active_levels(); ++lev) {
+        operator()(lev).setVal(value, start_comp, num_comp, nghost);
+    }
+}
+
+void IntField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
+{
+    BL_PROFILE("amr-wind::IntField::setVal 3")
+    AMREX_ASSERT(num_comp() == static_cast<int>(values.size()));
+
+    // Update 1 component at a time
+    const int ncomp = 1;
+    for (int lev=0; lev < m_repo.num_active_levels(); ++lev) {
+        auto& mf = operator()(lev);
+        for (int ic=0; ic < num_comp(); ++ic) {
+            int value = values[ic];
+            mf.setVal(value, ic, ncomp, nghost);
+        }
+    }
+}
+
 } // namespace amr_wind

--- a/unit_tests/core/test_field.cpp
+++ b/unit_tests/core/test_field.cpp
@@ -298,4 +298,27 @@ TEST_F(FieldRepoTest, scratch_fields)
     }
 }
 
+TEST_F(FieldRepoTest, int_fields)
+{
+    initialize_mesh();
+
+    auto& frepo = mesh().field_repo();
+    auto& ibcell = frepo.declare_int_field("iblank_cell", 1, 0, 1);
+    auto& ibnode = frepo.declare_int_field(
+        "iblank_node", 1, 0, 1, amr_wind::FieldLoc::NODE);
+
+    const int nlevels = frepo.num_active_levels();
+    for (int lev=0; lev < nlevels; ++lev) {
+        ibcell(lev).setVal(1);
+        ibnode(lev).setVal(0);
+    }
+
+    for (int lev=0; lev < nlevels; ++lev) {
+        EXPECT_EQ(ibcell(lev).max(0), 1);
+        EXPECT_EQ(ibcell(lev).min(0), 1);
+        EXPECT_EQ(ibnode(lev).max(0), 0);
+        EXPECT_EQ(ibnode(lev).min(0), 0);
+    }
+}
+
 }


### PR DESCRIPTION
In preparation for introducing overset capability within amr-wind, this adds the ability to register and access integer fields from FieldRepo, and introduces a new class `IntField` to manage access to these `iMultiFab` collections

- Currently, integer fields have no state, but the declare interface allows that for future extension
- The API for IntField mimics that of `Field` without the BC stuff. 