### PR TITLE
added hoextrap to plm and mol to be consistent with incflo

### DIFF
--- a/amr-wind/convection/incflo_godunov_plm.cpp
+++ b/amr-wind/convection/incflo_godunov_plm.cpp
@@ -30,7 +30,7 @@ void godunov::predict_plm_x(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi = amr_wind::utils::has_extdir(
+    auto extdir_lohi = amr_wind::utils::has_extdir_or_ho(
         h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
@@ -44,8 +44,8 @@ void godunov::predict_plm_x(
             [q, vcc, domain_ilo, domain_ihi, Imx, Ipx, dtdx,
              pbc] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
                 const auto& bc = pbc[n];
-                bool extdir_ilo = bc.lo(0) == BCType::ext_dir;
-                bool extdir_ihi = bc.hi(0) == BCType::ext_dir;
+                bool extdir_ilo = (bc.lo(0) == BCType::ext_dir) || (bc.lo(0) == BCType::hoextrap);
+                bool extdir_ihi = (bc.hi(0) == BCType::ext_dir) || (bc.hi(0) == BCType::hoextrap);
 
                 Real upls =
                     q(i, j, k, n) + 0.5 * (-1.0 - vcc(i, j, k, 0) * dtdx) *
@@ -113,7 +113,7 @@ void godunov::predict_plm_y(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi = amr_wind::utils::has_extdir(
+    auto extdir_lohi = amr_wind::utils::has_extdir_or_ho(
         h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
@@ -127,8 +127,8 @@ void godunov::predict_plm_y(
             [q, vcc, domain_jlo, domain_jhi, Imy, Ipy, dtdy,
              pbc] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
                 const auto& bc = pbc[n];
-                bool extdir_jlo = bc.lo(0) == BCType::ext_dir;
-                bool extdir_jhi = bc.hi(0) == BCType::ext_dir;
+                bool extdir_jlo = (bc.lo(1) == BCType::ext_dir) || (bc.lo(1) == BCType::hoextrap);
+                bool extdir_jhi = (bc.hi(1) == BCType::ext_dir) || (bc.hi(1) == BCType::hoextrap);
 
                 Real vpls =
                     q(i, j, k, n) + 0.5 * (-1.0 - vcc(i, j, k, 1) * dtdy) *
@@ -197,7 +197,7 @@ void godunov::predict_plm_z(
 
     BCRec const* pbc = bcrec_device.data();
 
-    auto extdir_lohi = amr_wind::utils::has_extdir(
+    auto extdir_lohi = amr_wind::utils::has_extdir_or_ho(
         h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
@@ -211,8 +211,8 @@ void godunov::predict_plm_z(
             [q, vcc, domain_klo, domain_khi, Ipz, Imz, dtdz,
              pbc] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
                 const auto& bc = pbc[n];
-                bool extdir_klo = bc.lo(0) == BCType::ext_dir;
-                bool extdir_khi = bc.hi(0) == BCType::ext_dir;
+                bool extdir_klo = (bc.lo(2) == BCType::ext_dir) || (bc.lo(2) == BCType::hoextrap);
+                bool extdir_khi = (bc.hi(2) == BCType::ext_dir) || (bc.hi(2) == BCType::hoextrap);
 
                 Real wpls =
                     q(i, j, k, n) + 0.5 * (-1.0 - vcc(i, j, k, 2) * dtdz) *

--- a/amr-wind/convection/incflo_mol_fluxes.cpp
+++ b/amr-wind/convection/incflo_mol_fluxes.cpp
@@ -177,9 +177,9 @@ mol::compute_convective_fluxes (int lev, Box const& bx, int ncomp,
                 qs = q(i,j,domain_khi+1,n);
             } else {
                 Real qpls = q(i,j,k,n) - 0.5 * incflo_zslope_extdir
-                    (i,j,k,n,q, extdir_klo, extdir_khi, domain_klo, domain_khi);
+                    (i,j,k,n,q, extdir_or_ho_klo, extdir_or_ho_khi, domain_klo, domain_khi);
                 Real qmns = q(i,j,k-1,n) + 0.5 * incflo_zslope_extdir(
-                    i,j,k-1,n,q, extdir_klo, extdir_khi, domain_klo, domain_khi);
+                    i,j,k-1,n,q, extdir_or_ho_klo, extdir_or_ho_khi, domain_klo, domain_khi);
                 if (wmac(i,j,k) > small_vel) {
                     qs = qmns;
                 } else if (wmac(i,j,k) < -small_vel) {

--- a/amr-wind/convection/incflo_mol_predict.cpp
+++ b/amr-wind/convection/incflo_mol_predict.cpp
@@ -29,7 +29,7 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
 
     // At an ext_dir boundary, the boundary value is on the face, not cell center.
 
-    auto extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
+    auto extdir_lohi = amr_wind::utils::has_extdir_or_ho(h_bcrec.data(), ncomp, static_cast<int>(Direction::x));
     bool has_extdir_lo = extdir_lohi.first;
     bool has_extdir_hi = extdir_lohi.second;
 
@@ -39,31 +39,41 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         amrex::ParallelFor(ubx, [vcc,domain_ilo,domain_ihi,u,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            bool extdir_ilo = d_bcrec[0].lo(0) == BCType::ext_dir;
-            bool extdir_ihi = d_bcrec[0].hi(0) == BCType::ext_dir;
+            bool extdir_or_ho_ilo = (d_bcrec[0].lo(0) == BCType::ext_dir) ||
+                                    (d_bcrec[0].lo(0) == BCType::hoextrap);
+            bool extdir_or_ho_ihi = (d_bcrec[0].hi(0) == BCType::ext_dir) ||
+                                    (d_bcrec[0].hi(0) == BCType::hoextrap);
 
-            Real upls = vcc(i,j,k,0) - 0.5 * incflo_xslope_extdir
-                (i,j,k,0,vcc, extdir_ilo, extdir_ihi, domain_ilo, domain_ihi);
-            Real umns = vcc(i-1,j,k,0) + 0.5 * incflo_xslope_extdir
-                (i-1,j,k,0,vcc, extdir_ilo, extdir_ihi, domain_ilo, domain_ihi);
-            if (umns < 0.0 and upls > 0.0) {
-                u(i,j,k) = 0.0;
-            } else {
+            const Real vcc_pls = vcc(i,j,k,0);
+            const Real vcc_mns = vcc(i-1,j,k,0);
+
+            Real upls = vcc_pls - 0.5 * incflo_xslope_extdir
+                (i,j,k,0,vcc, extdir_or_ho_ilo, extdir_or_ho_ihi, domain_ilo, domain_ihi);
+
+            Real umns = vcc_mns + 0.5 * incflo_xslope_extdir
+                (i-1,j,k,0,vcc, extdir_or_ho_ilo, extdir_or_ho_ihi, domain_ilo, domain_ihi);
+
+            Real u_val(0);
+
+            if (umns >= 0.0 or upls <= 0.0) {
+
                 Real avg = 0.5 * (upls + umns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    u(i,j,k) = 0.0;
-                } else if (avg > 0.0) {
-                    u(i,j,k) = umns;
-                } else {
-                    u(i,j,k) = upls;
+
+                if (avg >= small_vel) {
+                    u_val = umns;
+                }
+                else if (avg <= -small_vel){
+                    u_val = upls;
                 }
             }
 
-            if (extdir_ilo and i == domain_ilo) {
-                u(i,j,k) = vcc(i-1,j,k,0);
-            } else if (extdir_ihi and i == domain_ihi+1) {
-                u(i,j,k) = vcc(i,j,k,0);
+            if (i == domain_ilo && (d_bcrec[0].lo(0) == BCType::ext_dir)) {
+                u_val = vcc_mns;
+            } else if (i == domain_ihi+1 && (d_bcrec[0].hi(0) == BCType::ext_dir)) {
+                u_val = vcc_pls;
             }
+
+            u(i,j,k) = u_val;
         });
     }
     else
@@ -73,22 +83,25 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         {
             Real upls = vcc(i  ,j,k,0) - 0.5 * incflo_xslope(i  ,j,k,0,vcc);
             Real umns = vcc(i-1,j,k,0) + 0.5 * incflo_xslope(i-1,j,k,0,vcc);
-            if (umns < 0.0 and upls > 0.0) {
-                u(i,j,k) = 0.0;
-            } else {
+            Real u_val(0);
+
+            if (umns >= 0.0 or upls <= 0.0) {
+
                 Real avg = 0.5 * (upls + umns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    u(i,j,k) = 0.0;
-                } else if (avg > 0.0) {
-                    u(i,j,k) = umns;
-                } else {
-                    u(i,j,k) = upls;
+
+                if (avg >= small_vel) {
+                    u_val = umns;
+                }
+                else if (avg <= -small_vel){
+                    u_val = upls;
                 }
             }
+
+            u(i,j,k) = u_val;
         });
     }
 
-    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
+    extdir_lohi = amr_wind::utils::has_extdir_or_ho(h_bcrec.data(), ncomp, static_cast<int>(Direction::y));
     has_extdir_lo = extdir_lohi.first;
     has_extdir_hi = extdir_lohi.second;
 
@@ -98,31 +111,39 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         amrex::ParallelFor(vbx, [vcc,domain_jlo,domain_jhi,v,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            bool extdir_jlo = d_bcrec[1].lo(1) == BCType::ext_dir;
-            bool extdir_jhi = d_bcrec[1].hi(1) == BCType::ext_dir;
+            bool extdir_or_ho_jlo = (d_bcrec[1].lo(1) == BCType::ext_dir) ||
+                                    (d_bcrec[1].lo(1) == BCType::hoextrap);
+            bool extdir_or_ho_jhi = (d_bcrec[1].hi(1) == BCType::ext_dir) ||
+                                    (d_bcrec[1].hi(1) == BCType::hoextrap);
 
-            Real vpls = vcc(i,j,k,1) - 0.5 * incflo_yslope_extdir
-                (i,j,k,1,vcc, extdir_jlo, extdir_jhi, domain_jlo, domain_jhi);
-            Real vmns = vcc(i,j-1,k,1) + 0.5 * incflo_yslope_extdir
-                (i,j-1,k,1,vcc, extdir_jlo, extdir_jhi, domain_jlo, domain_jhi);
-            if (vmns < 0.0 and vpls > 0.0) {
-                v(i,j,k) = 0.0;
-            } else {
+            const Real vcc_pls = vcc(i,j,k,1);
+            const Real vcc_mns = vcc(i,j-1,k,1);
+
+            Real vpls = vcc_pls - 0.5 * incflo_yslope_extdir
+                (i,j,k,1,vcc, extdir_or_ho_jlo, extdir_or_ho_jhi, domain_jlo, domain_jhi);
+            Real vmns = vcc_mns + 0.5 * incflo_yslope_extdir
+                (i,j-1,k,1,vcc, extdir_or_ho_jlo, extdir_or_ho_jhi, domain_jlo, domain_jhi);
+
+            Real v_val(0);
+
+            if (vmns >= 0.0 or vpls <= 0.0) {
                 Real avg = 0.5 * (vpls + vmns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    v(i,j,k) = 0.0;
-                } else if (avg > 0.0) {
-                    v(i,j,k) = vmns;
-                } else {
-                    v(i,j,k) = vpls;
+
+                if (avg >= small_vel) {
+                    v_val = vmns;
+                }
+                else if (avg <= -small_vel){
+                    v_val = vpls;
                 }
             }
 
-            if (extdir_jlo and j == domain_jlo) {
-                v(i,j,k) = vcc(i,j-1,k,1);
-            } else if (extdir_jhi and j == domain_jhi+1) {
-                v(i,j,k) = vcc(i,j,k,1);
+            if (j == domain_jlo && (d_bcrec[1].lo(1) == BCType::ext_dir)) {
+                v_val = vcc_mns;
+            } else if (j == domain_jhi+1 && (d_bcrec[1].hi(1) == BCType::ext_dir)) {
+                v_val = vcc_pls;
             }
+
+            v(i,j,k) = v_val;
         });
     }
     else
@@ -132,22 +153,25 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         {
             Real vpls = vcc(i,j  ,k,1) - 0.5 * incflo_yslope(i,j  ,k,1,vcc);
             Real vmns = vcc(i,j-1,k,1) + 0.5 * incflo_yslope(i,j-1,k,1,vcc);
-            if (vmns < 0.0 and vpls > 0.0) {
-                v(i,j,k) = 0.0;
-            } else {
+
+            Real v_val(0);
+
+            if (vmns >= 0.0 or vpls <= 0.0) {
                 Real avg = 0.5 * (vpls + vmns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    v(i,j,k) = 0.0;
-                } else if (avg > 0.0) {
-                    v(i,j,k) = vmns;
-                } else {
-                    v(i,j,k) = vpls;
+
+                if (avg >= small_vel) {
+                    v_val = vmns;
+                }
+                else if (avg <= -small_vel) {
+                    v_val = vpls;
                 }
             }
+
+            v(i,j,k) = v_val;
         });
     }
 
-    extdir_lohi = amr_wind::utils::has_extdir(h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
+    extdir_lohi = amr_wind::utils::has_extdir_or_ho(h_bcrec.data(), ncomp, static_cast<int>(Direction::z));
     has_extdir_lo = extdir_lohi.first;
     has_extdir_hi = extdir_lohi.second;
 
@@ -157,31 +181,40 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         amrex::ParallelFor(wbx, [vcc,domain_klo,domain_khi,w,d_bcrec]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            bool extdir_klo = d_bcrec[2].lo(2) == BCType::ext_dir;
-            bool extdir_khi = d_bcrec[2].hi(2) == BCType::ext_dir;
+            bool extdir_or_ho_klo = (d_bcrec[2].lo(2) == BCType::ext_dir) or
+                                    (d_bcrec[2].lo(2) == BCType::hoextrap);
+            bool extdir_or_ho_khi = (d_bcrec[2].hi(2) == BCType::ext_dir) or
+                                    (d_bcrec[2].hi(2) == BCType::hoextrap);
 
-            Real wpls = vcc(i,j,k,2) - 0.5 * incflo_zslope_extdir
-                (i,j,k,2,vcc, extdir_klo, extdir_khi, domain_klo, domain_khi);
-            Real wmns = vcc(i,j,k-1,2) + 0.5 * incflo_zslope_extdir(
-                i,j,k-1,2,vcc, extdir_klo, extdir_khi, domain_klo, domain_khi);
-            if (wmns < 0.0 and wpls > 0.0) {
-                w(i,j,k) = 0.0;
-            } else {
+            const Real vcc_pls = vcc(i,j,k,2);
+            const Real vcc_mns = vcc(i,j,k-1,2);
+
+            Real wpls = vcc_pls - 0.5 * incflo_zslope_extdir
+                (i,j,k,2,vcc, extdir_or_ho_klo, extdir_or_ho_khi, domain_klo, domain_khi);
+            Real wmns = vcc_mns + 0.5 * incflo_zslope_extdir(
+                i,j,k-1,2,vcc, extdir_or_ho_klo, extdir_or_ho_khi, domain_klo, domain_khi);
+
+            Real w_val(0);
+
+            if (wmns >= 0.0 or wpls <= 0.0) {
                 Real avg = 0.5 * (wpls + wmns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    w(i,j,k) = 0.0;
-                } else if (avg > 0.0) {
-                    w(i,j,k) = wmns;
-                } else {
-                    w(i,j,k) = wpls;
+
+                if (avg >= small_vel) {
+                    w_val = wmns;
+                }
+                else if (avg <= -small_vel) {
+                    w_val = wpls;
                 }
             }
 
-            if (extdir_klo and k == domain_klo) {
-                w(i,j,k) = vcc(i,j,k-1,2);
-            } else if (extdir_khi and k == domain_khi+1) {
-                w(i,j,k) = vcc(i,j,k,2);
+            if (k == domain_klo && (d_bcrec[2].lo(2) == BCType::ext_dir)) {
+                w_val = vcc_mns;
+            } else if (k == domain_khi+1 && (d_bcrec[2].hi(2) == BCType::ext_dir)) {
+                w_val = vcc_pls;
             }
+
+            w(i,j,k) = w_val;
+
         });
     }
     else
@@ -191,18 +224,21 @@ void mol::predict_vels_on_faces (int lev, Box const& ubx, Box const& vbx, Box co
         {
             Real wpls = vcc(i,j,k  ,2) - 0.5 * incflo_zslope(i,j,k  ,2,vcc);
             Real wmns = vcc(i,j,k-1,2) + 0.5 * incflo_zslope(i,j,k-1,2,vcc);
-            if (wmns < 0.0 and wpls > 0.0) {
-                w(i,j,k) = 0.0;
-            } else {
+
+            Real w_val(0);
+
+            if (wmns >= 0.0 or wpls <= 0.0) {
                 Real avg = 0.5 * (wpls + wmns);
-                if (amrex::Math::abs(avg) < small_vel) {
-                    w(i,j,k) = 0.0;
-            } else if (avg > 0.0) {
-                    w(i,j,k) = wmns;
-                } else {
-                    w(i,j,k) = wpls;
+
+                if (avg >= small_vel) {
+                    w_val = wmns;
+                }
+                else if (avg <= -small_vel) {
+                    w_val = wpls;
                 }
             }
+
+            w(i,j,k) = w_val;
         });
     }
 }

--- a/amr-wind/utilities/bc_ops.H
+++ b/amr-wind/utilities/bc_ops.H
@@ -14,6 +14,7 @@ namespace utils {
 //! Return a pair of bools,
 //! value is true if at least one boundary has an ext_dir specified
 std::pair<bool, bool> has_extdir(amrex::BCRec const* bcrec, int ncomp, int dir);
+std::pair<bool, bool> has_extdir_or_ho(amrex::BCRec const* bcrec, int ncomp, int dir);
 
 } // namespace utils
 } // namespace amr_wind

--- a/amr-wind/utilities/bc_ops.cpp
+++ b/amr-wind/utilities/bc_ops.cpp
@@ -10,3 +10,19 @@ amr_wind::utils::has_extdir(amrex::BCRec const* bcrec, int ncomp, int dir)
     }
     return r;
 }
+
+
+std::pair<bool,bool>
+amr_wind::utils::has_extdir_or_ho(amrex::BCRec const* bcrec, int ncomp, int dir)
+{
+    std::pair<bool,bool> r{false,false};
+    for (int n = 0; n < ncomp; ++n) {
+        r.first = r.first
+             or (bcrec[n].lo(dir) == amrex::BCType::ext_dir)
+             or (bcrec[n].lo(dir) == amrex::BCType::hoextrap);
+        r.second = r.second
+             or (bcrec[n].hi(dir) == amrex::BCType::ext_dir)
+             or (bcrec[n].hi(dir) == amrex::BCType::hoextrap);
+    }
+    return r;
+}


### PR DESCRIPTION
@jrood-nrel this will cause reg tests failures for:  
	  5 - abl_mol (Failed)
	 10 - abl_godunov_plm (Failed)
	 13 - abl_mol_explicit (Failed)
	 14 - abl_mol_cn (Failed)

