### PR TITLE
Fix omega in CTV

### DIFF
--- a/amr-wind/physics/ConvectingTaylorVortex.cpp
+++ b/amr-wind/physics/ConvectingTaylorVortex.cpp
@@ -53,7 +53,7 @@ ConvectingTaylorVortex::ConvectingTaylorVortex(const CFDSim& sim)
         amrex::Real nu;
         amrex::ParmParse pp("transport");
         pp.query("viscosity", nu);
-        m_omega = utils::pi() * nu;
+        m_omega = utils::pi() * utils::pi() * nu;
     }
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream f;


### PR DESCRIPTION
The value of `omega` was wrong in CTV. It should be `pi^2 nu`

Thanks @michaeljbrazell for finding this.