### PR TITLE
Fix inflow/outflow for ABL simulations

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
@@ -3,6 +3,7 @@
 
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/equation_systems/icns/MomentumSource.H"
+#include "amr-wind/utilities/FieldPlaneAveraging.H"
 
 namespace amr_wind {
 namespace pde {
@@ -31,16 +32,25 @@ public:
         const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
+    void mean_temperature_init(const FieldPlaneAveraging&);
+
+    void mean_temperature_update(const FieldPlaneAveraging&);
+
 private:
     const amrex::AmrCore& m_mesh;
 
     amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+
+    amrex::Gpu::DeviceVector<amrex::Real> m_theta_ht;
+    amrex::Gpu::DeviceVector<amrex::Real> m_theta_vals;
 
     //! Reference temperature (Kelvin)
     amrex::Real m_ref_theta{300.0};
 
     //! Thermal expansion coefficient
     amrex::Real m_beta{0.0};
+
+    int m_axis{2};
 };
 } // namespace icns
 

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
@@ -1,0 +1,51 @@
+#ifndef ABLMEANBOUSSINESQ_H
+#define ABLMEANBOUSSINESQ_H
+
+#include "amr-wind/core/FieldRepo.H"
+#include "amr-wind/equation_systems/icns/MomentumSource.H"
+
+namespace amr_wind {
+namespace pde {
+namespace icns {
+
+/** Boussinesq bouyancy source term
+ *  \ingroup icns_src we_abl
+ *
+ *  \f[
+ *    S = \beta g \left( T_\mathrm{mean} - T_\mathrm{ref} \right)
+ *  \f]
+ */
+class ABLMeanBoussinesq : public MomentumSource::Register<ABLMeanBoussinesq>
+{
+public:
+    static const std::string identifier() { return "ABLMeanBoussinesq"; }
+
+    ABLMeanBoussinesq(const CFDSim& sim);
+
+    virtual ~ABLMeanBoussinesq();
+
+    virtual void operator()(
+        const int lev,
+        const amrex::MFIter& mfi,
+        const amrex::Box& bx,
+        const FieldState fstate,
+        const amrex::Array4<amrex::Real>& src_term) const override;
+
+private:
+    const amrex::AmrCore& m_mesh;
+
+    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+
+    //! Reference temperature (Kelvin)
+    amrex::Real m_ref_theta{300.0};
+
+    //! Thermal expansion coefficient
+    amrex::Real m_beta{0.0};
+};
+} // namespace icns
+
+} // namespace pde
+} // namespace amr_wind
+
+
+#endif /* ABLMEANBOUSSINESQ_H */

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -1,0 +1,72 @@
+#include "amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H"
+#include "amr-wind/CFDSim.H"
+#include "amr-wind/core/FieldUtils.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace pde {
+namespace icns {
+
+/** Boussinesq buoyancy source term for ABL simulations
+ *
+ *  Reads in the following parameters from `ABLMeanBoussinesq` namespace:
+ *
+ *  - `reference_temperature` (Mandatory) temperature (`T0`) in Kelvin
+ *  - `thermal_expansion_coeff` Optional, default = `1.0 / T0`
+ *  - `gravity` acceleration due to gravity (m/s)
+ */
+ABLMeanBoussinesq::ABLMeanBoussinesq(const CFDSim& sim)
+    : m_mesh(sim.mesh())
+{
+    amrex::ParmParse pp_boussinesq_buoyancy("BoussinesqBuoyancy");
+    pp_boussinesq_buoyancy.get("reference_temperature", m_ref_theta);
+
+    if (pp_boussinesq_buoyancy.contains("thermal_expansion_coeff")) {
+        pp_boussinesq_buoyancy.get("thermal_expansion_coeff", m_beta);
+    } else {
+        m_beta = 1.0 / m_ref_theta;
+    }
+
+    // FIXME: gravity in `incflo` namespace
+    amrex::ParmParse pp_incflo("incflo");
+    pp_incflo.queryarr("gravity", m_gravity);
+}
+
+ABLMeanBoussinesq::~ABLMeanBoussinesq() = default;
+
+void ABLMeanBoussinesq::operator()(
+    const int lev,
+    const amrex::MFIter&,
+    const amrex::Box& bx,
+    const FieldState,
+    const amrex::Array4<amrex::Real>& src_term) const
+{
+    const auto& problo = m_mesh.Geom(lev).ProbLoArray();
+    const auto& dx = m_mesh.Geom(lev).CellSizeArray();
+    const amrex::Real T0 = m_ref_theta;
+    const amrex::Real beta = m_beta;
+    const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{{
+        m_gravity[0], m_gravity[1], m_gravity[2]}};
+
+    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        amrex::Real temp = 308.75;
+        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+        if (z > 750.0) {
+            temp = 308.0 + 0.003 * (z - 750.0);
+        } else if (z > 650.0) {
+            temp = 300.0 + 0.08 * (z - 650.0);
+        } else {
+            temp = 300.0;
+        }
+
+        const amrex::Real fac = beta * (temp - T0);
+        src_term(i, j, k, 0) += gravity[0] * fac;
+        src_term(i, j, k, 1) += gravity[1] * fac;
+        src_term(i, j, k, 2) += gravity[2] * fac;
+    });
+}
+
+} // namespace icns
+} // namespace pde
+} // namespace amr_wind

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -1,6 +1,7 @@
 #include "amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H"
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/core/FieldUtils.H"
+#include "amr-wind/wind_energy/ABL.H"
 
 #include "AMReX_ParmParse.H"
 
