### PR TITLE
Introduce checks in static refinement for user inputs

### DIFF
--- a/src/utilities/tagging/CartBoxRefinement.cpp
+++ b/src/utilities/tagging/CartBoxRefinement.cpp
@@ -51,14 +51,17 @@ amrex::BoxArray realbox_to_boxarray(
 {
     amrex::BoxList bx_list;
     const auto* problo = geom.ProbLo();
+    const auto* probhi = geom.ProbHi();
     const auto* dx = geom.CellSize();
 
     for (const auto& rb : rbx) {
         amrex::IntVect lo, hi;
 
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            amrex::Real rlo = std::floor((rb.lo()[i] - problo[i]) / dx[i]);
-            amrex::Real rhi = std::ceil((rb.hi()[i] - problo[i]) / dx[i]);
+            amrex::Real bbox_min = amrex::max(rb.lo()[i], problo[i]);
+            amrex::Real bbox_max = amrex::min(rb.hi()[i], probhi[i]);
+            amrex::Real rlo = std::floor((bbox_min - problo[i]) / dx[i]);
+            amrex::Real rhi = std::ceil((bbox_max - problo[i]) / dx[i]);
             lo[i] = static_cast<int>(rlo);
             hi[i] = static_cast<int>(rhi);
         }
@@ -93,6 +96,13 @@ void CartBoxRefinement::read_inputs(const amrex::AmrCore& mesh, std::istream& if
     int nlev_in;
     ifh >> nlev_in;
     ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+
+    // Issue a warning if the max levels in the input file is less than what's
+    // requested in the refinement file.
+    if (max_lev < nlev_in)
+        amrex::Print() << "WARNING: AmrMesh::finestLevel() is less than the "
+                          "requested levels in static refinement file"
+                       << std::endl;
 
     // Set the number of levels to the minimum of what is in the input file and
     // the simulation

--- a/unit_tests/aw_test_utils/OutputCapture.H
+++ b/unit_tests/aw_test_utils/OutputCapture.H
@@ -1,0 +1,65 @@
+#ifndef OUTPUTCAPTURE_H
+#define OUTPUTCAPTURE_H
+
+#include <iostream>
+#include <sstream>
+
+namespace amr_wind_tests {
+
+/** Class to handle output capture
+ */
+class CaptureOutput
+{
+public:
+    CaptureOutput()
+    {
+        redirect_io();
+    }
+
+    CaptureOutput(bool stdout, bool stderr)
+        : m_stdout(stdout), m_stderr(stderr)
+    {
+        redirect_io();
+    }
+
+    ~CaptureOutput()
+    {
+        if (m_stdout && (m_cout_buf != nullptr)) {
+            std::cout.rdbuf(m_cout_buf);
+        }
+        if (m_stderr && (m_cerr_buf != nullptr)) {
+            std::cerr.rdbuf(m_cerr_buf);
+        }
+    }
+
+    inline bool capture_stdout() { return m_stdout; }
+    inline bool capture_stderr() { return m_stderr; }
+
+    inline std::stringstream& stdout() { return m_cout; }
+    inline std::stringstream& stderr() { return m_cerr; }
+
+protected:
+    void redirect_io()
+    {
+        if (m_stdout) {
+            m_cout_buf = std::cout.rdbuf();
+            std::cout.rdbuf(m_cout.rdbuf());
+        }
+        if (m_stderr) {
+            m_cerr_buf = std::cerr.rdbuf();
+            std::cerr.rdbuf(m_cerr.rdbuf());
+        }
+    }
+
+    std::stringstream m_cout;
+    std::stringstream m_cerr;
+
+    std::streambuf* m_cout_buf{nullptr};
+    std::streambuf* m_cerr_buf{nullptr};
+    bool m_stdout{true};
+    bool m_stderr{false};
+};
+
+} // namespace amr_wind_tests
+
+#endif /* OUTPUTCAPTURE_H */

--- a/unit_tests/utilities/test_refinement.cpp
+++ b/unit_tests/utilities/test_refinement.cpp
@@ -2,6 +2,7 @@
 
 #include "aw_test_utils/AmrexTest.H"
 #include "aw_test_utils/MeshTest.H"
+#include "aw_test_utils/OutputCapture.H"
 
 #include "AMReX_Box.H"
 #include "AMReX_BoxArray.H"
@@ -25,11 +26,10 @@ public:
     }
 
 protected:
-    virtual void
-    ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override
+    virtual void ErrorEst(
+        int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override
     {
-        for (auto& ref: m_refine_crit)
-            (*ref)(lev, tags, time, ngrow);
+        for (auto& ref : m_refine_crit) (*ref)(lev, tags, time, ngrow);
     }
 
 private:
@@ -38,28 +38,36 @@ private:
 
 //! Custom test fixture for Cartesian Box refinement
 class NestRefineTest : public MeshTest
-{};
+{
+protected:
+    void setup_refinement_inputs()
+    {
+        populate_parameters();
+
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{16, 128, 16}};
+
+            pp.add("max_level", 1);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{-20.0, -100.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{20.0, 100.0, 30.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+        }
+    }
+
+    std::stringstream m_cout_buf;
+    std::streambuf* m_orig_buf{nullptr};
+};
 
 TEST_F(NestRefineTest, box_refine)
 {
-    populate_parameters();
-
-    {
-        amrex::ParmParse pp("amr");
-        amrex::Vector<int> ncell{{16, 128, 16}};
-
-        pp.add("max_level", 1);
-        pp.addarr("n_cell", ncell);
-    }
-    {
-        amrex::ParmParse pp("geometry");
-        amrex::Vector<amrex::Real> problo {{-20.0, -100.0, 0.0}};
-        amrex::Vector<amrex::Real> probhi {{20.0, 100.0, 30.0}};
-
-        pp.addarr("prob_lo", problo);
-        pp.addarr("prob_hi", probhi);
-    }
-
+    setup_refinement_inputs();
     // Create the "input file"
     std::stringstream ss;
     ss << "1 // Number of levels" << std::endl;
@@ -70,13 +78,15 @@ TEST_F(NestRefineTest, box_refine)
     ss << "-10.0  65.0 0.0 15.0  75.0 20.0" << std::endl;
 
     create_mesh_instance<NestRefineMesh>();
-    std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(new amr_wind::CartBoxRefinement);
+    std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(
+        new amr_wind::CartBoxRefinement);
     box_refine->read_inputs(mesh(), ss);
 
     // Store the target boxarray for future tests
     auto targets = box_refine->boxarray_vec();
 
-    mesh<NestRefineMesh>()->refine_criteria_vec().push_back(std::move(box_refine));
+    mesh<NestRefineMesh>()->refine_criteria_vec().push_back(
+        std::move(box_refine));
     initialize_mesh();
 
     auto ba1 = mesh().boxArray(1);
@@ -85,4 +95,69 @@ TEST_F(NestRefineTest, box_refine)
     EXPECT_TRUE(ba1.contains(ba2));
 }
 
-}  // amr_wind_tests
+/*  Check that the implementation emits a warning when the levels requested in
+ *  the input file does not match the levels in static refinement file
+ */
+TEST_F(NestRefineTest, level_warning)
+{
+    setup_refinement_inputs();
+    {
+        amrex::ParmParse pp("amr");
+        pp.add("max_level", 0);
+    }
+
+    // Create the "input file"
+    std::stringstream ss;
+    ss << "2 // Number of levels" << std::endl;
+    ss << "2 // Number of boxes at this level" << std::endl;
+    ss << "-10.0 -75.0 0.0 15.0 -65.0 20.0" << std::endl;
+    ss << "-10.0 -55.0 0.0 15.0 -45.0 20.0" << std::endl;
+    ss << "2 // Number of boxes at this level" << std::endl;
+    ss << "-10.0  25.0 0.0 15.0  35.0 20.0" << std::endl;
+    ss << "-10.0  65.0 0.0 15.0  75.0 20.0" << std::endl;
+
+    {
+        CaptureOutput io;
+        create_mesh_instance<NestRefineMesh>();
+        std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(
+            new amr_wind::CartBoxRefinement);
+        box_refine->read_inputs(mesh(), ss);
+
+        auto msg = io.stdout().str();
+        EXPECT_GT(msg.size(), 0);
+        auto found = msg.find("WARNING");
+        EXPECT_NE(found, std::string::npos);
+    }
+}
+
+/* Check that the implementation handles bounding box limits that extend beyond
+ * the problem domain.
+ */
+TEST_F(NestRefineTest, bbox_limits)
+{
+    setup_refinement_inputs();
+
+    // Create the "input file"
+    std::stringstream ss;
+    ss << "1 // Number of levels" << std::endl;
+    ss << "1 // Number of boxes at this level" << std::endl;
+    ss << "-60.0 -200.0 -10.0 35.0 200.0 60.0" << std::endl;
+
+    create_mesh_instance<NestRefineMesh>();
+    std::unique_ptr<amr_wind::CartBoxRefinement> box_refine(
+        new amr_wind::CartBoxRefinement);
+    box_refine->read_inputs(mesh(), ss);
+
+    auto targets = box_refine->boxarray_vec();
+    EXPECT_EQ(targets.size(), 1u);
+    EXPECT_EQ(targets[0].size(), 1u);
+
+    auto domain = mesh().Geom(0).Domain();
+    auto bx = targets[0][0];
+
+    EXPECT_EQ(bx.smallEnd(), domain.smallEnd());
+    auto big_end = domain.bigEnd();
+    EXPECT_EQ(bx.bigEnd(), big_end.diagShift(1));
+}
+
+} // namespace amr_wind_tests


### PR DESCRIPTION
- Generate a warning if max_level in input file is smaller than the number of
  refinement level inputs in the static refinement file

- Ensure that box limits are calculated correctly when the user specifies
  bounding boxes that extend beyond the problem domain

- Add unit tests to check these

- Introduce a new I/O capture utility for unit tests