### PR TITLE
Enable CUDA CI workflow using docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.*
+test
+build*
+docs
+tools

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -1,0 +1,33 @@
+name: AMR-Wind CUDA CI
+
+on:
+  push:
+    branches:
+      - development
+    paths:
+      - 'cmake/**'
+      - 'amr-wind/**'
+      - 'submods/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - 'Dockerfile'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    branches:
+      - development
+    paths:
+      - 'cmake/**'
+      - 'amr-wind/**'
+      - 'submods/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - 'Dockerfile'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check CUDA build
+        run: docker build -t amr-wind .

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -29,5 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Check CUDA build
         run: docker build -t amr-wind .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM exawind/exw-cuda-dev:latest as base
+
+WORKDIR /amr-wind
+COPY . /amr-wind
+
+ARG ENABLE_CUDA=ON
+ARG ENABLE_MPI=OFF
+
+RUN (\
+    cmake \
+        -Bbuild \
+        -DCMAKE_INSTALL_PREFIX=/opt/exawind \
+        -DAMR_WIND_ENABLE_MPI=${ENABLE_MPI} \
+        -DAMR_WIND_ENABLE_CUDA=${ENABLE_CUDA} \
+        -DAMR_WIND_ENABLE_OPENMP=OFF \
+        -DAMR_WIND_ENABLE_MASA=OFF \
+        -DAMR_WIND_ENABLE_TESTS=OFF . \
+    && cd build \
+    && make -j$(nproc) \
+    )


### PR DESCRIPTION
Use Docker dev environment based on [nvidia/cuda:10.2-devel](https://hub.docker.com/r/nvidia/cuda/) to test compilation of AMR-Wind with NVIDIA CUDA compiler. This will only test that the compilation builds successfully, but cannot run any of the tests as the GitHub machines don't have GPUs. Still I think it would catch errors like the one fixed in #159 