### PR TITLE
Add tolerance for fcompare when using CUDA

### DIFF
--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -33,10 +33,13 @@ function(add_test_r TEST_NAME)
     # Copy files to test working directory
     file(COPY ${TEST_FILES} DESTINATION "${CURRENT_TEST_BINARY_DIR}/")
     # Set some default runtime options for all tests in this category
-    set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt amr.checkpoint_files_output=0 amr.plot_files_output=1 amrex.throw_exception=1 amrex.signal_handling=0")
+    set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 time.checkpoint_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
+    #if(AMR_WIND_ENABLE_CUDA)
+      set(FCOMPARE_TOLERANCE "-r 1e-12")
+    #endif()
     # Use fcompare to test diffs in plots against gold files
     if(AMR_WIND_TEST_WITH_FCOMPARE)
-      set(FCOMPARE_COMMAND "&& ${FCOMPARE} ${PLOT_GOLD} ${PLOT_TEST}")
+      set(FCOMPARE_COMMAND "&& ${FCOMPARE} ${FCOMPARE_TOLERANCE} ${PLOT_GOLD} ${PLOT_TEST}")
     endif()
     if(AMR_WIND_ENABLE_MPI)
       set(NP 4)

--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -33,7 +33,7 @@ function(add_test_r TEST_NAME)
     # Copy files to test working directory
     file(COPY ${TEST_FILES} DESTINATION "${CURRENT_TEST_BINARY_DIR}/")
     # Set some default runtime options for all tests in this category
-    set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 time.checkpoint_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
+    set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
     if(AMR_WIND_ENABLE_CUDA)
       set(FCOMPARE_TOLERANCE "-r 1e-12")
     endif()

--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -34,9 +34,9 @@ function(add_test_r TEST_NAME)
     file(COPY ${TEST_FILES} DESTINATION "${CURRENT_TEST_BINARY_DIR}/")
     # Set some default runtime options for all tests in this category
     set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 time.checkpoint_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
-    #if(AMR_WIND_ENABLE_CUDA)
+    if(AMR_WIND_ENABLE_CUDA)
       set(FCOMPARE_TOLERANCE "-r 1e-12")
-    #endif()
+    endif()
     # Use fcompare to test diffs in plots against gold files
     if(AMR_WIND_TEST_WITH_FCOMPARE)
       set(FCOMPARE_COMMAND "&& ${FCOMPARE} ${FCOMPARE_TOLERANCE} ${PLOT_GOLD} ${PLOT_TEST}")


### PR DESCRIPTION
Since GPU results are nondeterministic, this adds a 1e-12 tolerance bound when CUDA is enabled to fix test failures from the gold file comparison. This also fixes the default override for test checkpoint and plot intervals I initially had wrong.