### PR TITLE
Add masking for overset in linear solver calls

### DIFF
--- a/amr-wind/equation_systems/AdvOp_Godunov.H
+++ b/amr-wind/equation_systems/AdvOp_Godunov.H
@@ -37,7 +37,8 @@ struct AdvectionOp<
         iconserv.resize(PDE::ndim, 1);
     }
 
-    void operator()(const FieldState fstate, const amrex::Real dt)
+    void operator()(const FieldState fstate, const amrex::Real dt,
+                    const bool /* has_overset */)
     {
         static_assert(PDE::ndim == 1, "Invalid number of components for scalar");
         auto& repo = fields.repo;

--- a/amr-wind/equation_systems/AdvOp_MOL.H
+++ b/amr-wind/equation_systems/AdvOp_MOL.H
@@ -31,7 +31,8 @@ struct AdvectionOp<
     , w_mac(fields_in.repo.get_field("w_mac"))
     {}
 
-    void operator()(const FieldState fstate, const amrex::Real )
+    void operator()(const FieldState fstate, const amrex::Real ,
+                    const bool /* has_overset */)
     {
         static_assert(PDE::ndim == 1, "Invalid number of components for scalar");
 

--- a/amr-wind/equation_systems/DiffusionOps.H
+++ b/amr-wind/equation_systems/DiffusionOps.H
@@ -27,7 +27,10 @@ template <typename LinOp>
 class DiffSolverIface
 {
 public:
-    DiffSolverIface(PDEFields& fields, const std::string& prefix = "diffusion");
+    DiffSolverIface(
+        PDEFields& fields,
+        const bool has_overset,
+        const std::string& prefix = "diffusion");
 
     virtual ~DiffSolverIface() = default;
 
@@ -103,8 +106,8 @@ struct DiffusionOp<
     static_assert(std::is_same<typename PDE::MLDiffOp, amrex::MLABecLaplacian>::value,
                   "Invalid linear operator for scalar diffusion operator");
 
-    DiffusionOp(PDEFields& fields)
-        : DiffSolverIface<typename PDE::MLDiffOp>(fields)
+    DiffusionOp(PDEFields& fields, const bool has_overset)
+        : DiffSolverIface<typename PDE::MLDiffOp>(fields, has_overset)
     {
         this->m_solver->setDomainBC(
             diffusion::get_diffuse_scalar_bc(this->m_pdefields.field, amrex::Orientation::low),

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -105,7 +105,7 @@ public:
     void compute_advection_term(const FieldState fstate) override
     {
         BL_PROFILE("amr-wind::" + this->identifier() + "::compute_advection_term");
-        m_adv_op(fstate, m_time.deltaT());
+        m_adv_op(fstate, m_time.deltaT(), m_sim.has_overset());
     }
 
     virtual void compute_predictor_rhs(const DiffusionType difftype) override

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -59,7 +59,7 @@ public:
     {
         if (PDE::has_diffusion) {
             BL_PROFILE("amr-wind::" + this->identifier() + "::initialize");
-            m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields));
+            m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
             m_turb_op.reset(new TurbulenceOp<PDE>(m_sim.turbulence_model(), m_fields));
         }
 
@@ -71,7 +71,7 @@ public:
     {
         if (PDE::has_diffusion){
             BL_PROFILE("amr-wind::" + this->identifier() + "::post_regrid_actions");
-            m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields));
+            m_diff_op.reset(new DiffusionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
         }
     }
 

--- a/amr-wind/equation_systems/icns/icns_diffusion.H
+++ b/amr-wind/equation_systems/icns/icns_diffusion.H
@@ -24,8 +24,8 @@ struct DiffusionOp<ICNS, Scheme>
         std::is_same<typename ICNS::MLDiffOp, amrex::MLTensorOp>::value,
         "Invalid linear operator for scalar diffusion operator");
 
-    DiffusionOp(PDEFields& fields)
-        : DiffSolverIface<typename ICNS::MLDiffOp>(fields)
+    DiffusionOp(PDEFields& fields, const bool has_overset)
+        : DiffSolverIface<typename ICNS::MLDiffOp>(fields, has_overset)
     {
         this->m_solver->setDomainBC(
             diffusion::get_diffuse_tensor_bc(

--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -13,7 +13,7 @@
 namespace amr_wind {
 namespace pde {
 
-void advection_mac_project(FieldRepo& repo, FieldState fstate);
+void advection_mac_project(FieldRepo& repo, FieldState fstate, const bool);
 
 /** Specialization of field registration for ICNS
  *  \ingroup icns
@@ -137,7 +137,8 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         iconserv.resize(ICNS::ndim, 0);
     }
 
-    void operator()(const FieldState fstate, const amrex::Real dt)
+    void operator()(
+        const FieldState fstate, const amrex::Real dt, const bool has_overset)
     {
         auto& repo = fields.repo;
         auto& geom = repo.mesh().Geom();
@@ -229,7 +230,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         }
 
         // MAC projection
-        advection_mac_project(repo, fstate);
+        advection_mac_project(repo, fstate, has_overset);
 
         //
         // Advect momentum eqns
@@ -288,7 +289,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
     , w_mac(fields_in.repo.get_field("w_mac"))
     {}
 
-    void operator()(const FieldState fstate, const amrex::Real )
+    void operator()(const FieldState fstate, const amrex::Real , const bool has_overset)
     {
 
         auto& repo = fields.repo;
@@ -327,7 +328,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
             }
         }
 
-        advection_mac_project(repo, fstate);
+        advection_mac_project(repo, fstate, has_overset);
 
         //
         // Advect velocity

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -255,6 +255,15 @@ void incflo::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& new_gr
 
 void incflo::init_physics_and_pde()
 {
+    {
+        // Query and activate overset before initializing PDEs and physics
+        amrex::ParmParse pp("incflo");
+        bool activate_overset = false;
+        pp.query("activate_overset", activate_overset);
+
+        if (activate_overset) m_sim.activate_overset();
+    }
+
     auto& pde_mgr = m_sim.pde_manager();
 
     // Always register incompressible Navier-Stokes equation

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -60,11 +60,19 @@ TiogaInterface::TiogaInterface(CFDSim& sim)
 void TiogaInterface::post_init_actions()
 {
     amr_to_tioga_mesh();
+
+    // Initialize masking so that all cells are active in solvers
+    m_mask_cell.setVal(0);
+    m_mask_node.setVal(0);
 }
 
 void TiogaInterface::post_regrid_actions()
 {
     amr_to_tioga_mesh();
+
+    // Initialize masking so that all cells are active in solvers
+    m_mask_cell.setVal(0);
+    m_mask_node.setVal(0);
 }
 
 void TiogaInterface::pre_overset_conn_work()

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -182,6 +182,16 @@ void incflo::ApplyProjection (Vector<MultiFab const*> density,
     nodal_projector.reset(new NodalProjector(vel, GetVecOfConstPtrs(sigma),
                                              Geom(0,finest_level), LPInfo()));
     nodal_projector->setDomainBC(bclo, bchi);
+
+    // Setup masking for overset simulations
+    if (sim().has_overset()) {
+        auto& linop = nodal_projector->getLinOp();
+        auto& imask_node = repo().get_int_field("mask_node");
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            linop.setDirichletMask(lev, imask_node(lev));
+        }
+    }
+
     nodal_projector->setVerbose(options.verbose);
     nodal_projector->project(options.rel_tol, options.abs_tol);
     amr_wind::io::print_mlmg_info("Nodal_projection", nodal_projector->getMLMG());


### PR DESCRIPTION
This PR introduces the _overset mask_ information into linear solver calls – nodal projection, tensor/scalar diffusion solve, and MAC projection

- Adds necessary calls to the AMReX linear solver constructors to pass overset masking information when overset is active. If overset is inactive, then the original code pathways are used. 

- Initializes the masking field to `no overset` state so that passing the overset mask field should generate same results as a non-overset run

- Adds an `activate_overset` input parameter so that overset code paths can be tested in standalone AMR-Wind regression tests