### PR TITLE
Fix bug in CFL computation and clean up CFL/time output in log file

### DIFF
--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -49,11 +49,13 @@ public:
      */
     bool write_last_checkpoint();
 
-    /** Set current CFL and update timestep based on CFL
+    /** Set current CFL and update timestep based on CFL components
      *
-     *  @param cfl_unit_time `(U / dx)`, i.e., CFL assuming unit dt
      */
-    void set_current_cfl(amrex::Real cfl_unit_time);
+    void set_current_cfl(
+        const amrex::Real conv_cfl,
+        const amrex::Real diff_cfl,
+        const amrex::Real src_cfl);
 
     /** Set start time and index based on checkpoint/restart file
      *

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -108,9 +108,10 @@ void SimTime::set_current_cfl(
     } else {
         // If user has specified fixed DT then issue a warning if the timestep
         // is larger than the deltaT determined from max. CFL considerations.
-        if ((dt_new < m_fixed_dt) && !m_is_init) {
-            issue_cfl_warning = true;
-        }
+        // Only issue warnings when the error is greater than 1% of the timestep
+        // specified
+        if ((1.0 - (dt_new / m_fixed_dt)) > 0.01) issue_cfl_warning = true;
+
         // Ensure that we use user-specified dt. Checkpoint restart might have
         // overridden this
         m_dt[0] = m_fixed_dt;
@@ -133,7 +134,7 @@ void SimTime::set_current_cfl(
                        << " src: "  << std::setprecision(6) << std::sqrt(src_cfl) * m_dt[0]
                        << " )" << std::endl;
     }
-    if (issue_cfl_warning)
+    if (issue_cfl_warning && !m_is_init)
         amrex::Print() << "WARNING: fixed_dt does not satisfy CFL condition.\n"
                        << "Max. CFL: " << m_max_cfl
                        << " => dt: " << std::setprecision(6) << dt_new

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -130,7 +130,7 @@ void SimTime::set_current_cfl(
                        << std::setprecision(6) << m_current_cfl
                        << " (conv: " << std::setprecision(6) << conv_cfl * m_dt[0]
                        << " diff: " << std::setprecision(6) << diff_cfl * m_dt[0]
-                       << " src: "  << std::setprecision(6) << src_cfl * m_dt[0]
+                       << " src: "  << std::setprecision(6) << std::sqrt(src_cfl) * m_dt[0]
                        << " )" << std::endl;
     }
     if (issue_cfl_warning)

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -129,7 +129,7 @@ void SimTime::set_current_cfl(
         amrex::Print() << "CFL: "
                        << std::setprecision(6) << m_current_cfl
                        << " (conv: " << std::setprecision(6) << conv_cfl * m_dt[0]
-                       << " diff: " << std::setprecision(12) << diff_cfl * m_dt[0]
+                       << " diff: " << std::setprecision(6) << diff_cfl * m_dt[0]
                        << " src: "  << std::setprecision(6) << src_cfl * m_dt[0]
                        << " )" << std::endl;
     }

--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -114,17 +114,5 @@ void incflo::ComputeDt(bool explicit_diffusion)
             force_cfl, ParallelContext::CommunicatorSub());
     }
 
-    const Real cd_cfl = conv_cfl + diff_cfl;
-
-    // Combined CFL conditioner
-    const Real comb_cfl =
-        2.0 * cd_cfl + std::sqrt(cd_cfl * cd_cfl + 4.0 * force_cfl);
-
-    if (m_verbose > 2) {
-        amrex::Print() << "conv_cfl: " << conv_cfl << " diff_cfl: " << diff_cfl
-                       << " force_cfl: " << force_cfl
-                       << " comb_cfl: " << comb_cfl << std::endl;
-    }
-
-    m_time.set_current_cfl(comb_cfl);
+    m_time.set_current_cfl(conv_cfl, diff_cfl, force_cfl);
 }

--- a/unit_tests/core/test_simtime.cpp
+++ b/unit_tests/core/test_simtime.cpp
@@ -49,7 +49,7 @@ TEST_F(SimTimeTest, init)
 
     // Check that the timestep size during initialization respects the shrink
     // value
-    time.set_current_cfl(cur_cfl);
+    time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
     EXPECT_NEAR(time.deltaT(), 0.1 * dt_new, tol);
     const double first_dt = time.deltaT();
 
@@ -57,7 +57,7 @@ TEST_F(SimTimeTest, init)
     EXPECT_TRUE(stop_sim);
     // Check that the timestep growth is not greater than 10% of the last
     // timestep
-    time.set_current_cfl(cur_cfl);
+    time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
     EXPECT_NEAR(time.deltaT(), 1.1 * first_dt, tol);
 }
 
@@ -72,7 +72,7 @@ TEST_F(SimTimeTest, time_loop)
     int plot_counter = 0;
     int chkpt_counter = 0;
     while (time.new_timestep()) {
-        time.set_current_cfl(2.0);
+        time.set_current_cfl(1.125, 0.0, 0.0);
         ++counter;
 
         if (time.write_plot_file()) ++plot_counter;
@@ -103,7 +103,7 @@ TEST_F(SimTimeTest, fixed_dt_loop)
     int plot_counter = 0;
     int chkpt_counter = 0;
     while (time.new_timestep()) {
-        time.set_current_cfl(2.0);
+        time.set_current_cfl(2.0, 0.0, 0.0);
         ++counter;
 
         if (time.write_plot_file()) ++plot_counter;

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -54,7 +54,7 @@ TEST_F(ABLMeshTest, abl_forcing)
     {
         auto& time = sim().time();
         time.new_timestep();
-        time.set_current_cfl(2.0);
+        time.set_current_cfl(2.0, 0.0, 0.0);
         EXPECT_NEAR(time.deltaT(), 0.1, tol);
 
         src_term.setVal(0.0);


### PR DESCRIPTION
This PR fixes a bug in the combined CFL computation logic in amr-wind https://github.com/Exawind/amr-wind/blob/4c033b9323e9a72dae9ab9ab56b265cf0847b648/amr-wind/incflo_compute_dt.cpp#L119-L122

There is an extra factor of 2.0 that shouldn't be there. With this bug-fix, we recover the exact CFL (and timestep) in the initial time when there is only advection term and there are no contributions from diffusion or source terms. 

In addition to the bug fix, the following changes clean up output of time/cfl details into log file

- CFL components are always printed (previously required `verbose > 2`)
- CFL components are scaled by the current `deltaT` instead of printed at unit time. 
- Time step output now clearly specifies the old/new time 

Will need re-bless of adaptive time-stepping and explicit diffusion tests. 