### PR TITLE
Overset updates for AMR-Wind

### DIFF
--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -39,7 +39,7 @@ struct FieldRegOp<ICNS, Scheme>
         auto& rho = repo.declare_cc_field(
             "density", 1, Scheme::nghost_state, Scheme::num_states);
         auto& grad_p = repo.declare_cc_field("gp", ICNS::ndim, 0, 1);
-        auto& pressure = repo.declare_nd_field("p", 1, 0, 1);
+        auto& pressure = repo.declare_nd_field("p", 1, Scheme::nghost_state, 1);
         repo.declare_face_normal_field(
             {"u_mac", "v_mac", "w_mac"}, 1, Scheme::nghost_mac, 1);
 

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -62,8 +62,8 @@ void TiogaInterface::post_init_actions()
     amr_to_tioga_mesh();
 
     // Initialize masking so that all cells are active in solvers
-    m_mask_cell.setVal(0);
-    m_mask_node.setVal(0);
+    m_mask_cell.setVal(1);
+    m_mask_node.setVal(1);
 }
 
 void TiogaInterface::post_regrid_actions()
@@ -71,8 +71,8 @@ void TiogaInterface::post_regrid_actions()
     amr_to_tioga_mesh();
 
     // Initialize masking so that all cells are active in solvers
-    m_mask_cell.setVal(0);
-    m_mask_node.setVal(0);
+    m_mask_cell.setVal(1);
+    m_mask_node.setVal(1);
 }
 
 void TiogaInterface::pre_overset_conn_work()

--- a/amr-wind/physics/ConvectingTaylorVortex.H
+++ b/amr-wind/physics/ConvectingTaylorVortex.H
@@ -85,6 +85,8 @@ private:
 
     //! error log file
     const std::string m_output_fname{"ctv.log"};
+
+    bool m_activate_pressure{false};
 };
 } // namespace ctv
 } // namespace amr_wind


### PR DESCRIPTION
- Update overset mask definitions to be consistent with AMReX linear solvers
- Use existing pressure field in nodal projection in presence of overset 
- Increase ghost nodes for pressure to be consistent with velocity (as required by TIOGA AMR interface)
- Allow CTV to also initialize pressure field for use with overset simulations coupled to nalu-wind. 