### PR TITLE
Per-solver MLMG options

### DIFF
--- a/src/core/MLMGOptions.H
+++ b/src/core/MLMGOptions.H
@@ -8,9 +8,50 @@
 
 namespace amr_wind {
 
+/** Collection of solver options to control MLMG behavior
+ */
 struct MLMGOptions
 {
-    MLMGOptions(const std::string& prefix)
+    /** Parse user options with a given prefix
+     *
+     *  \param prefix Prefix used to parse user inputs, e.g., mac_proj
+     */
+    MLMGOptions(const std::string& prefix) { parse_options(prefix); }
+
+    /** Parse options in two stages
+     *
+     *  This constructor parses the default options from `default_prefix` and
+     *  then overrides certain options based on a custom prefix.
+     *
+     *  \param default_prefix Namespace for default options
+     *  \param custom_prefix Namespace for override options
+     */
+    MLMGOptions(
+        const std::string& default_prefix, const std::string& custom_prefix)
+    {
+        parse_options(default_prefix);
+        parse_options(custom_prefix);
+    }
+
+    //! Bottom solver type bicgstab, cg, hypre, etc.
+    std::string bottom_solver_type{"bicgstab"};
+
+    //! Relative tolerance for convergence of MLMG solvers
+    amrex::Real rel_tol{1.0e-11};
+    //! Absolute tolerance for convergence checks
+    amrex::Real abs_tol{1.0e-14};
+
+    int verbose{0};
+    int max_iter{200};
+    int max_coarsen_level{100};
+    int max_order{2};
+    int fmg_max_iter{0};
+
+    int cg_verbose{0};
+    int cg_max_iter{200};
+
+private:
+    void parse_options(const std::string& prefix)
     {
         amrex::ParmParse pp(prefix);
 
@@ -26,22 +67,8 @@ struct MLMGOptions
         pp.query("mg_atol", abs_tol);
         pp.query("bottom_solver_type", bottom_solver_type);
     }
-
-    std::string bottom_solver_type{"bicgstab"};
-    amrex::Real rel_tol{1.0e-11};
-    amrex::Real abs_tol{1.0e-14};
-
-    int verbose{0};
-    int max_iter{200};
-    int max_coarsen_level{100};
-    int max_order{2};
-    int fmg_max_iter{0};
-
-    int cg_verbose{0};
-    int cg_max_iter{200};
 };
 
-}
-
+} // namespace amr_wind
 
 #endif /* MLMGOPTIONS_H */

--- a/src/equation_systems/DiffusionOps.cpp
+++ b/src/equation_systems/DiffusionOps.cpp
@@ -12,7 +12,7 @@ DiffSolverIface<LinOp>::DiffSolverIface(
     PDEFields& fields, const std::string& prefix)
     : m_pdefields(fields)
     , m_density(fields.repo.get_field("density"))
-    , m_options(prefix)
+    , m_options(prefix, m_pdefields.field.name() + "_" + prefix)
 {
     amrex::LPInfo isolve;
     amrex::LPInfo iapply;


### PR DESCRIPTION
Enhance MLMGOptions to handle default options and per-solver custom overrides.
For example,

```
diffusion.mg_rtol = 1.0e-6
temperature_diffusion.mg_rtol = 1.0e-11
```

will allow all solves (e.g., velocity, tke) to use a relaxed tolerance of
1.0e-6, but a tighter tolerance of 1.0e-11 for temperature.