### PR TITLE
Prepare codebase for DPC++

### DIFF
--- a/src/convection/incflo_convection_K.H
+++ b/src/convection/incflo_convection_K.H
@@ -30,21 +30,21 @@ amrex::Real incflo_ho_xslope (int i, int j, int k, int n,
     dlft = qm - q(i-2,j,k,n);
     drgt = qi - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qi;
     drgt = q(i+2,j,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qi - qm;
     drgt = qp - qi;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -86,21 +86,21 @@ amrex::Real incflo_ho_xslope_extdir (int i, int j, int k, int n,
     dlft = qm - q(i-2,j,k,n);
     drgt = qi - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qi;
     drgt = q(i+2,j,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qi - qm;
     drgt = qp - qi;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -111,13 +111,13 @@ amrex::Real incflo_ho_xslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
        drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edlo and i == domlo+1) {
        dfm  = -16./15.*q(domlo-1,j,k,n) + .5*q(domlo,j,k,n) + 2./3.*q(domlo+1,j,k,n) -  0.1*q(domlo+2,j,k,n);
        dlft = 2.*(q(domlo  ,j,k,n)-q(domlo-1,j,k,n));
        drgt = 2.*(q(domlo+1,j,k,n)-q(domlo  ,j,k,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfm);
+       dsgnsh = amrex::Math::copysign(1.e0, dfm);
        dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and i == domhi) {
@@ -125,13 +125,13 @@ amrex::Real incflo_ho_xslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
        drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edhi and i == domhi-1) {
        dfp  = 16./15.*q(domhi+1,j,k,n) - .5*q(domhi,j,k,n) - 2./3.*q(domhi-1,j,k,n) +  0.1*q(domhi-2,j,k,n);
        dlft = 2.*(q(domhi  ,j,k,n)-q(domhi-1,j,k,n));
        drgt = 2.*(q(domhi+1,j,k,n)-q(domhi  ,j,k,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfp);
+       dsgnsh = amrex::Math::copysign(1.e0, dfp);
        dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }
@@ -164,21 +164,21 @@ amrex::Real incflo_ho_yslope (int i, int j, int k, int n,
     dlft = qm - q(i,j-2,k,n);
     drgt = qj - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qj;
     drgt = q(i,j+2,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qj - qm;
     drgt = qp - qj;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -219,21 +219,21 @@ amrex::Real incflo_ho_yslope_extdir (int i, int j, int k, int n,
     dlft = qm - q(i,j-2,k,n);
     drgt = qj - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qj;
     drgt = q(i,j+2,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qj - qm;
     drgt = qp - qj;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -244,13 +244,13 @@ amrex::Real incflo_ho_yslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
        drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edlo and j == domlo+1) {
        dfm  = -16./15.*q(i,domlo-1,k,n) + .5*q(i,domlo,k,n) + 2./3.*q(i,domlo+1,k,n) -  0.1*q(i,domlo+2,k,n);
        dlft = 2.*(q(i  ,domlo,k,n)-q(i,domlo-1,k,n));
        drgt = 2.*(q(i,domlo+1,k,n)-q(i  ,domlo,k,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfm);
+       dsgnsh = amrex::Math::copysign(1.e0, dfm);
        dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and j == domhi) {
@@ -258,13 +258,13 @@ amrex::Real incflo_ho_yslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
        drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edhi and j == domhi-1) {
        dfp  = 16./15.*q(i,domhi+1,k,n) - .5*q(i,domhi,k,n) - 2./3.*q(i,domhi-1,k,n) +  0.1*q(i,domhi-2,k,n);
        dlft = 2.*(q(i  ,domhi,k,n)-q(i,domhi-1,k,n));
        drgt = 2.*(q(i,domhi+1,k,n)-q(i  ,domhi,k,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfp);
+       dsgnsh = amrex::Math::copysign(1.e0, dfp);
        dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }
@@ -299,21 +299,21 @@ amrex::Real incflo_ho_zslope (int i, int j, int k, int n,
     dlft = qm - q(i,j,k-2,n);
     drgt = qk - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qk;
     drgt = q(i,j,k+2,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qk - qm;
     drgt = qp - qk;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -354,21 +354,21 @@ amrex::Real incflo_ho_zslope_extdir (int i, int j, int k, int n,
     dlft = qm - q(i,j,k-2,n);
     drgt = qk - qm;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qk;
     drgt = q(i,j,k+2,n) - qp;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qk - qm;
     drgt = qp - qk;
     dcen = 0.5*(dlft+drgt);
-    dsgn = std::copysign(1.e0, dcen);
+    dsgn = amrex::Math::copysign(1.e0, dcen);
     dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
     dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
@@ -379,13 +379,13 @@ amrex::Real incflo_ho_zslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
        drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edlo and k == domlo+1) {
        dfm  = -16./15.*q(i,j,domlo-1,n) + .5*q(i,j,domlo,n) + 2./3.*q(i,j,domlo+1,n) -  0.1*q(i,j,domlo+2,n);
        dlft = 2.*(q(i  ,j,domlo,n)-q(i,j,domlo-1,n));
        drgt = 2.*(q(i,j,domlo+1,n)-q(i  ,j,domlo,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfm);
+       dsgnsh = amrex::Math::copysign(1.e0, dfm);
        dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and k == domhi) {
@@ -393,13 +393,13 @@ amrex::Real incflo_ho_zslope_extdir (int i, int j, int k, int n,
        dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
        drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgn = std::copysign(1.e0, dtemp);
+       dsgn = amrex::Math::copysign(1.e0, dtemp);
     } else if (edhi and k == domhi-1) {
        dfp  = 16./15.*q(i,j,domhi+1,n) - .5*q(i,j,domhi,n) - 2./3.*q(i,j,domhi-1,n) +  0.1*q(i,j,domhi-2,n);
        dlft = 2.*(q(i  ,j,domhi,n)-q(i,j,domhi-1,n));
        drgt = 2.*(q(i,j,domhi+1,n)-q(i  ,j,domhi,n));
        dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
-       dsgnsh = std::copysign(1.e0, dfp);
+       dsgnsh = amrex::Math::copysign(1.e0, dfp);
        dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }

--- a/src/convection/incflo_convection_K.H
+++ b/src/convection/incflo_convection_K.H
@@ -12,7 +12,7 @@ amrex::Real incflo_xslope (int i, int j, int k, int n,
     amrex::Real dl = 2.0*(vcc(i  ,j,k,n) - vcc(i-1,j,k,n));
     amrex::Real dr = 2.0*(vcc(i+1,j,k,n) - vcc(i  ,j,k,n));
     amrex::Real dc = 0.5*(vcc(i+1,j,k,n) - vcc(i-1,j,k,n));
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -31,26 +31,26 @@ amrex::Real incflo_ho_xslope (int i, int j, int k, int n,
     drgt = qi - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qi;
     drgt = q(i+2,j,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qi - qm;
     drgt = qp - qi;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 
 }
 
@@ -67,7 +67,7 @@ amrex::Real incflo_xslope_extdir (int i, int j, int k, int n,
     } else if (edhi and i == domhi) {
         dc = (4.0*vcc(i+1,j,k,n)-3.0*vcc(i,j,k,n)-vcc(i-1,j,k,n))/3.0;
     }
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -87,22 +87,22 @@ amrex::Real incflo_ho_xslope_extdir (int i, int j, int k, int n,
     drgt = qi - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qi;
     drgt = q(i+2,j,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qi - qm;
     drgt = qp - qi;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
@@ -110,33 +110,33 @@ amrex::Real incflo_ho_xslope_extdir (int i, int j, int k, int n,
        dtemp  = -16./15.*q(i-1,j,k,n) + .5*q(i,j,k,n) + 2./3.*q(i+1,j,k,n) -  0.1*q(i+2,j,k,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
        drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edlo and i == domlo+1) {
        dfm  = -16./15.*q(domlo-1,j,k,n) + .5*q(domlo,j,k,n) + 2./3.*q(domlo+1,j,k,n) -  0.1*q(domlo+2,j,k,n);
        dlft = 2.*(q(domlo  ,j,k,n)-q(domlo-1,j,k,n));
        drgt = 2.*(q(domlo+1,j,k,n)-q(domlo  ,j,k,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfm);
-       dfm = dsgnsh*amrex::min(dlimsh, std::abs(dfm));
+       dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and i == domhi) {
        dtemp  = 16./15.*q(i+1,j,k,n) - .5*q(i,j,k,n) - 2./3.*q(i-1,j,k,n) +  0.1*q(i-2,j,k,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
        drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edhi and i == domhi-1) {
        dfp  = 16./15.*q(domhi+1,j,k,n) - .5*q(domhi,j,k,n) - 2./3.*q(domhi-1,j,k,n) +  0.1*q(domhi-2,j,k,n);
        dlft = 2.*(q(domhi  ,j,k,n)-q(domhi-1,j,k,n));
        drgt = 2.*(q(domhi+1,j,k,n)-q(domhi  ,j,k,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfp);
-       dfp = dsgnsh*amrex::min(dlimsh, std::abs(dfp));
+       dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }
 
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -146,7 +146,7 @@ amrex::Real incflo_yslope (int i, int j, int k, int n,
     amrex::Real dl = 2.0*(vcc(i,j  ,k,n) - vcc(i,j-1,k,n));
     amrex::Real dr = 2.0*(vcc(i,j+1,k,n) - vcc(i,j  ,k,n));
     amrex::Real dc = 0.5*(vcc(i,j+1,k,n) - vcc(i,j-1,k,n));
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -165,25 +165,25 @@ amrex::Real incflo_ho_yslope (int i, int j, int k, int n,
     drgt = qj - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qj;
     drgt = q(i,j+2,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qj - qm;
     drgt = qp - qj;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 
 }
 
@@ -200,7 +200,7 @@ amrex::Real incflo_yslope_extdir (int i, int j, int k, int n,
     } else if (edhi and j == domhi) {
         dc = (4.0*vcc(i,j+1,k,n)-3.0*vcc(i,j,k,n)-vcc(i,j-1,k,n))/3.0;
     }
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -220,22 +220,22 @@ amrex::Real incflo_ho_yslope_extdir (int i, int j, int k, int n,
     drgt = qj - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qj;
     drgt = q(i,j+2,k,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qj - qm;
     drgt = qp - qj;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
@@ -243,33 +243,33 @@ amrex::Real incflo_ho_yslope_extdir (int i, int j, int k, int n,
        dtemp  = -16./15.*q(i,j-1,k,n) + .5*q(i,j,k,n) + 2./3.*q(i,j+1,k,n) -  0.1*q(i,j+2,k,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
        drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edlo and j == domlo+1) {
        dfm  = -16./15.*q(i,domlo-1,k,n) + .5*q(i,domlo,k,n) + 2./3.*q(i,domlo+1,k,n) -  0.1*q(i,domlo+2,k,n);
        dlft = 2.*(q(i  ,domlo,k,n)-q(i,domlo-1,k,n));
        drgt = 2.*(q(i,domlo+1,k,n)-q(i  ,domlo,k,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfm);
-       dfm = dsgnsh*amrex::min(dlimsh, std::abs(dfm));
+       dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and j == domhi) {
        dtemp  = 16./15.*q(i,j+1,k,n) - .5*q(i,j,k,n) - 2./3.*q(i,j-1,k,n) +  0.1*q(i,j-2,k,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
        drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edhi and j == domhi-1) {
        dfp  = 16./15.*q(i,domhi+1,k,n) - .5*q(i,domhi,k,n) - 2./3.*q(i,domhi-1,k,n) +  0.1*q(i,domhi-2,k,n);
        dlft = 2.*(q(i  ,domhi,k,n)-q(i,domhi-1,k,n));
        drgt = 2.*(q(i,domhi+1,k,n)-q(i  ,domhi,k,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfp);
-       dfp = dsgnsh*amrex::min(dlimsh, std::abs(dfp));
+       dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }
 
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 
 }
 
@@ -281,7 +281,7 @@ amrex::Real incflo_zslope (int i, int j, int k, int n,
     amrex::Real dl = 2.0*(vcc(i,j,k  ,n) - vcc(i,j,k-1,n));
     amrex::Real dr = 2.0*(vcc(i,j,k+1,n) - vcc(i,j,k  ,n));
     amrex::Real dc = 0.5*(vcc(i,j,k+1,n) - vcc(i,j,k-1,n));
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -300,25 +300,25 @@ amrex::Real incflo_ho_zslope (int i, int j, int k, int n,
     drgt = qk - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qk;
     drgt = q(i,j,k+2,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qk - qm;
     drgt = qp - qk;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 
 }
 
@@ -335,7 +335,7 @@ amrex::Real incflo_zslope_extdir (int i, int j, int k, int n,
     } else if (edhi and k == domhi) {
         dc = (4.0*vcc(i,j,k+1,n)-3.0*vcc(i,j,k,n)-vcc(i,j,k-1,n))/3.0;
     }
-    amrex::Real slope = amrex::min(std::abs(dl),std::abs(dc),std::abs(dr));
+    amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
     slope = (dr*dl > 0.0) ? slope : 0.0;
     return (dc > 0.0) ? slope : -slope;
 }
@@ -355,22 +355,22 @@ amrex::Real incflo_ho_zslope_extdir (int i, int j, int k, int n,
     drgt = qk - qm;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfm = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qp - qk;
     drgt = q(i,j,k+2,n) - qp;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dfp = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dlft = qk - qm;
     drgt = qp - qk;
     dcen = 0.5*(dlft+drgt);
     dsgn = std::copysign(1.e0, dcen);
-    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
-    dcen = dsgn*amrex::min(dlim, std::abs(dcen));
+    dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+    dcen = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
 
     dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
@@ -378,32 +378,32 @@ amrex::Real incflo_ho_zslope_extdir (int i, int j, int k, int n,
        dtemp  = -16./15.*q(i,j,k-1,n) + .5*q(i,j,k,n) + 2./3.*q(i,j,k+1,n) -  0.1*q(i,j,k+2,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
        drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edlo and k == domlo+1) {
        dfm  = -16./15.*q(i,j,domlo-1,n) + .5*q(i,j,domlo,n) + 2./3.*q(i,j,domlo+1,n) -  0.1*q(i,j,domlo+2,n);
        dlft = 2.*(q(i  ,j,domlo,n)-q(i,j,domlo-1,n));
        drgt = 2.*(q(i,j,domlo+1,n)-q(i  ,j,domlo,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfm);
-       dfm = dsgnsh*amrex::min(dlimsh, std::abs(dfm));
+       dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     } else if (edhi and k == domhi) {
        dtemp  = 16./15.*q(i,j,k+1,n) - .5*q(i,j,k,n) - 2./3.*q(i,j,k-1,n) +  0.1*q(i,j,k-2,n);
        dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
        drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
-       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgn = std::copysign(1.e0, dtemp);
     } else if (edhi and k == domhi-1) {
        dfp  = 16./15.*q(i,j,domhi+1,n) - .5*q(i,j,domhi,n) - 2./3.*q(i,j,domhi-1,n) +  0.1*q(i,j,domhi-2,n);
        dlft = 2.*(q(i  ,j,domhi,n)-q(i,j,domhi-1,n));
        drgt = 2.*(q(i,j,domhi+1,n)-q(i  ,j,domhi,n));
-       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(std::abs(dlft), std::abs(drgt)) : 0.0;
+       dlimsh = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
        dsgnsh = std::copysign(1.e0, dfp);
-       dfp = dsgnsh*amrex::min(dlimsh, std::abs(dfp));
+       dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
     }
-    return dsgn*amrex::min(dlim, std::abs(dtemp));
+    return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
 
 
 }

--- a/src/convection/incflo_godunov_advection.cpp
+++ b/src/convection/incflo_godunov_advection.cpp
@@ -119,7 +119,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1.e-10;
 
             Real uad = umac(i,j,k);
-            Real fux = (std::abs(uad) < small_vel)? 0. : 1.;
+            Real fux = (amrex::Math::abs(uad) < small_vel)? 0. : 1.;
             bool uval = uad >= 0.; 
             Real cons1 = (iconserv[n]) ? -0.5*l_dt*q(i-1,j,k,n)*divu(i-1,j,k) : 0.;
             Real cons2 = (iconserv[n]) ? -0.5*l_dt*q(i  ,j,k,n)*divu(i  ,j,k) : 0.;
@@ -144,7 +144,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1.e-10;
 
             Real vad = vmac(i,j,k);
-            Real fuy = (std::abs(vad) < small_vel)? 0. : 1.;
+            Real fuy = (amrex::Math::abs(vad) < small_vel)? 0. : 1.;
             bool vval = vad >= 0.;
             Real cons1 = (iconserv[n]) ? -0.5*l_dt*q(i,j-1,k,n)*divu(i,j-1,k) : 0.;
             Real cons2 = (iconserv[n]) ? -0.5*l_dt*q(i,j  ,k,n)*divu(i,j  ,k) : 0.;
@@ -169,7 +169,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1.e-10;
 
             Real wad = wmac(i,j,k);
-            Real fuz = (std::abs(wad) < small_vel) ? 0. : 1.;
+            Real fuz = (amrex::Math::abs(wad) < small_vel) ? 0. : 1.;
             bool wval = wad >= 0.; 
             auto bc = pbc[n];
             Real cons1 = (iconserv[n]) ? -0.5*l_dt*q(i,j,k-1,n)*divu(i,j,k-1) : 0.;
@@ -218,7 +218,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (wad >= 0.) ? l_zylo : l_zyhi;
-        Real fu = (std::abs(wad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(wad) < small_vel) ? 0.0 : 1.0;
         zylo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_zyhi + l_zylo);
     },
     Box(yzlo), ncomp,
@@ -237,7 +237,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (vad >= 0.) ? l_yzlo : l_yzhi;
-        Real fu = (std::abs(vad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
         yzlo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_yzhi + l_yzlo);
     });
     //
@@ -278,7 +278,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         Godunov_cc_xbc_hi(i, j, k, n, q, stl, sth, umac, bc.hi(0), dhi.x);
 
         Real temp = (umac(i,j,k) >= 0.) ? stl : sth; 
-        temp = (std::abs(umac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp;
+        temp = (amrex::Math::abs(umac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp;
         qx(i,j,k,n) = temp;
     }); 
 
@@ -305,7 +305,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (uad >= 0.) ? l_xzlo : l_xzhi;
-        Real fu = (std::abs(uad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
         xzlo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_xzhi + l_xzlo);
     },
     Box(zxlo), ncomp,
@@ -324,7 +324,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (wad >= 0.) ? l_zxlo : l_zxhi;
-        Real fu = (std::abs(wad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(wad) < small_vel) ? 0.0 : 1.0;
         zxlo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_zxhi + l_zxlo);
     });
     //
@@ -367,7 +367,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         Godunov_cc_ybc_hi(i, j, k, n, q, stl, sth, vmac, bc.hi(1), dhi.y);
 
         Real temp = (vmac(i,j,k) >= 0.) ? stl : sth; 
-        temp = (std::abs(vmac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp; 
+        temp = (amrex::Math::abs(vmac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp; 
         qy(i,j,k,n) = temp;
     });
 
@@ -394,7 +394,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (uad >= 0.) ? l_xylo : l_xyhi;
-        Real fu = (std::abs(uad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
         xylo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_xyhi + l_xylo);
     },
     Box(yxlo), ncomp,
@@ -413,7 +413,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (vad >= 0.) ? l_yxlo : l_yxhi;
-        Real fu = (std::abs(vad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
         yxlo(i,j,k,n) = fu*st + (1.0 - fu) * 0.5 * (l_yxhi + l_yxlo);
     });
     //
@@ -454,7 +454,7 @@ godunov::compute_advection(int lev, Box const& bx, int ncomp,
         Godunov_cc_zbc_hi(i, j, k, n, q, stl, sth, wmac, bc.hi(2), dhi.z);
 
         Real temp = (wmac(i,j,k) >= 0.) ? stl : sth; 
-        temp = (std::abs(wmac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp; 
+        temp = (amrex::Math::abs(wmac(i,j,k)) < small_vel) ? 0.5*(stl + sth) : temp; 
         qz(i,j,k,n) = temp;
     });
 

--- a/src/convection/incflo_godunov_ppm.H
+++ b/src/convection/incflo_godunov_ppm.H
@@ -19,7 +19,7 @@ amrex::Real vanLeer(const amrex::Real a, const amrex::Real b, const amrex::Real 
     amrex::Real dsl = 2.e0*(a - c);
     amrex::Real dsr = 2.e0*(b - a);
     return (dsl*dsr > small_qty_sq) ? 
-        std::copysign(1., dsc)*amrex::min(std::abs(dsc),amrex::min(std::abs(dsl), std::abs(dsr))) : 0.;
+        std::copysign(1., dsc)*amrex::min(amrex::Math::abs(dsc),amrex::min(amrex::Math::abs(dsl), amrex::Math::abs(dsr))) : 0.;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -59,9 +59,9 @@ void Godunov_ppm_xbc(const int i, const int j, const int k, const int n,
                 sp = s(domlo+1,j,k,n);
                 sm = s(domlo+1,j,k,n);
             }
-            else if(std::abs(sp - s(domlo+1,j,k,n)) >= 2.*std::abs(sm - s(domlo+1,j,k,n)))
+            else if(amrex::Math::abs(sp - s(domlo+1,j,k,n)) >= 2.*amrex::Math::abs(sm - s(domlo+1,j,k,n)))
                 sp = 3.*s(domlo+1,j,k,n) - 2.*sm;
-            else if(std::abs(sm - s(domlo+1,j,k,n)) >= 2.*std::abs(sp - s(domlo+1,j,k,n)))
+            else if(amrex::Math::abs(sm - s(domlo+1,j,k,n)) >= 2.*amrex::Math::abs(sp - s(domlo+1,j,k,n)))
                 sm = 3.*s(domlo+1,j,k,n) - 2.*sp;
         }
     }
@@ -93,9 +93,9 @@ void Godunov_ppm_xbc(const int i, const int j, const int k, const int n,
                 sp = s(domhi-1,j,k,n);
                 sm = s(domhi-1,j,k,n);
             }
-            else if(std::abs(sp - s(domhi-1,j,k,n)) >= 2.*std::abs(sm - s(domhi-1,j,k,n)))
+            else if(amrex::Math::abs(sp - s(domhi-1,j,k,n)) >= 2.*amrex::Math::abs(sm - s(domhi-1,j,k,n)))
                 sp = 3.*s(domhi-1,j,k,n) - 2.*sm;
-            else if(std::abs(sm - s(domhi-1,j,k,n)) >= 2.*std::abs(sp - s(domhi-1,j,k,n)))
+            else if(amrex::Math::abs(sm - s(domhi-1,j,k,n)) >= 2.*amrex::Math::abs(sp - s(domhi-1,j,k,n)))
                 sm = 3.*s(domhi-1,j,k,n) - 2.*sp;
         }
     }
@@ -138,9 +138,9 @@ void Godunov_ppm_ybc(const int i, const int j, const int k, const int n,
                 sp = s(i,domlo+1,k,n);
                 sm = s(i,domlo+1,k,n);
             }
-            else if(std::abs(sp - s(i,domlo+1,k,n)) >= 2.*std::abs(sm - s(i,domlo+1,k,n)))
+            else if(amrex::Math::abs(sp - s(i,domlo+1,k,n)) >= 2.*amrex::Math::abs(sm - s(i,domlo+1,k,n)))
                 sp = 3.*s(i,domlo+1,k,n) - 2.*sm;
-            else if(std::abs(sm - s(i,domlo+1,k,n)) >= 2.*std::abs(sp - s(i,domlo+1,k,n)))
+            else if(amrex::Math::abs(sm - s(i,domlo+1,k,n)) >= 2.*amrex::Math::abs(sp - s(i,domlo+1,k,n)))
                 sm = 3.*s(i,domlo+1,k,n) - 2.*sp;
         }
     }
@@ -171,10 +171,10 @@ void Godunov_ppm_ybc(const int i, const int j, const int k, const int n,
                 sp = s(i,domhi-1,k,n);
                 sm = s(i,domhi-1,k,n);
             }
-            else if(std::abs(sp - s(i,domhi-1,k,n)) >= 2.*std::abs(sm - s(i,domhi-1,k,n))) 
+            else if(amrex::Math::abs(sp - s(i,domhi-1,k,n)) >= 2.*amrex::Math::abs(sm - s(i,domhi-1,k,n))) 
                 sp = 3.*s(i,domhi-1,k,n) - 2.*sm;
 
-            else if(std::abs(sm - s(i,domhi-1,k,n)) >= 2.*std::abs(sp - s(i,domhi-1,k,n))) 
+            else if(amrex::Math::abs(sm - s(i,domhi-1,k,n)) >= 2.*amrex::Math::abs(sp - s(i,domhi-1,k,n))) 
                 sm = 3.*s(i,domhi-1,k,n) - 2.*sp;
         }
     }
@@ -218,10 +218,10 @@ void Godunov_ppm_zbc(const int i, const int j, const int k, const int n,
                 sp = s(i,j,domlo+1,n);
                 sm = s(i,j,domlo+1,n);
             }
-            else if(std::abs(sp - s(i,j,domlo+1,n)) >= 2.*std::abs(sm - s(i,j,domlo+1,n))) 
+            else if(amrex::Math::abs(sp - s(i,j,domlo+1,n)) >= 2.*amrex::Math::abs(sm - s(i,j,domlo+1,n))) 
                 sp = 3.*s(i,j,domlo+1,n) - 2.*sm;
 
-            else if(std::abs(sm - s(i,j,domlo+1,n)) >= 2.*std::abs(sp - s(i,j,domlo+1,n)))
+            else if(amrex::Math::abs(sm - s(i,j,domlo+1,n)) >= 2.*amrex::Math::abs(sp - s(i,j,domlo+1,n)))
                 sm = 3.*s(i,j,domlo+1,n) - 2.*sp;
         }
     }
@@ -253,10 +253,10 @@ void Godunov_ppm_zbc(const int i, const int j, const int k, const int n,
                 sp = s(i,j,domhi-1,n);
                 sm = s(i,j,domhi-1,n);
             }
-            else if(std::abs(sp - s(i,j,domhi-1,n)) >= 2.*std::abs(sm - s(i,j,domhi-1,n)))
+            else if(amrex::Math::abs(sp - s(i,j,domhi-1,n)) >= 2.*amrex::Math::abs(sm - s(i,j,domhi-1,n)))
                 sp = 3.*s(i,j,domhi-1,n) - 2.*sm;
             
-            else if(std::abs(sm - s(i,j,domhi-1,n)) >= 2.*std::abs(sp - s(i,j,domhi-1,n))) 
+            else if(amrex::Math::abs(sm - s(i,j,domhi-1,n)) >= 2.*amrex::Math::abs(sp - s(i,j,domhi-1,n))) 
                 sm = 3.*s(i,j,domhi-1,n) - 2.*sp;
               
         }
@@ -307,17 +307,17 @@ void Godunov_ppm_pred_x(const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
 
-    } else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    } else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
         sp = 3.0*s0 - 2.0*sedge1;
 
-      else if (std::abs(sedge1-S(i,j,k,n)) >=  2.0*std::abs(sedge2-s0))
+      else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >=  2.0*amrex::Math::abs(sedge2-s0))
         sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_xbc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(0), bc.hi(0), domlo, domhi);
 
     amrex::Real s6 = 6.0*s0 - 3.0*(sm + sp);
 
-    amrex::Real sigma = std::abs(v_ad)*dtdx;
+    amrex::Real sigma = amrex::Math::abs(v_ad)*dtdx;
 
     if (v_ad > small_vel)
     {
@@ -376,17 +376,17 @@ void Godunov_ppm_pred_y(const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
 
-    } else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    } else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
         sp = 3.0*s0 - 2.0*sedge1;
 
-      else if (std::abs(sedge1-S(i,j,k,n)) >= 2.0*std::abs(sedge2-s0))
+      else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge2-s0))
         sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_ybc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(1), bc.hi(1), domlo, domhi);
 
     amrex::Real s6 = 6.0*s0- 3.0*(sm + sp);
 
-    amrex::Real sigma = std::abs(v_ad)*dtdy;
+    amrex::Real sigma = amrex::Math::abs(v_ad)*dtdy;
 
     if (v_ad > small_vel)
     {
@@ -445,17 +445,17 @@ void Godunov_ppm_pred_z(const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
 
-    } else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    } else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
         sp = 3.0*s0 - 2.0*sedge1;
 
-      else if (std::abs(sedge1-S(i,j,k,n)) >= 2.0*std::abs(sedge2-s0))
+      else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge2-s0))
         sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_zbc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(2), bc.hi(2), domlo, domhi);
 
     amrex::Real s6 = 6.0*s0- 3.0*(sm + sp);
 
-    amrex::Real sigma = std::abs(v_ad)*dtdz;
+    amrex::Real sigma = amrex::Math::abs(v_ad)*dtdz;
 
     if (v_ad > small_vel)
     {
@@ -519,18 +519,18 @@ void Godunov_ppm_fpu_x (const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
     }
-    else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
       sp = 3.0*s0 - 2.0*sedge1;
 
-    else if (std::abs(sedge1-S(i,j,k,n)) >=  2.0*std::abs(sedge2-s0))
+    else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >=  2.0*amrex::Math::abs(sedge2-s0))
       sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_xbc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(0), bc.hi(0), domlo, domhi);
 
     Real s6 = 6.0*s0 - 3.0*(sm + sp);
 
-    Real sigmap = std::abs(vel_edge(i+1,j,k))*dt/dx;
-    Real sigmam = std::abs(vel_edge(i  ,j,k))*dt/dx;
+    Real sigmap = amrex::Math::abs(vel_edge(i+1,j,k))*dt/dx;
+    Real sigmam = amrex::Math::abs(vel_edge(i  ,j,k))*dt/dx;
 
     if (vel_edge(i+1,j,k) > small_vel) 
         Ip = sp - (0.5*sigmap)*((sp - sm) - (1.e0 -2.e0/3.e0*sigmap)*s6);
@@ -587,18 +587,18 @@ void Godunov_ppm_fpu_y (const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
     } 
-    else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
         sp = 3.0*s0 - 2.0*sedge1;
 
-    else if (std::abs(sedge1-S(i,j,k,n)) >= 2.0*std::abs(sedge2-s0))
+    else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge2-s0))
         sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_ybc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(1), bc.hi(1), domlo, domhi);
 
     amrex::Real s6 = 6.0*s0- 3.0*(sm + sp);
 
-    Real sigmap = std::abs(vel_edge(i,j+1,k))*dt/dx;
-    Real sigmam = std::abs(vel_edge(i,j  ,k))*dt/dx;
+    Real sigmap = amrex::Math::abs(vel_edge(i,j+1,k))*dt/dx;
+    Real sigmam = amrex::Math::abs(vel_edge(i,j  ,k))*dt/dx;
 
     if (vel_edge(i,j+1,k) > small_vel)
         Ip = sp - (0.5*sigmap)*((sp - sm) - (1.e0 -2.e0/3.e0*sigmap)*s6);
@@ -655,17 +655,17 @@ void Godunov_ppm_fpu_z (const int i, const int j, const int k, const int n,
         sp = s0;
         sm = s0;
     } 
-    else if (std::abs(sedge2-S(i,j,k,n)) >= 2.0*std::abs(sedge1-s0))
+    else if (amrex::Math::abs(sedge2-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge1-s0))
         sp = 3.0*s0 - 2.0*sedge1;
 
-    else if (std::abs(sedge1-S(i,j,k,n)) >= 2.0*std::abs(sedge2-s0))
+    else if (amrex::Math::abs(sedge1-S(i,j,k,n)) >= 2.0*amrex::Math::abs(sedge2-s0))
         sm = 3.0*s0 - 2.0*sedge2;
 
     Godunov_ppm_zbc(i, j, k, n, sm, sp, sedge1, sedge2, S, bc.lo(2), bc.hi(2), domlo, domhi);
 
     Real s6 = 6.0*s0- 3.0*(sm + sp);
-    Real sigmap = std::abs(vel_edge(i,j,k+1))*dt/dx;
-    Real sigmam = std::abs(vel_edge(i,j,k  ))*dt/dx;
+    Real sigmap = amrex::Math::abs(vel_edge(i,j,k+1))*dt/dx;
+    Real sigmam = amrex::Math::abs(vel_edge(i,j,k  ))*dt/dx;
 
     if(vel_edge(i,j,k+1) > small_vel)
         Ip = sp - (0.5*sigmap)*((sp-sm) - (1.e0 -2.e0/3.e0*sigmap)*s6);

--- a/src/convection/incflo_godunov_ppm.H
+++ b/src/convection/incflo_godunov_ppm.H
@@ -19,7 +19,7 @@ amrex::Real vanLeer(const amrex::Real a, const amrex::Real b, const amrex::Real 
     amrex::Real dsl = 2.e0*(a - c);
     amrex::Real dsr = 2.e0*(b - a);
     return (dsl*dsr > small_qty_sq) ? 
-        std::copysign(1., dsc)*amrex::min(amrex::Math::abs(dsc),amrex::min(amrex::Math::abs(dsl), amrex::Math::abs(dsr))) : 0.;
+        amrex::Math::copysign(1., dsc)*amrex::min(amrex::Math::abs(dsc),amrex::min(amrex::Math::abs(dsl), amrex::Math::abs(dsr))) : 0.;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/src/convection/incflo_godunov_predict.cpp
+++ b/src/convection/incflo_godunov_predict.cpp
@@ -55,7 +55,7 @@ void godunov::make_trans_velocities (int lev, Box const& xbx, Box const& ybx, Bo
         constexpr Real small_vel = 1e-10;
 
         Real st = ( (lo+hi) >= 0.) ? lo : hi;
-        bool ltm = ( (lo <= 0. && hi >= 0.) || (std::abs(lo+hi) < small_vel) );
+        bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
         u_ad(i,j,k) = ltm ? 0. : st;
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -78,7 +78,7 @@ void godunov::make_trans_velocities (int lev, Box const& xbx, Box const& ybx, Bo
         constexpr Real small_vel = 1e-10;
 
         Real st = ( (lo+hi) >= 0.) ? lo : hi;
-        bool ltm = ( (lo <= 0. && hi >= 0.) || (std::abs(lo+hi) < small_vel) );
+        bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
         v_ad(i,j,k) = ltm ? 0. : st;
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -101,7 +101,7 @@ void godunov::make_trans_velocities (int lev, Box const& xbx, Box const& ybx, Bo
         constexpr Real small_vel = 1e-10;
 
         Real st = ( (lo+hi) >= 0.) ? lo : hi;
-        bool ltm = ( (lo <= 0. && hi >= 0.) || (std::abs(lo+hi) < small_vel) );
+        bool ltm = ( (lo <= 0. && hi >= 0.) || (amrex::Math::abs(lo+hi) < small_vel) );
         w_ad(i,j,k) = ltm ? 0. : st;
     });
 }
@@ -180,7 +180,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1e-10;
 
             Real st = (uad >= 0.) ? lo : hi;
-            Real fu = (std::abs(uad) < small_vel) ? 0.0 : 1.0;
+            Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
             Imx(i, j, k, n) = fu*st + (1.0 - fu) *0.5 * (hi + lo); // store xedge
         },
         yebox, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -205,7 +205,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1e-10;
 
             Real st = (vad >= 0.) ? lo : hi;
-            Real fu = (std::abs(vad) < small_vel) ? 0.0 : 1.0;
+            Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
             Imy(i, j, k, n) = fu*st + (1.0 - fu)*0.5*(hi + lo); // store yedge
         },
         zebox, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -230,7 +230,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
             constexpr Real small_vel = 1e-10;
 
             Real st = (wad >= 0.) ? lo : hi;
-            Real fu = (std::abs(wad) < small_vel) ? 0.0 : 1.0;
+            Real fu = (amrex::Math::abs(wad) < small_vel) ? 0.0 : 1.0;
             Imz(i, j, k, n) = fu*st + (1.0 - fu)*0.5*(hi + lo); // store zedge
         });
 
@@ -272,7 +272,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (wad >= 0.) ? l_zylo : l_zyhi;
-        Real fu = (std::abs(wad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(wad) < small_vel) ? 0.0 : 1.0;
         zylo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_zyhi + l_zylo);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -291,7 +291,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (vad >= 0.) ? l_yzlo : l_yzhi;
-        Real fu = (std::abs(vad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
         yzlo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_yzhi + l_yzlo);
     });
     //
@@ -318,7 +318,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = ( (stl+sth) >= 0.) ? stl : sth;
-        bool ltm = ( (stl <= 0. && sth >= 0.) || (std::abs(stl+sth) < small_vel) );
+        bool ltm = ( (stl <= 0. && sth >= 0.) || (amrex::Math::abs(stl+sth) < small_vel) );
         qx(i,j,k) = ltm ? 0. : st;
     });
 
@@ -350,7 +350,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (uad >= 0.) ? l_xzlo : l_xzhi;
-        Real fu = (std::abs(uad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
         xzlo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_xzhi + l_xzlo);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
@@ -369,7 +369,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (wad >= 0.) ? l_zxlo : l_zxhi;
-        Real fu = (std::abs(wad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(wad) < small_vel) ? 0.0 : 1.0;
         zxlo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_zxhi + l_zxlo);
     });
     //
@@ -396,7 +396,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = ( (stl+sth) >= 0.) ? stl : sth;
-        bool ltm = ( (stl <= 0. && sth >= 0.) || (std::abs(stl+sth) < small_vel) );
+        bool ltm = ( (stl <= 0. && sth >= 0.) || (amrex::Math::abs(stl+sth) < small_vel) );
         qy(i,j,k) = ltm ? 0. : st;
     });
 
@@ -428,7 +428,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (uad >= 0.) ? l_xylo : l_xyhi;
-        Real fu = (std::abs(uad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(uad) < small_vel) ? 0.0 : 1.0;
         xylo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_xyhi + l_xylo);
     },
     //
