### PR TITLE
Preliminary overset implementation for AMR-Wind 

### DIFF
--- a/amr-wind/equation_systems/CompRHSOps.H
+++ b/amr-wind/equation_systems/CompRHSOps.H
@@ -61,6 +61,7 @@ struct ComputeRHSOp
         auto& src_term = fields.src_term;
         auto& diff_term = fields.diff_term.state(fstate);
         auto& conv_term = fields.conv_term.state(fstate);
+        auto& mask_cell = fields.repo.get_int_field("mask_cell");
 
         for (int lev = 0; lev < nlevels; ++lev) {
 #ifdef _OPENMP
@@ -75,6 +76,7 @@ struct ComputeRHSOp
                 const auto src = src_term(lev).const_array(mfi);
                 const auto diff = diff_term(lev).const_array(mfi);
                 const auto ddt_o = conv_term(lev).const_array(mfi);
+                const auto imask = mask_cell(lev).const_array(mfi);
 
                 if (PDE::multiply_rho) {
                     // Remove multiplication by density as it will be added back
@@ -85,8 +87,9 @@ struct ComputeRHSOp
                             int i, int j, int k, int n) noexcept {
                             fld(i, j, k, n) =
                                 rho_o(i, j, k) * fld_o(i, j, k, n) +
-                                dt * (ddt_o(i, j, k, n) + src(i, j, k, n) +
-                                      factor * diff(i, j, k, n));
+                                static_cast<amrex::Real>(imask(i, j, k)) * dt *
+                                    (ddt_o(i, j, k, n) + src(i, j, k, n) +
+                                     factor * diff(i, j, k, n));
 
                             fld(i, j, k, n) /= rho(i, j, k);
                         });
@@ -97,8 +100,9 @@ struct ComputeRHSOp
                             int i, int j, int k, int n) noexcept {
                             fld(i, j, k, n) =
                                 fld_o(i, j, k, n) +
-                                dt * (ddt_o(i, j, k, n) + src(i, j, k, n) +
-                                      factor * diff(i, j, k, n));
+                                static_cast<amrex::Real>(imask(i, j, k)) * dt *
+                                    (ddt_o(i, j, k, n) + src(i, j, k, n) +
+                                     factor * diff(i, j, k, n));
                         });
                 }
             }
@@ -144,6 +148,7 @@ struct ComputeRHSOp
         auto& conv_term = fields.conv_term;
         auto& diff_term_old = fields.diff_term.state(FieldState::Old);
         auto& conv_term_old = fields.conv_term.state(FieldState::Old);
+        auto& mask_cell = fields.repo.get_int_field("mask_cell");
 
         for (int lev = 0; lev < nlevels; ++lev) {
 #ifdef _OPENMP
@@ -160,6 +165,7 @@ struct ComputeRHSOp
                 const auto ddt = conv_term(lev).const_array(mfi);
                 const auto diff_o = diff_term_old(lev).const_array(mfi);
                 const auto ddt_o = conv_term_old(lev).const_array(mfi);
+                const auto imask = mask_cell(lev).const_array(mfi);
 
                 if (PDE::multiply_rho) {
                     // Remove multiplication by density as it will be added back
@@ -170,7 +176,7 @@ struct ComputeRHSOp
                             int i, int j, int k, int n) noexcept {
                             fld(i, j, k, n) =
                                 rho_o(i, j, k) * fld_o(i, j, k, n) +
-                                dt *
+                                static_cast<amrex::Real>(imask(i, j, k)) * dt *
                                     (0.5 *
                                          (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
                                      ofac * diff_o(i, j, k, n) +
@@ -183,12 +189,13 @@ struct ComputeRHSOp
                         bx, PDE::ndim,
                         [=] AMREX_GPU_DEVICE(
                             int i, int j, int k, int n) noexcept {
-                            fld(i, j, k, n) = fld_o(i, j, k, n) +
-                                              dt * (0.5 * (ddt_o(i, j, k, n) +
-                                                           ddt(i, j, k, n)) +
-                                                    ofac * diff_o(i, j, k, n) +
-                                                    nfac * diff(i, j, k, n) +
-                                                    src(i, j, k, n));
+                            fld(i, j, k, n) =
+                                fld_o(i, j, k, n) +
+                                static_cast<amrex::Real>(imask(i, j, k)) * dt *
+                                    (0.5 *
+                                         (ddt_o(i, j, k, n) + ddt(i, j, k, n)) +
+                                     ofac * diff_o(i, j, k, n) +
+                                     nfac * diff(i, j, k, n) + src(i, j, k, n));
                         });
                 }
             }

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -132,7 +132,7 @@ public:
 
     void post_solve_actions() override
     {
-        m_post_solve_op();
+        m_post_solve_op(m_time.new_time());
     }
 
 protected:

--- a/amr-wind/equation_systems/PDEOps.H
+++ b/amr-wind/equation_systems/PDEOps.H
@@ -198,9 +198,14 @@ struct BCOp;
 template<typename PDE>
 struct PostSolveOp
 {
-    PostSolveOp(PDEFields&) {}
+    PostSolveOp(PDEFields& fields) : m_fields(fields) {}
 
-    void operator()() {}
+    void operator()(const amrex::Real time)
+    {
+        m_fields.field.fillpatch(time);
+    }
+
+    PDEFields& m_fields;
 };
 
 }

