### PR TITLE
Fix IO plt file time

### DIFF
--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -120,7 +120,7 @@ void IOManager::write_plot_file()
         << m_sim.time().new_time() << std::endl;
     amrex::WriteMultiLevelPlotfile(
         plt_filename, nlevels, outfield->vec_const_ptrs(), m_plt_var_names,
-        mesh.Geom(), m_sim.time().current_time(), istep, mesh.refRatio());
+        mesh.Geom(), m_sim.time().new_time(), istep, mesh.refRatio());
 
     write_info_file(plt_filename);
 }


### PR DESCRIPTION
IO time was misreported in the plot file

before this commit:
![Screen Shot 2020-06-03 at 9 38 09 AM](https://user-images.githubusercontent.com/15038415/83657491-27c67000-a57e-11ea-88e7-76c9b66f1c82.png)

with this commit:
![Screen Shot 2020-06-03 at 9 38 24 AM](https://user-images.githubusercontent.com/15038415/83657505-2b59f700-a57e-11ea-85cc-cb2a043e36ee.png)

Notice the time went from `0.5` to the correct value of `0.51`. The step output in those pictures are from CTV at:
```
==============================================================================
Step: 51 Time: 0.5
CFL: 0.4806488239 dt: 0.01

Godunov:
  System                     Iters      Initial residual        Final residual
  ----------------------------------------------------------------------------
  MAC_projection                 9          0.2808165601       3.232969448e-13
  velocity_solve                 3       0.0003100551825       5.606626274e-14
  Nodal_projection               7          0.1997638897       4.614364446e-13

Writing plot file       plt00051 at time 0.51
Time, Kinetic Energy: 0.51, 1.244217776
WallClockTime: 51 Solve: 0.37148094 Misc: 0.019176 Total: 0.3906579
```

