### PR TITLE
Fix failing unit-test for Intel compiler

### DIFF
--- a/unit_tests/core/CMakeLists.txt
+++ b/unit_tests/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(
   ${amr_wind_unit_test_exe_name} PRIVATE
+  physics_test_utils.cpp
 
   test_simtime.cpp
   test_field.cpp

--- a/unit_tests/core/physics_test_utils.H
+++ b/unit_tests/core/physics_test_utils.H
@@ -1,0 +1,28 @@
+#ifndef PHYSICS_TEST_UTILS_H
+#define PHYSICS_TEST_UTILS_H
+
+#include <string>
+
+#include "amr-wind/core/Physics.H"
+
+namespace amr_wind_tests {
+
+class PhysicsEx : public amr_wind::Physics::Register<PhysicsEx>
+{
+public:
+    static const std::string identifier() { return "PhysicsEx"; }
+
+    PhysicsEx(amr_wind::CFDSim&);
+
+    virtual ~PhysicsEx() = default;
+
+    void post_init_actions() override;
+    void post_regrid_actions() override;
+    void initialize_fields(int, const amrex::Geometry&) override;
+    void pre_advance_work() override;
+    void post_advance_work() override;
+};
+
+}
+
+#endif /* PHYSICS_TEST_UTILS_H */

--- a/unit_tests/core/physics_test_utils.cpp
+++ b/unit_tests/core/physics_test_utils.cpp
@@ -1,0 +1,13 @@
+#include "physics_test_utils.H"
+
+namespace amr_wind_tests {
+
+PhysicsEx::PhysicsEx(amr_wind::CFDSim&) {}
+
+void PhysicsEx::post_init_actions()  {}
+void PhysicsEx::post_regrid_actions()  {}
+void PhysicsEx::initialize_fields(int, const amrex::Geometry&)  {}
+void PhysicsEx::pre_advance_work()  {}
+void PhysicsEx::post_advance_work()  {}
+
+}

--- a/unit_tests/core/test_physics.cpp
+++ b/unit_tests/core/test_physics.cpp
@@ -1,26 +1,17 @@
 #include "aw_test_utils/MeshTest.H"
 #include "amr-wind/core/Physics.H"
+#include "physics_test_utils.H"
 
 namespace amr_wind_tests {
 
 class PhysicsTest : public MeshTest
 {};
 
-class PhysicsEx : public amr_wind::Physics::Register<PhysicsEx>
+TEST_F(PhysicsTest, physics_example)
 {
-public:
-    static const std::string identifier() { return "PhysicsEx"; }
-
-    PhysicsEx(amr_wind::CFDSim&) {}
-
-    virtual ~PhysicsEx() = default;
-
-    void post_init_actions() override {}
-    void post_regrid_actions() override {}
-    void initialize_fields(int, const amrex::Geometry&) override {}
-    void pre_advance_work() override {}
-    void post_advance_work() override {}
-};
+    PhysicsEx obj(sim());
+    EXPECT_EQ("PhysicsEx", obj.identifier());
+}
 
 TEST_F(PhysicsTest, physics_interface)
 {


### PR DESCRIPTION
Introduce an indirection to force Intel compiler to retain the PhysicsEx class.