### PR TITLE
Add verfication test category and add MMS 2nd order verification test

### DIFF
--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -5,6 +5,10 @@ if(AMR_WIND_TEST_WITH_FCOMPARE)
   message(STATUS "Test golds directory for fcompare: ${FCOMPARE_GOLD_FILES_DIRECTORY}")
 endif()
 
+if(AMR_WIND_ENABLE_MASA AND NOT AMR_WIND_ENABLE_MPI)
+  message(WARNING "Running verification tests without MPI enabled will require long run times")
+endif()
+
 # Have CMake discover the number of cores on the node
 include(ProcessorCount)
 ProcessorCount(PROCESSES)
@@ -72,6 +76,52 @@ function(add_test_red TEST_NAME TEST_DEPENDENCY)
     set_tests_properties(${TEST_DEPENDENCY} PROPERTIES FIXTURES_SETUP fixture_${TEST_DEPENDENCY})
 endfunction(add_test_red)
 
+# Verification test using multiple resolutions
+function(add_test_v TEST_NAME LIST_OF_GRID_SIZES)
+    # Make sure run command is cleared before we construct it
+    unset(MASTER_RUN_COMMAND)
+    # Set variables for respective binary and source directories for the test
+    set(CURRENT_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${TEST_NAME})
+    set(CURRENT_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_files/${TEST_NAME})
+    # Get last item in resolution list so we can find out when we are on the last item in our loop
+    list(GET LIST_OF_GRID_SIZES -1 LAST_GRID_SIZE_IN_LIST)
+    # Create the commands to run for each resolution
+    foreach(GRID_SIZE IN LISTS LIST_OF_GRID_SIZES)
+      # Make working directory for test
+      file(MAKE_DIRECTORY ${CURRENT_TEST_BINARY_DIR}/${GRID_SIZE})
+      # Gather all files in source directory for test
+      file(GLOB TEST_FILES "${CURRENT_TEST_SOURCE_DIR}/*")
+      # Copy files to test working directory
+      file(COPY ${TEST_FILES} DESTINATION "${CURRENT_TEST_BINARY_DIR}/${GRID_SIZE}/")
+      # Set number of cells at runtime according to dimension
+      set(NCELLS "${GRID_SIZE} ${GRID_SIZE} ${GRID_SIZE}")
+      if(AMR_WIND_ENABLE_MPI)
+        set(NP 4)
+        set(MPI_COMMANDS "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${NP} ${MPIEXEC_PREFLAGS}")
+      else()
+        set(NP 1)
+        unset(MPI_COMMANDS)
+      endif()
+      # Set the run command for this resolution
+      set(RUN_COMMAND_${GRID_SIZE} "${MPI_COMMANDS} ${CMAKE_BINARY_DIR}/${amr_wind_exe_name} ${MPIEXEC_POSTFLAGS} ${CURRENT_TEST_BINARY_DIR}/${GRID_SIZE}/${TEST_NAME}.i")
+      # Set some runtime options for each resolution
+      set(RUNTIME_OPTIONS_${GRID_SIZE} "amrex.throw_exception=1 amrex.signal_handling=0 amr.n_cell=${NCELLS}")
+      # Construct our large run command for the entire test with everything &&'d together
+      string(APPEND MASTER_RUN_COMMAND "cd ${CURRENT_TEST_BINARY_DIR}/${GRID_SIZE}")
+      string(APPEND MASTER_RUN_COMMAND " && ")
+      string(APPEND MASTER_RUN_COMMAND "${RUN_COMMAND_${GRID_SIZE}} ${RUNTIME_OPTIONS_${GRID_SIZE}}")
+      # Add another " && " unless we are on the last resolution in the list
+      if(NOT ${GRID_SIZE} EQUAL ${LAST_GRID_SIZE_IN_LIST})
+        string(APPEND MASTER_RUN_COMMAND " && ")
+      endif()
+    endforeach()
+    # Convert list of grid sizes to space separated string
+    list(JOIN LIST_OF_GRID_SIZES " " STRING_OF_GRID_SIZES)
+    # Add test and actual test commands to CTest database (python script requires a very specific python environment)
+    add_test(${TEST_NAME} sh -c "${MASTER_RUN_COMMAND} && cd ${CURRENT_TEST_BINARY_DIR} && ${PYTHON_EXECUTABLE} ${CURRENT_TEST_SOURCE_DIR}/plotter.py -f ${STRING_OF_GRID_SIZES}")
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 7200 PROCESSORS ${NP} WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}" LABELS "verification;no_ci" ATTACHED_FILES "plots.pdf")
+endfunction(add_test_v)
+
 # Standard unit test
 function(add_test_u TEST_NAME)
     # Set variables for respective binary and source directories for the test
@@ -138,6 +188,10 @@ add_test_red(abl_godunov_restart abl_godunov)
 #=============================================================================
 # Verification tests
 #=============================================================================
+if(AMR_WIND_ENABLE_MASA)
+  set(LIST_OF_GRID_SIZES 8 16 32 64)
+  add_test_v(mms "${LIST_OF_GRID_SIZES}")
+endif()
 
 #=============================================================================
 # Performance tests

