### PR TITLE
Allow fillpatch operation on any field

### DIFF
--- a/src/boundary_conditions/BCInterface.H
+++ b/src/boundary_conditions/BCInterface.H
@@ -91,6 +91,27 @@ protected:
     }
 };
 
+class BCFillPatchExtrap : public BCIface
+{
+public:
+    BCFillPatchExtrap(
+        Field& field,
+        amrex::BCType::mathematicalBndryTypes bctype = amrex::BCType::hoextrap)
+        : BCIface(field)
+        , m_extrap_type(bctype)
+    {}
+
+protected:
+    virtual void set_bcrec() override;
+    virtual void read_values() override
+    {
+        // No values specified for source terms. empty method to satisfy
+        // inheritance
+    }
+
+    amrex::BCType::mathematicalBndryTypes m_extrap_type;
+};
+
 } // namespace amr_wind
 
 #endif /* BCINTERFACE_H */

--- a/src/boundary_conditions/BCInterface.cpp
+++ b/src/boundary_conditions/BCInterface.cpp
@@ -323,4 +323,31 @@ void BCSrcTerm::set_bcrec()
     }
 }
 
+void BCFillPatchExtrap::set_bcrec()
+{
+    auto& ibctype = m_field.bc_type();
+    for (amrex::OrientationIter oit; oit; ++oit) {
+        auto ori = oit();
+        const auto side = ori.faceDir();
+        const auto bct = ibctype[ori];
+        const int dir = ori.coordDir();
+
+        switch (bct) {
+        case BC::periodic:
+            if (side == amrex::Orientation::low)
+                set_bcrec_lo(dir, amrex::BCType::int_dir);
+            else
+                set_bcrec_hi(dir, amrex::BCType::int_dir);
+            break;
+
+        default:
+            if (side == amrex::Orientation::low)
+                set_bcrec_lo(dir, m_extrap_type);
+            else
+                set_bcrec_hi(dir, m_extrap_type);
+            break;
+        }
+    }
+}
+
 } // namespace amr_wind

--- a/src/core/Field.H
+++ b/src/core/Field.H
@@ -18,6 +18,7 @@ class Field;
 class FieldRepo;
 class FieldFillPatchOpsBase;
 class FieldBCIface;
+class SimTime;
 
 /** Information common to a field that has multiple states
  */
@@ -35,6 +36,7 @@ struct FieldInfo
 
     ~FieldInfo();
 
+    //! Check indicating whether BCs are being set to sane values
     bool bc_initialized();
 
     //! Copy the BC information to device data structures
@@ -75,6 +77,7 @@ struct FieldInfo
     //! Custom boundary condition actions for this field
     amrex::Vector<std::unique_ptr<FieldBCIface>> m_bc_func;
 
+    //! Flag indicating whether BCs have been initialized and copied to device
     bool m_bc_copied_to_device{false};
 };
 
@@ -186,6 +189,30 @@ public:
     //! The data must have been created on host using the host arrays
     //!
     inline void copy_bc_to_device() { m_info->copy_bc_to_device(); }
+
+    //! Return flag indicating whether BCs have been initialized
+    inline bool bc_initialized() const
+    {
+        return m_info->m_bc_copied_to_device;
+    }
+
+    //! Return a flag indicating whether a fillpatch Op has been registered
+    inline bool has_fillpatch_op() const
+    {
+        return static_cast<bool>(m_info->m_fillpatch_op);
+    }
+
+    /** Setup default BC conditions for fillpatch operations
+     *
+     *  This method initializes the necessary BC data on the field so that a
+     *  fillpatch call will interpolations on periodic faces and extrapolation
+     *  on all the other boundaries. This method is useful for use with derived
+     *  quantities where we still require some fill patch operations.
+     */
+    void set_default_fillpatch_bc(
+        const SimTime& time,
+        const amrex::BCType::mathematicalBndryTypes bctype =
+            amrex::BCType::hoextrap) noexcept;
 
     //! Return field at a different time state
     Field& state(const FieldState fstate);

