### PR TITLE
Implement temperature perturbations for ABL simulations

### DIFF
--- a/docs/sphinx_doc/user/inputs.rst
+++ b/docs/sphinx_doc/user/inputs.rst
@@ -526,8 +526,32 @@ This section is for setting atmospheric boundary layer parameters.
    **type:** Boolean, optional, default = false
    
    Perturb temperature field with random fluctuations.
-   This feature is currently deactivated. 
-	
+
+.. input_param:: ABL.theta_amplitude
+
+   **type:** Real, optional, default = 0.8 K
+
+   Amplitude of the temperature perturbations added to the initial field. Only
+   active when :input_param:`ABL.perturb_temperature` is true.
+
+.. input_param:: ABL.cutoff_height
+
+   **type:** Real, optional, default = domain height
+
+   Height below which temperature perturbations are added
+
+.. input_param:: ABL.random_gauss_mean
+
+   **type:** Real, optional, default = 0.0
+
+   Mean for the Gaussian random number generator
+
+.. input_param:: ABL.random_gauss_var
+
+   **type:** Real, optional, default = 1.0
+
+   Variance for the Gaussian random number generator
+
 	
 Section: ``Momentum Sources``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/wind_energy/ABL.cpp
+++ b/src/wind_energy/ABL.cpp
@@ -41,6 +41,12 @@ void ABL::initialize_fields(
     auto& density = m_density(level);
     auto& temp = (*m_temperature)(level);
 
+    if (m_field_init->add_temperature_perturbations()) {
+        m_field_init->perturb_temperature(level, geom, *m_temperature);
+    } else {
+        temp.setVal(0.0);
+    }
+
     for (amrex::MFIter mfi(density); mfi.isValid(); ++mfi) {
         const auto& vbx = mfi.validbox();
 

--- a/src/wind_energy/ABLFieldInit.H
+++ b/src/wind_energy/ABLFieldInit.H
@@ -1,6 +1,8 @@
 #ifndef ABLFIELDINIT_H
 #define ABLFIELDINIT_H
 
+#include "Field.H"
+
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
 #include "AMReX_Box.H"
@@ -26,6 +28,19 @@ public:
         const amrex::Array4<amrex::Real>& velocity,
         const amrex::Array4<amrex::Real>& density,
         const amrex::Array4<amrex::Real>& tracer) const;
+
+    /** Add temperature perturbations
+     *
+     *  This uses amrex::Random and, therefore, executes the loop on CPU and
+     *  pushes the field to device.
+     */
+    void perturb_temperature(
+        const int lev,
+        const amrex::Geometry& geom,
+        Field& temperature);
+
+    //! Flag indicating whether temperature field needs perturbations
+    bool add_temperature_perturbations() const { return m_perturb_theta; }
 
 private:
     //! Initial velocity components
@@ -60,6 +75,18 @@ private:
 
     //! Reference height for velocity perturbations
     amrex::Real m_ref_height{50.0};
+
+    //! Amplitude of temperature perturbations
+    amrex::Real m_deltaT{0.8};
+
+    //! Mean for Gaussian number generator
+    amrex::Real m_theta_gauss_mean{0.0};
+
+    //! Variance for Gaussian number generator
+    amrex::Real m_theta_gauss_var{1.0};
+
+    //! Cutoff height for temperature fluctuations
+    amrex::Real m_theta_cutoff_height{1.0e16};
 
     //! Perturb initial velocity field with sinusoidal fluctuations
     bool m_perturb_vel{true};

--- a/src/wind_energy/ABLFieldInit.cpp
+++ b/src/wind_energy/ABLFieldInit.cpp
@@ -25,6 +25,10 @@ ABLFieldInit::ABLFieldInit()
     pp.query("deltaV", m_deltaV);
 
     pp.query("perturb_temperature", m_perturb_theta);
+    pp.query("random_gauss_mean", m_theta_gauss_mean);
+    pp.query("random_gauss_var", m_theta_gauss_var);
+    pp.query("cutoff_height", m_theta_cutoff_height);
+    pp.query("theta_amplitude", m_deltaT);
 
     {
         // TODO: Modify this to accept velocity as a function of height
@@ -92,7 +96,7 @@ void ABLFieldInit::operator()(
             }
         }
 
-        temperature(i, j, k, 0) = theta;
+        temperature(i, j, k, 0) += theta;
 
         if (perturb_vel) {
             const amrex::Real xl = x - problo[0];
@@ -103,9 +107,36 @@ void ABLFieldInit::operator()(
             velocity(i, j, k, 0) += ufac * damp * z * std::cos(aval * yl);
             velocity(i, j, k, 1) += vfac * damp * z * std::cos(bval * xl);
         }
-
-        // TODO: Implement temperature perturbations
     });
+}
+
+void ABLFieldInit::perturb_temperature(
+    const int lev,
+    const amrex::Geometry& geom,
+    Field& temperature)
+{
+    const auto& dx = geom.CellSizeArray();
+    const auto& problo = geom.ProbLoArray();
+    auto& theta_fab = temperature(lev);
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(theta_fab, amrex::TilingIfNotGPU()); mfi.isValid();
+         ++mfi) {
+        const auto& bx = mfi.tilebox();
+        const auto& theta = theta_fab.array(mfi);
+
+        amrex::LoopOnCpu(bx, [&](int i, int j, int k) noexcept {
+            const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+
+            if (z < m_theta_cutoff_height)
+                theta(i, j, k) =
+                    m_deltaT *
+                    amrex::RandomNormal(m_theta_gauss_mean, m_theta_gauss_var);
+        });
+    }
+    amrex::prefetchToDevice(theta_fab);
 }
 
 } // namespace amr_wind

--- a/src/wind_energy/ABLFieldInit.cpp
+++ b/src/wind_energy/ABLFieldInit.cpp
@@ -115,6 +115,15 @@ void ABLFieldInit::perturb_temperature(
     const amrex::Geometry& geom,
     Field& temperature)
 {
+    /** Perturbations for the temperature field is adapted from the following paper:
+     *
+     *  D. Munoz-Esparza, B. Kosovic, J. van Beeck, J. D. Mirocha, A stocastic
+     *  perturbation method to generate inflow turbulence in large-eddy
+     *  simulation models: Application to neutrally stratified atmospheric
+     *  boundary layers. Physics of Fluids, Vol. 27, 2015.
+     *
+     */
+
     const auto& dx = geom.CellSizeArray();
     const auto& problo = geom.ProbLoArray();
     auto& theta_fab = temperature(lev);


### PR DESCRIPTION
Uses amrex::Random to generate random fluctuations in temperature field. This
executes the loop on host and then transfers the field to device, so is GPU
safe.

Closes #103