@@ -451,7 +451,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = (vad >= 0.) ? l_yxlo : l_yxhi;
-        Real fu = (std::abs(vad) < small_vel) ? 0.0 : 1.0;
+        Real fu = (amrex::Math::abs(vad) < small_vel) ? 0.0 : 1.0;
         yxlo(i,j,k) = fu*st + (1.0 - fu) * 0.5 * (l_yxhi + l_yxlo);
     });
     //
@@ -479,7 +479,7 @@ void godunov::predict_godunov (int lev, Box const& bx, int ncomp,
         constexpr Real small_vel = 1.e-10;
 
         Real st = ( (stl+sth) >= 0.) ? stl : sth;
-        bool ltm = ( (stl <= 0. && sth >= 0.) || (std::abs(stl+sth) < small_vel) );
+        bool ltm = ( (stl <= 0. && sth >= 0.) || (amrex::Math::abs(stl+sth) < small_vel) );
         qz(i,j,k) = ltm ? 0. : st;
     });
 }

--- a/src/convection/incflo_mol_predict.cpp
+++ b/src/convection/incflo_mol_predict.cpp
@@ -51,7 +51,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 u(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (upls + umns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     u(i,j,k) = 0.0;
                 } else if (avg > 0.0) {
                     u(i,j,k) = umns;
@@ -78,7 +78,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 u(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (upls + umns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     u(i,j,k) = 0.0;
                 } else if (avg > 0.0) {
                     u(i,j,k) = umns;
@@ -110,7 +110,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 v(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (vpls + vmns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     v(i,j,k) = 0.0;
                 } else if (avg > 0.0) {
                     v(i,j,k) = vmns;
@@ -137,7 +137,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 v(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (vpls + vmns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     v(i,j,k) = 0.0;
                 } else if (avg > 0.0) {
                     v(i,j,k) = vmns;
@@ -169,7 +169,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 w(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (wpls + wmns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     w(i,j,k) = 0.0;
                 } else if (avg > 0.0) {
                     w(i,j,k) = wmns;
@@ -196,7 +196,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
                 w(i,j,k) = 0.0;
             } else {
                 Real avg = 0.5 * (wpls + wmns);
-                if (std::abs(avg) < small_vel) {
+                if (amrex::Math::abs(avg) < small_vel) {
                     w(i,j,k) = 0.0;
             } else if (avg > 0.0) {
                     w(i,j,k) = wmns;

--- a/src/incflo_compute_dt.cpp
+++ b/src/incflo_compute_dt.cpp
@@ -93,9 +93,9 @@ void incflo::ComputeDt(bool explicit_diffusion)
                 });
         }
 
-        conv_cfl = std::max(conv_cfl, conv_lev);
-        diff_cfl = std::max(diff_cfl, diff_lev);
-        force_cfl = std::max(force_cfl, force_lev);
+        conv_cfl = amrex::max(conv_cfl, conv_lev);
+        diff_cfl = amrex::max(diff_cfl, diff_lev);
+        force_cfl = amrex::max(force_cfl, force_lev);
     }
 
     ParallelAllReduce::Max<Real>(conv_cfl, ParallelContext::CommunicatorSub());

--- a/src/incflo_compute_dt.cpp
+++ b/src/incflo_compute_dt.cpp
@@ -50,9 +50,9 @@ void incflo::ComputeDt(bool explicit_diffusion)
                 Real mx = -1.0;
                 amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
                     mx = amrex::max(
-                        std::abs(v(i, j, k, 0)) * dxinv[0],
-                        std::abs(v(i, j, k, 1)) * dxinv[1],
-                        std::abs(v(i, j, k, 2)) * dxinv[2], mx);
+                        amrex::Math::abs(v(i, j, k, 0)) * dxinv[0],
+                        amrex::Math::abs(v(i, j, k, 1)) * dxinv[1],
+                        amrex::Math::abs(v(i, j, k, 2)) * dxinv[2], mx);
                 });
                 return mx;
             });
@@ -85,9 +85,9 @@ void incflo::ComputeDt(bool explicit_diffusion)
                     Real mx = -1.0;
                     amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
                         mx = amrex::max(
-                            std::abs(vf(i, j, k, 0)) * dxinv[0],
-                            std::abs(vf(i, j, k, 1)) * dxinv[1],
-                            std::abs(vf(i, j, k, 2)) * dxinv[2], mx);
+                            amrex::Math::abs(vf(i, j, k, 0)) * dxinv[0],
+                            amrex::Math::abs(vf(i, j, k, 1)) * dxinv[1],
+                            amrex::Math::abs(vf(i, j, k, 2)) * dxinv[2], mx);
                     });
                     return mx;
                 });