--- a/src/core/Field.H
+++ b/src/core/Field.H
@@ -35,6 +35,8 @@ struct FieldInfo
 
     ~FieldInfo();
 
+    bool bc_initialized();
+
     //! Copy the BC information to device data structures
     void copy_bc_to_device() noexcept;
 
@@ -72,6 +74,8 @@ struct FieldInfo
 
     //! Custom boundary condition actions for this field
     amrex::Vector<std::unique_ptr<FieldBCIface>> m_bc_func;
+
+    bool m_bc_copied_to_device{false};
 };
 
 /** Computational field
@@ -171,10 +175,10 @@ public:
     //! Return reference to host view of BCRec array
     amrex::Vector<amrex::BCRec>& bcrec() { return m_info->m_bcrec; }
 
-    amrex::GpuArray<const amrex::Real*, AMREX_SPACEDIM*2>& bc_values_device()
+    const amrex::GpuArray<const amrex::Real*, AMREX_SPACEDIM*2>& bc_values_device() const
     { return m_info->m_bc_values_d; }
 
-    amrex::Gpu::DeviceVector<amrex::BCRec>& bcrec_device()
+    const amrex::Gpu::DeviceVector<amrex::BCRec>& bcrec_device() const
     { return m_info->m_bcrec_d; }
 
     //! Copy BC data from host to device

--- a/src/core/Field.cpp
+++ b/src/core/Field.cpp
@@ -2,6 +2,8 @@
 #include "FieldRepo.H"
 #include "FieldFillPatchOps.H"
 #include "FieldBCOps.H"
+#include "BCInterface.H"
+#include "SimTime.H"
 
 namespace amr_wind {
 
@@ -283,6 +285,22 @@ void Field::setVal(const amrex::Vector<amrex::Real>& values, int nghost) noexcep
             amrex::Real value = values[ic];
             mf.setVal(value, ic, ncomp, nghost);
         }
+    }
+}
+
+void Field::set_default_fillpatch_bc(
+    const SimTime& time,
+    amrex::BCType::mathematicalBndryTypes bctype) noexcept
+{
+    if (!m_info->bc_initialized()) {
+        BCFillPatchExtrap bc_op(*this, bctype);
+        bc_op();
+    }
+
+    if (!m_info->m_fillpatch_op) {
+        const int probtype = 0;
+        register_fill_patch_op<FieldFillPatchOps<FieldBCNoOp>>(
+            repo().mesh(), time, probtype);
     }
 }
 

--- a/unit_tests/core/test_field.cpp
+++ b/unit_tests/core/test_field.cpp
@@ -321,4 +321,21 @@ TEST_F(FieldRepoTest, int_fields)
     }
 }
 
+TEST_F(FieldRepoTest, default_fillpatch_op)
+{
+    initialize_mesh();
+    auto& frepo = mesh().field_repo();
+
+    auto& velocity = frepo.declare_field("vel", 3, 1);
+    EXPECT_FALSE(velocity.bc_initialized());
+    EXPECT_FALSE(velocity.has_fillpatch_op());
+
+    velocity.set_default_fillpatch_bc(sim().time());
+    EXPECT_TRUE(velocity.bc_initialized());
+    EXPECT_TRUE(velocity.has_fillpatch_op());
+
+    velocity.setVal({10.0, 20.0, 30.0}, 0);
+    velocity.fillpatch(sim().time().current_time());
+}
+
 }


### PR DESCRIPTION
This pull-request adds convenience methods to  Field so that fillpatch operation can be performed on any field. 

- Adds a `Field::set_default_fillpatch_bc` method that will set `BCRec` with `int_dir` for periodic and `hoextrap` everywhere else
- Registers a callback `fillpatch` functor similar to what's done for `grad_p` that is called by AMReX 

The user can override `hoextrap` with other extrapolation types. 