--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -13,7 +13,7 @@
 namespace amr_wind {
 namespace pde {
 
-void advection_mac_project(FieldRepo& repo, FieldState fstate, const bool);
+void advection_mac_project(FieldRepo& repo, FieldState fstate, const bool, const amrex::Real dt);
 
 /** Specialization of field registration for ICNS
  *  \ingroup icns
@@ -230,7 +230,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         }
 
         // MAC projection
-        advection_mac_project(repo, fstate, has_overset);
+        advection_mac_project(repo, fstate, has_overset, dt);
 
         //
         // Advect momentum eqns
@@ -289,7 +289,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
     , w_mac(fields_in.repo.get_field("w_mac"))
     {}
 
-    void operator()(const FieldState fstate, const amrex::Real , const bool has_overset)
+    void operator()(const FieldState fstate, const amrex::Real dt, const bool has_overset)
     {
 
         auto& repo = fields.repo;
@@ -328,7 +328,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
             }
         }
 
-        advection_mac_project(repo, fstate, has_overset);
+        advection_mac_project(repo, fstate, has_overset, dt);
 
         //
         // Advect velocity

--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -39,7 +39,7 @@ struct FieldRegOp<ICNS, Scheme>
         auto& rho = repo.declare_cc_field(
             "density", 1, Scheme::nghost_state, Scheme::num_states);
         auto& grad_p = repo.declare_cc_field("gp", ICNS::ndim, 0, 1);
-        auto& pressure = repo.declare_nd_field("p", 1, 0, 1);
+        auto& pressure = repo.declare_nd_field("p", 1, Scheme::nghost_state, 1);
         repo.declare_face_normal_field(
             {"u_mac", "v_mac", "w_mac"}, 1, Scheme::nghost_mac, 1);
 

--- a/amr-wind/equation_systems/icns/icns_ops.cpp
+++ b/amr-wind/equation_systems/icns/icns_ops.cpp
@@ -3,6 +3,8 @@
 #include "amr-wind/convection/mac_projection.H"
 #include "amr-wind/core/MLMGOptions.H"
 #include "amr-wind/utilities/console_io.H"
+#include "amr-wind/fvm/divergence.H"
+#include "amr-wind/core/field_ops.H"
 
 namespace amr_wind {
 namespace pde {
@@ -28,7 +30,7 @@ namespace pde {
 //       div(ep*grad(phi)/rho) = div(ep * u*)
 //
 
-void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool has_overset)
+void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool has_overset, const amrex::Real dt)
 {
     BL_PROFILE("amr-wind::ICNS::advection_mac_project");
     auto& geom = repo.mesh().Geom();
@@ -61,7 +63,7 @@ void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool 
         amrex::average_cellcenter_to_face(
             rho_face[lev], density(lev), geom[lev]);
         for (int idim = 0; idim < ICNS::ndim; ++idim) {
-            rho_face[lev][idim]->invert(1.0, 0);
+            rho_face[lev][idim]->invert(dt, 0);
         }
 
         rho_face_const.push_back(GetArrOfConstPtrs(rho_face[lev]));
@@ -83,13 +85,16 @@ void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool 
         mac_vec, amrex::MLMG::Location::FaceCenter,
         rho_face_const, amrex::MLMG::Location::FaceCenter,
         amrex::MLMG::Location::CellCenter,
-        repo.mesh().Geom(0, repo.num_active_levels() - 1), lp_info, {},
+        repo.mesh().Geom(0, repo.num_active_levels() - 1), lp_info,
+        {},
         amrex::MLMG::Location::CellCenter,
         (has_overset ? repo.get_int_field("mask_cell").vec_const_ptrs()
                      : amrex::Vector<const amrex::iMultiFab*>()));
+                                                                    
 
     // get the bc types from pressure field
-    auto& bctype = repo.get_field("p").bc_type();
+    auto& pressure = repo.get_field("p");
+    auto& bctype = pressure.bc_type();
 
     macproj.setDomainBC(
         mac::get_projection_bc(
@@ -97,7 +102,17 @@ void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool 
         mac::get_projection_bc(
             amrex::Orientation::high, bctype, repo.mesh().Geom()));
 
-    macproj.project(options.rel_tol, options.abs_tol);
+    if(has_overset){
+
+        auto phif = repo.create_scratch_field(1, 1, amr_wind::FieldLoc::CELL);
+        for(int lev=0;lev<repo.num_active_levels(); ++lev)
+            amrex::average_node_to_cellcenter((*phif)(lev), 0, pressure(lev), 0, 1);
+
+        macproj.project(phif->vec_ptrs(), options.rel_tol, options.abs_tol);
+
+    } else {
+        macproj.project(options.rel_tol, options.abs_tol);
+    }
 
     io::print_mlmg_info("MAC_projection", macproj.getMLMG());
 }

--- a/amr-wind/equation_systems/icns/icns_ops.cpp
+++ b/amr-wind/equation_systems/icns/icns_ops.cpp
@@ -55,6 +55,8 @@ void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool 
         rho_face_const;
     rho_face_const.reserve(repo.num_active_levels());
 
+    amrex::Real factor = has_overset ? 0.5 * dt : 1.0;
+
     for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
         rho_face[lev][0] = &(*rho_xf)(lev);
         rho_face[lev][1] = &(*rho_yf)(lev);
@@ -63,7 +65,7 @@ void advection_mac_project(FieldRepo& repo, const FieldState fstate, const bool 
         amrex::average_cellcenter_to_face(
             rho_face[lev], density(lev), geom[lev]);
         for (int idim = 0; idim < ICNS::ndim; ++idim) {
-            rho_face[lev][idim]->invert(dt, 0);
+            rho_face[lev][idim]->invert(factor, 0);
         }
 
         rho_face_const.push_back(GetArrOfConstPtrs(rho_face[lev]));

--- a/amr-wind/equation_systems/tke/TKE.H
+++ b/amr-wind/equation_systems/tke/TKE.H
@@ -45,9 +45,10 @@ struct PostSolveOp<TKE>
 {
     PostSolveOp(PDEFields& fields) : m_fields(fields) {}
 
-    void operator()()
+    void operator()(const amrex::Real time)
     {
         field_ops::lower_bound(m_fields.field, clip_value);
+        m_fields.field.fillpatch(time);
     }
 
     PDEFields& m_fields;

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -83,6 +83,8 @@ public:
     void init_amr_wind_modules();
     void prepare_for_time_integration();
     bool regrid_and_update();
+    void pre_advance_stage1();
+    void pre_advance_stage2();
     void advance();
     void post_advance_work();
 

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -223,9 +223,11 @@ void incflo::Evolve()
     while(m_time.new_timestep()) {
         amrex::Real time0 = amrex::ParallelDescriptor::second();
         regrid_and_update();
+        pre_advance_stage1();
+        pre_advance_stage2();
 
-        // Advance to time t + dt
         amrex::Real time1 = amrex::ParallelDescriptor::second();
+        // Advance to time t + dt
         advance();
         amrex::Print() << std::endl;
         amrex::Real time2 = amrex::ParallelDescriptor::second();
@@ -233,9 +235,10 @@ void incflo::Evolve()
         amrex::Real time3 = amrex::ParallelDescriptor::second();
 
         amrex::Print() << "WallClockTime: " << m_time.time_index()
-                       << " Solve: " << std::setprecision(8) << (time2 - time1)
-                       << " Misc: " << std::setprecision(6) << (time3 - time2)
-                       << " Total: " << std::setprecision(8) << (time3 - time0) << std::endl;
+                       << " Pre: " << std::setprecision(3) << (time1 - time0)
+                       << " Solve: " << std::setprecision(4) << (time2 - time1)
+                       << " Post: " << std::setprecision(3) << (time3 - time2)
+                       << " Total: " << std::setprecision(4) << (time3 - time0) << std::endl;
     }
     amrex::Print()
         << "\n==============================================================================\n"

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -187,6 +187,12 @@ bool incflo::regrid_and_update()
 void incflo::post_advance_work()
 {
     BL_PROFILE("amr-wind::incflo::post_advance_work");
+    for (auto& pp: m_sim.physics())
+        pp->post_advance_work();
+
+    m_sim.post_manager().post_advance_work();
+    if (m_verbose > 1) PrintMaxValues("end of timestep");
+
     if (m_time.write_plot_file()) {
         m_sim.io_manager().write_plot_file();
     }

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -58,15 +58,7 @@ void incflo::advance()
 
     ApplyPredictor();
 
-    if (!m_use_godunov) {
-        vel.state(amr_wind::FieldState::New).fillpatch(m_time.current_time());
-        for (auto& eqn: scalar_eqns()) {
-            auto& field = eqn->fields().field;
-            field.state(amr_wind::FieldState::New).fillpatch(m_time.current_time());
-        }
-
-        ApplyCorrector();
-    }
+    if (!m_use_godunov) ApplyCorrector();
 }
 
 // Apply predictor step

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -67,12 +67,6 @@ void incflo::advance()
 
         ApplyCorrector();
     }
-
-    for (auto& pp: m_sim.physics())
-        pp->post_advance_work();
-
-    m_sim.post_manager().post_advance_work();
-    if (m_verbose > 1) PrintMaxValues("end of timestep");
 }
 
 // Apply predictor step

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -7,6 +7,7 @@
 namespace amr_wind {
 
 class IntField;
+class ScratchField;
 
 struct AMROversetInfo
 {
@@ -76,6 +77,9 @@ public:
 
     AMROversetInfo& amr_mesh_info() { return m_info; }
 
+    ScratchField& qvars_cell() { return *m_qcell; }
+    ScratchField& qvars_node() { return *m_qnode; }
+
 private:
     void amr_to_tioga_mesh();
 
@@ -93,6 +97,9 @@ private:
     IntField& m_mask_node;
 
     AMROversetInfo m_info;
+
+    std::unique_ptr<ScratchField> m_qcell;
+    std::unique_ptr<ScratchField> m_qnode;
 };
 
 } // namespace amr_wind

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -85,6 +85,11 @@ void TiogaInterface::post_overset_conn_work()
 {
     iblank_to_mask(m_iblank_cell, m_mask_cell);
     iblank_to_mask(m_iblank_node, m_mask_node);
+
+    // Update equation systems after a connectivity update
+    m_sim.pde_manager().icns().post_regrid_actions();
+    for (auto& eqn: m_sim.pde_manager().scalar_eqns())
+        eqn->post_regrid_actions();
 }
 
 void TiogaInterface::register_solution() {}

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -62,8 +62,8 @@ void TiogaInterface::post_init_actions()
     amr_to_tioga_mesh();
 
     // Initialize masking so that all cells are active in solvers
-    m_mask_cell.setVal(0);
-    m_mask_node.setVal(0);
+    m_mask_cell.setVal(1);
+    m_mask_node.setVal(1);
 }
 
 void TiogaInterface::post_regrid_actions()
@@ -71,8 +71,8 @@ void TiogaInterface::post_regrid_actions()
     amr_to_tioga_mesh();
 
     // Initialize masking so that all cells are active in solvers
-    m_mask_cell.setVal(0);
-    m_mask_node.setVal(0);
+    m_mask_cell.setVal(1);
+    m_mask_node.setVal(1);
 }
 
 void TiogaInterface::pre_overset_conn_work()

--- a/amr-wind/physics/ConvectingTaylorVortex.H
+++ b/amr-wind/physics/ConvectingTaylorVortex.H
@@ -85,6 +85,8 @@ private:
 
     //! error log file
     const std::string m_output_fname{"ctv.log"};
+
+    bool m_activate_pressure{false};
 };
 } // namespace ctv
 } // namespace amr_wind

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -2,6 +2,7 @@
 #include "amr-wind/incflo.H"
 #include "amr-wind/core/MLMGOptions.H"
 #include "amr-wind/utilities/console_io.H"
+#include "amr-wind/core/field_ops.H"
 
 using namespace amrex;
 
@@ -193,8 +194,17 @@ void incflo::ApplyProjection (Vector<MultiFab const*> density,
         }
     }
 
+    auto phif = m_repo.create_scratch_field(1, 1, amr_wind::FieldLoc::NODE);
+    if (incremental) {
+        for (int lev=0; lev <= finestLevel(); ++lev) {
+            (*phif)(lev).setVal(0.0);
+        }
+    } else {
+        amr_wind::field_ops::copy(*phif, pressure, 0, 0, 1, 1);
+    }
+
     nodal_projector->setVerbose(options.verbose);
-    nodal_projector->project(options.rel_tol, options.abs_tol);
+    nodal_projector->project(phif->vec_ptrs(), options.rel_tol, options.abs_tol);
     amr_wind::io::print_mlmg_info("Nodal_projection", nodal_projector->getMLMG());
 
     // Define "vel" to be U^{n+1} rather than (U^{n+1}-U^n)

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -266,6 +266,7 @@ void incflo::ApplyProjection (Vector<MultiFab const*> density,
                             0, AMREX_SPACEDIM, refRatio(lev));
     }
 
+    velocity.fillpatch(m_time.new_time());
     if (m_verbose > 2)
     {
         if (proj_for_small_dt) {


### PR DESCRIPTION
This PR introduces necessary changes in the codebase to facilitate overset simulations with Nalu-Wind and AMR-Wind using TIOGA library. 

- Refactor time advance methods to interject overset connectivity and solution exchange steps at appropriate times from the driver
- Update MAC projection to provide a *pressure-like* solution in presence of overset constraints
- Change RHS computation to skip overset fringe/hole cells during update 
- Update linear solver interfaces to register overset mask and use it during linear solves. 