--- a/test/test_files/mms/mms.i
+++ b/test/test_files/mms/mms.i
@@ -1,0 +1,41 @@
+time.max_step                = 1000000
+time.stop_time               = 5.0           # Max (simulated) time to evolve
+
+incflo.use_godunov                     = true
+
+time.fixed_dt = 0.05
+time.cfl              = 0.49           # CFL factor
+time.init_shrink      = 1.0
+
+time.plot_interval            =   140         # Steps between plot files
+time.checkpoint_interval           =  -100         # Steps between checkpoint files
+
+transport.viscosity = 1.0
+transport.laminar_prandtl = 0.33333333333333337
+turbulence.model = Laminar
+
+amr.max_level           =   0
+amr.n_cell              =   16 16 16     # Grid cells at coarsest AMRlevel
+amr.max_grid_size       =   16 16 16  # Max grid size at AMR levels
+amr.blocking_factor     =   8            # Blocking factor for grids
+
+geometry.prob_lo        = -3.14159265358979323 -3.14159265358979323 -3.14159265358979323 # Lo corner coordinates
+geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.14159265358979323 # Hi corner coordinates
+  
+geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
+
+incflo.probtype         =  0
+incflo.gravity          = 0. 0. 0.
+
+incflo.physics = MMS
+MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"
+ICNS.source_terms = MMSForcing
+
+incflo.diffusion_type   = 2             # 0 = Explicit, 1 = Crank-Nicolson, 2 = Implicit
+
+incflo.verbose          =   1           # incflo_level
+mac_proj.verbose        =   0           # MAC Projector
+nodal_proj.verbose      =   0           # Nodal Projector
+diffusion.mg_verbose    =   0           # Diffusion
+
+mac_proj.mg_rtol        = 1.e-12

--- a/test/test_files/mms/plotter.py
+++ b/test/test_files/mms/plotter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+import pandas as pd
+
+plt.rc("text", usetex=True)
+cmap_med = [
+    "#F15A60",
+    "#7AC36A",
+    "#5A9BD4",
+    "#FAA75B",
+    "#9E67AB",
+    "#CE7058",
+    "#D77FB4",
+    "#737373",
+]
+cmap = [
+    "#EE2E2F",
+    "#008C48",
+    "#185AA9",
+    "#F47D23",
+    "#662C91",
+    "#A21D21",
+    "#B43894",
+    "#010202",
+]
+dashseq = [
+    (None, None),
+    [10, 5],
+    [10, 4, 3, 4],
+    [3, 3],
+    [10, 4, 3, 4, 3, 4],
+    [3, 3],
+    [3, 3],
+]
+markertype = ["s", "d", "o", "p", "h"]
+
+
+if __name__ == "__main__":
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="A simple plot tool")
+    parser.add_argument(
+        "-f", "--fdirs", help="Folders to plot", type=str, required=True, nargs="+"
+    )
+    args = parser.parse_args()
+
+    fields = ["u", "v", "w"]
+
+    lst = []
+    for k, fdir in enumerate(args.fdirs):
+        df = pd.read_csv(os.path.join(fdir, "mms.log"), delim_whitespace=True)
+        df["res"] = float(fdir)
+        lst.append(df.iloc[-1])
+
+        for field in fields:
+            plt.figure(field)
+            p = plt.plot(df.time, df[f"L2_{field}"], lw=2, color=cmap[k], label=fdir)
+            p[0].set_dashes(dashseq[k])
+
+    df = pd.DataFrame(lst)
+    idx = 1
+    theory_order = 2
+    df["theory"] = df["L2_u"].iloc[idx] * (df.res.iloc[idx] / df.res) ** theory_order
+
+    fname = "plots.pdf"
+    with PdfPages(fname) as pdf:
+        for k, field in enumerate(fields):
+            plt.figure(field)
+            ax = plt.gca()
+            plt.xlabel(r"$t$", fontsize=22, fontweight="bold")
+            plt.ylabel(f"$L_2({field})$", fontsize=22, fontweight="bold")
+            plt.setp(ax.get_xmajorticklabels(), fontsize=18, fontweight="bold")
+            plt.setp(ax.get_ymajorticklabels(), fontsize=18, fontweight="bold")
+            legend = ax.legend(loc="best")
+            plt.tight_layout()
+            pdf.savefig(dpi=300)
+
+            plt.figure(f"ooa")
+            plt.loglog(
+                df.res,
+                df[f"L2_{field}"],
+                lw=2,
+                color=cmap[k],
+                marker=markertype[k],
+                mec=cmap[k],
+                mfc=cmap[k],
+                ms=10,
+                label=field,
+            )
+
+        plt.figure(f"ooa")
+        plt.loglog(df.res, df.theory, lw=1, color=cmap[-1], label="2nd order")
+        ax = plt.gca()
+        plt.xlabel(r"$N$", fontsize=22, fontweight="bold")
+        plt.ylabel(r"$L_2$", fontsize=22, fontweight="bold")
+        plt.setp(ax.get_xmajorticklabels(), fontsize=18, fontweight="bold")
+        plt.setp(ax.get_ymajorticklabels(), fontsize=18, fontweight="bold")
+        legend = ax.legend(loc="best")
+        plt.tight_layout()
+        pdf.savefig(dpi=300)


### PR DESCRIPTION
This allows anyone to run @marchdf 's MMS 2nd order verification. This test does require many Python packages to be available at run time, such as matplotlib and pandas. The test produces a `plots.pdf` file and is uploaded to CDash. Currently the python script doesn't appear to automatically check for 2nd order, so the test passes if the PDF is generated. Probably should add such a check in the future.