--- a/src/incflo_tagging.cpp
+++ b/src/incflo_tagging.cpp
@@ -65,12 +65,12 @@ void incflo::ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow)
                     tag(i,j,k) = tagval;
                 }
                 if (tag_gradrho) {
-                    Real ax = std::abs(rho(i+1,j,k) - rho(i,j,k));
-                    Real ay = std::abs(rho(i,j+1,k) - rho(i,j,k));
-                    Real az = std::abs(rho(i,j,k+1) - rho(i,j,k));
-                    ax = amrex::max(ax,std::abs(rho(i,j,k) - rho(i-1,j,k)));
-                    ay = amrex::max(ay,std::abs(rho(i,j,k) - rho(i,j-1,k)));
-                    az = amrex::max(az,std::abs(rho(i,j,k) - rho(i,j,k-1)));
+                    Real ax = amrex::Math::abs(rho(i+1,j,k) - rho(i,j,k));
+                    Real ay = amrex::Math::abs(rho(i,j+1,k) - rho(i,j,k));
+                    Real az = amrex::Math::abs(rho(i,j,k+1) - rho(i,j,k));
+                    ax = amrex::max(ax,amrex::Math::abs(rho(i,j,k) - rho(i-1,j,k)));
+                    ay = amrex::max(ay,amrex::Math::abs(rho(i,j,k) - rho(i,j-1,k)));
+                    az = amrex::max(az,amrex::Math::abs(rho(i,j,k) - rho(i,j,k-1)));
                     if (amrex::max(ax,ay,az) >= gradrhoerr) {
                         tag(i,j,k) = tagval;
                     }

--- a/src/setup/set_background_pressure.cpp
+++ b/src/setup/set_background_pressure.cpp
@@ -19,7 +19,7 @@ void incflo::set_background_pressure ()
     // (1) incflo.delp in inputs
     int delp_dir = -1;
     for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-        if (std::abs(m_delp[dir]) > std::numeric_limits<Real>::epsilon()) {
+        if (amrex::Math::abs(m_delp[dir]) > std::numeric_limits<Real>::epsilon()) {
             //fixme
             amrex::Abort("m_gp0 is being filled with delp/L but not used in the gradp forcing need to fix this");
             if (delp_dir == -1) {

--- a/src/utilities/tagging/CartBoxRefinement.cpp
+++ b/src/utilities/tagging/CartBoxRefinement.cpp
@@ -60,8 +60,8 @@ amrex::BoxArray realbox_to_boxarray(
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             amrex::Real bbox_min = amrex::max(rb.lo()[i], problo[i]);
             amrex::Real bbox_max = amrex::min(rb.hi()[i], probhi[i]);
-            amrex::Real rlo = std::floor((bbox_min - problo[i]) / dx[i]);
-            amrex::Real rhi = std::ceil((bbox_max - problo[i]) / dx[i]);
+            amrex::Real rlo = amrex::Math::floor((bbox_min - problo[i]) / dx[i]);
+            amrex::Real rhi = amrex::Math::ceil((bbox_max - problo[i]) / dx[i]);
             lo[i] = static_cast<int>(rlo);
             hi[i] = static_cast<int>(rhi);
         }

--- a/src/utilities/tagging/CartBoxRefinement.cpp
+++ b/src/utilities/tagging/CartBoxRefinement.cpp
@@ -106,7 +106,7 @@ void CartBoxRefinement::read_inputs(const amrex::AmrCore& mesh, std::istream& if
 
     // Set the number of levels to the minimum of what is in the input file and
     // the simulation
-    m_nlevels = std::min(max_lev, nlev_in);
+    m_nlevels = amrex::min(max_lev, nlev_in);
 
     if (m_nlevels < 1) return;
 


### PR DESCRIPTION
Replace `std::` math functions with `amrex::Math` versions in preparation for DPC++