@@ -19,6 +20,9 @@ namespace icns {
 ABLMeanBoussinesq::ABLMeanBoussinesq(const CFDSim& sim)
     : m_mesh(sim.mesh())
 {
+    const auto& abl = sim.physics_manager().get<amr_wind::ABL>();
+    abl.register_mean_boussinesq_term(this);
+
     amrex::ParmParse pp_boussinesq_buoyancy("BoussinesqBuoyancy");
     pp_boussinesq_buoyancy.get("reference_temperature", m_ref_theta);
 
@@ -31,6 +35,8 @@ ABLMeanBoussinesq::ABLMeanBoussinesq(const CFDSim& sim)
     // FIXME: gravity in `incflo` namespace
     amrex::ParmParse pp_incflo("incflo");
     pp_incflo.queryarr("gravity", m_gravity);
+
+    mean_temperature_init(abl.abl_statistics().temperature_plane_stats());
 }
 
 ABLMeanBoussinesq::~ABLMeanBoussinesq() = default;
@@ -49,22 +55,60 @@ void ABLMeanBoussinesq::operator()(
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{{
         m_gravity[0], m_gravity[1], m_gravity[2]}};
 
+    // Mean temperature profile used to compute background forcing term
+    //
+    // Assumes that the temperature profile is at the cell-centers of the level
+    // 0 grid. For finer meshes, it will extrapolate beyond the Level0
+    // cell-centers for the lo/hi cells.
+    //
+    const int idir = m_axis;
+    const int nh_max = m_theta_ht.size() - 2;
+    const int lp1 = lev + 1;
+    const amrex::Real* theights = m_theta_ht.data();
+    const amrex::Real* tvals = m_theta_vals.data();
+
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        amrex::Real temp = 308.75;
-        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
-        if (z > 750.0) {
-            temp = 308.0 + 0.003 * (z - 750.0);
-        } else if (z > 650.0) {
-            temp = 300.0 + 0.08 * (z - 650.0);
-        } else {
-            temp = 300.0;
-        }
+        amrex::Real temp = T0;
+        amrex::IntVect iv(i, j, k);
+        const amrex::Real ht = problo[idir] + (iv[idir] + 0.5) * dx[idir];
+
+        const int il = amrex::min(k / lp1, nh_max);
+        const int ir = il + 1;
+        temp = tvals[il] +
+            ((tvals[ir] - tvals[il]) / (theights[ir] - theights[il])) *
+            (ht - theights[il]);
 
         const amrex::Real fac = beta * (temp - T0);
         src_term(i, j, k, 0) += gravity[0] * fac;
         src_term(i, j, k, 1) += gravity[1] * fac;
         src_term(i, j, k, 2) += gravity[2] * fac;
     });
+}
+
+void ABLMeanBoussinesq::mean_temperature_init(const FieldPlaneAveraging& tavg)
+{
+    m_axis = tavg.axis();
+
+    // The implementation depends the assumption that the ABL statistics class
+    // computes statistics at the cell-centeres only on level 0. If this
+    // assumption changes in future, the implementation will break... so put in
+    // a check here to catch this.
+    AMREX_ALWAYS_ASSERT(
+        m_mesh.Geom(0).Domain().length(m_axis) ==
+        static_cast<int>(tavg.line_centroids().size()));
+    m_theta_ht.resize(tavg.line_centroids().size());
+    m_theta_vals.resize(tavg.line_average().size());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, tavg.line_centroids().begin(),
+        tavg.line_centroids().end(), m_theta_ht.begin());
+    mean_temperature_update(tavg);
+}
+
+void ABLMeanBoussinesq::mean_temperature_update(const FieldPlaneAveraging& tavg)
+{
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, tavg.line_average().begin(),
+        tavg.line_average().end(), m_theta_vals.begin());
 }
 
 } // namespace icns

