### PR TITLE
Enable fortran as a cmake language again to fix GPU builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ############################ BASE ######################################
 
 cmake_minimum_required (VERSION 3.14 FATAL_ERROR)
-project(AMR-Wind CXX C Fortran)
+project(AMR-Wind CXX C)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
@@ -36,6 +36,10 @@ option(AMR_WIND_ENABLE_MASA "Enable MASA library" OFF)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT AMR_WIND_ENABLE_DPCPP)
+  enable_language(Fortran)
+endif()
 
 if(AMR_WIND_ENABLE_CUDA)
   enable_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ############################ BASE ######################################
 
 cmake_minimum_required (VERSION 3.14 FATAL_ERROR)
-project(AMR-Wind CXX C)
+project(AMR-Wind CXX C Fortran)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,12 +37,10 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(NOT AMR_WIND_ENABLE_DPCPP)
-  enable_language(Fortran)
-endif()
-
 if(AMR_WIND_ENABLE_CUDA)
   enable_language(CUDA)
+  # Fix issues with GPU builds
+  enable_language(Fortran)
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.0")
     message(FATAL_ERROR "Your nvcc version is ${CMAKE_CUDA_COMPILER_VERSION} which is unsupported."
       "Please use CUDA toolkit version 10.0 or newer.")


### PR DESCRIPTION
I was able to build with CUDA again by just adding fortran as a language. Doesn't seem that the commit that removed it will need to be reverted.