--- a/amr-wind/equation_systems/icns/source_terms/CMakeLists.txt
+++ b/amr-wind/equation_systems/icns/source_terms/CMakeLists.txt
@@ -5,4 +5,5 @@ target_sources(${amr_wind_lib_name} PRIVATE
   DensityBuoyancy.cpp
   CoriolisForcing.cpp
   BodyForce.cpp
+  ABLMeanBoussinesq.cpp
   )

--- a/amr-wind/utilities/FieldPlaneAveraging.H
+++ b/amr-wind/utilities/FieldPlaneAveraging.H
@@ -72,9 +72,9 @@ public:
     int ncell_line() const { return m_ncell_line; };
     int last_updated_index() const { return m_last_updated_index; };
 
-    const amrex::Vector<amrex::Real>& line_average() { return m_line_average; };
+    const amrex::Vector<amrex::Real>& line_average() const { return m_line_average; };
     void line_average(int comp, amrex::Vector<amrex::Real> & l_vec);   
-    const amrex::Vector<amrex::Real>& line_centroids()
+    const amrex::Vector<amrex::Real>& line_centroids() const
     {
         return m_line_xcentroid;
     };

--- a/amr-wind/wind_energy/ABL.H
+++ b/amr-wind/wind_energy/ABL.H
@@ -34,6 +34,7 @@ namespace amr_wind {
 namespace pde {
 namespace icns {
 class ABLForcing;
+class ABLMeanBoussinesq;
 }
 }
 
@@ -78,6 +79,11 @@ public:
         m_abl_forcing = forcing;
     }
 
+    void register_mean_boussinesq_term(pde::icns::ABLMeanBoussinesq* term) const
+    {
+        m_abl_mean_bous = term;
+    }
+
     const ABLBoundaryPlane& bndry_plane() const { return *m_bndry_plane; }
 
     //! Return the ABL statistics calculator
@@ -106,6 +112,7 @@ private:
     //! ABL integrated statistics object
     std::unique_ptr<ABLStats> m_stats;
 
+    mutable pde::icns::ABLMeanBoussinesq* m_abl_mean_bous{nullptr};
 };
 
 }

--- a/amr-wind/wind_energy/ABL.H
+++ b/amr-wind/wind_energy/ABL.H
@@ -80,6 +80,9 @@ public:
 
     const ABLBoundaryPlane& bndry_plane() const { return *m_bndry_plane; }
 
+    //! Return the ABL statistics calculator
+    const ABLStats& abl_statistics() const { return *m_stats; }
+
 private:
     const CFDSim& m_sim;
 

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -2,6 +2,7 @@
 #include "amr-wind/wind_energy/ABLFieldInit.H"
 #include "amr-wind/wind_energy/ABLBoundaryPlane.H"
 #include "amr-wind/equation_systems/icns/source_terms/ABLForcing.H"
+#include "amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H"
 #include "amr-wind/incflo.H"
 
 #include "AMReX_ParmParse.H"
@@ -118,6 +119,9 @@ void ABL::pre_advance_work()
         // terms can be computed during the time integration calls
         m_abl_forcing->set_mean_velocities(vx, vy);
     }
+
+    if (m_abl_mean_bous != nullptr)
+        m_abl_mean_bous->mean_temperature_update(m_stats->temperature_plane_stats());
 
     if (m_bndry_plane->is_initialized()) {
         m_bndry_plane->read_file();

--- a/amr-wind/wind_energy/ABLStats.H
+++ b/amr-wind/wind_energy/ABLStats.H
@@ -48,7 +48,10 @@ public:
 
     //! Return vel plane averaging instance
     const VelPlaneAveraging& vel_plane_averaging() { return m_pa_vel;} ;
-    
+
+    //! Return instance that handles temperature statistics
+    const FieldPlaneAveraging& temperature_plane_stats() const
+    { return m_pa_temp; }
 
 protected:
     //! Output data based on user-defined format


### PR DESCRIPTION
This PR modifies the treatment of Boussinesq buoyancy source term for ABL simulations such that it can be used with ABL inflow/outflow BC simulations without the need for special treatment of the pressure BC for nodal projection step. 

Original Boussinesq implementation 

```
S = \beta ( Tref - T) 
```

New Boussinesq form, here the new term is implemented as `ABLMeanBoussinesq` source term.

```
S = \beta (Tmean - Tref) + \beta (Tref - T)
```

The first term acts as a mean background forcing term, and the nodal projection only has to deal with the Boussinesq perturbations from the mean temperature as a function of height. The mean temperature profile can be obtained either from the planar averaging, a temporal averaging from a virtual met-mast, or specified as inputs (e.g., when run with mesoscale inputs), or data saved from precursor simulations (similar to how the driving pressure gradient term is handled with ABLForcing).
 