### PR TITLE
Update ABL wall function to work with multiple levels

### DIFF
--- a/amr-wind/utilities/trig_ops.H
+++ b/amr-wind/utilities/trig_ops.H
@@ -8,6 +8,7 @@
 
 #include <cmath>
 #include "AMReX_REAL.H"
+#include "AMReX_Gpu.H"
 
 namespace amr_wind {
 namespace utils {

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -71,8 +71,6 @@ void ABL::initialize_fields(
         auto& tke = (*m_tke)(level);
         m_field_init->init_tke(geom, tke);
     }
-    
-
 }
 
 void ABL::post_init_actions()
@@ -80,8 +78,9 @@ void ABL::post_init_actions()
     m_abl_wall_func.init_log_law_height();
 
     m_stats->calc_averages();
-    
-    m_abl_wall_func.update_umean();
+
+    m_abl_wall_func.update_umean(
+        m_stats->vel_plane_averaging(), m_stats->temperature_plane_stats());
 
     // Register ABL wall function for velocity
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
@@ -108,7 +107,9 @@ void ABL::pre_advance_work()
 {
     m_stats->calc_averages();
     const auto& vel_pa = m_stats->vel_plane_averaging();
-    m_abl_wall_func.update_umean();
+    m_abl_wall_func.update_umean(
+        m_stats->vel_plane_averaging(), m_stats->temperature_plane_stats());
+
 
     if (m_abl_forcing != nullptr) {
         const amrex::Real zh = m_abl_forcing->forcing_height();

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -4,6 +4,7 @@
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/utilities/FieldPlaneAveraging.H"
 #include "amr-wind/core/FieldBCOps.H"
+#include "amr-wind/wind_energy/MOData.h"
 
 namespace amr_wind {
 
@@ -59,14 +60,10 @@ private:
 
     const amrex::AmrCore& m_mesh;
 
-    //! Mean velocity
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> m_umean{{0.0, 0.0, 0.0}};
+    //! Monin-Obukhov instance
+    MOData m_mo;
 
-    amrex::Real m_log_law_height{0.0}; ///< log-law height
     amrex::Real m_utau;                ///< Friction velocity
-
-    amrex::Real m_kappa{0.41}; ///< von Karman constant
-    amrex::Real m_z0{0.1};     ///< Roughness height
 
     int m_direction{2};   ///< Direction normal to wall
     bool m_use_fch{true}; ///< Use first cell height?
@@ -78,22 +75,13 @@ private:
 
     int m_ncells_x, m_ncells_y;
 
-    amrex::Real m_mean_windspeed, m_mean_pot_temp;
-
     amrex::Box m_bx_z_sample;
     amrex::FArrayBox m_store_xy_vel_temp;
 
     bool m_tempflux;
-    amrex::Real m_surf_temp_flux;
     amrex::Real m_surf_temp_rate;
     amrex::Real m_surf_temp_rate_tstart;
     amrex::Real m_surf_temp_init;
-    amrex::Real m_surf_temp;
-    amrex::Real m_ref_temp;
-
-    amrex::Real m_gamma_m{5.0};
-    amrex::Real m_gamma_h{5.0};
-    amrex::Real m_beta_m{16.0};
 
     const int m_max_iter{25};
 };

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -22,6 +22,9 @@ public:
 
     ~ABLWallFunction() = default;
 
+    MOData& mo() { return m_mo; }
+    const MOData& mo() const { return m_mo; }
+
     //! Return the plane-averaged computed friction velocity at any given
     //! instance
     amrex::Real utau() const { return m_mo.utau; }
@@ -30,23 +33,7 @@ public:
     void init_log_law_height();
 
     //! Update the mean velocity at a given timestep
-    void update_umean();
-
-    /**
-     * van der Laan, P., Kelly, M. C., & Sørensen, N. N. (2017). A new k-epsilon
-     * model consistent with Monin-Obukhov similarity theory. Wind Energy,
-     * 20(3), 479–489. https://doi.org/10.1002/we.2017
-     *
-     * Consistent with Dyer (1974) formulation from page 57, Chapter 2, Modeling
-     * the vertical ABL structure in Modelling of Atmospheric Flow Fields,
-     * Demetri P Lalas and Corrado F Ratto, January 1996,
-     * https://doi.org/10.1142/2975.
-     */
-    //! Return Monin-Obukhov Similarity function psi_m
-    amrex::Real mo_psi_m(amrex::Real zeta);
-
-    //! Return Monin-Obukhov Similarity function psi_h
-    amrex::Real mo_psi_h(amrex::Real zeta);
+    void update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
 
     void computeplanar();
 

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -24,7 +24,7 @@ public:
 
     //! Return the plane-averaged computed friction velocity at any given
     //! instance
-    amrex::Real utau() const { return m_utau; }
+    amrex::Real utau() const { return m_mo.utau; }
 
     //! Initialize the log-law height based on user inputs
     void init_log_law_height();
@@ -62,8 +62,6 @@ private:
 
     //! Monin-Obukhov instance
     MOData m_mo;
-
-    amrex::Real m_utau;                ///< Friction velocity
 
     int m_direction{2};   ///< Direction normal to wall
     bool m_use_fch{true}; ///< Use first cell height?

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -71,8 +71,6 @@ public:
 
     bool use_fch() const { return m_use_fch; }
 
-    amrex::Real obukhov_length() const { return m_obukhov_length; }
-
 private:
 
     const CFDSim& m_sim;
@@ -108,8 +106,6 @@ private:
     amrex::Real m_surf_temp_rate;
     amrex::Real m_surf_temp_rate_tstart;
     amrex::Real m_surf_temp_init;
-    amrex::Real m_obukhov_length;
-    amrex::Real m_psi_m, m_psi_h;
     amrex::Real m_surf_temp;
     amrex::Real m_ref_temp;
 

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -80,8 +80,6 @@ private:
     amrex::Real m_surf_temp_rate;
     amrex::Real m_surf_temp_rate_tstart;
     amrex::Real m_surf_temp_init;
-
-    const int m_max_iter{25};
 };
 
 /** Applies a shear-stress value at the domain boundary

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -21,25 +21,15 @@ public:
 
     ~ABLWallFunction() = default;
 
-    //! Return the height used to perform friction velocity computations
-    amrex::Real log_law_height() const { return m_log_law_height; }
-
     //! Return the plane-averaged computed friction velocity at any given
     //! instance
     amrex::Real utau() const { return m_utau; }
-
-    //! Return the mean velocity used for friction velocity computations
-    const amrex::Array<amrex::Real, AMREX_SPACEDIM>& umean() const
-    {
-        return m_umean;
-    }
 
     //! Initialize the log-law height based on user inputs
     void init_log_law_height();
 
     //! Update the mean velocity at a given timestep
     void update_umean();
-
 
     /**
      * van der Laan, P., Kelly, M. C., & Sørensen, N. N. (2017). A new k-epsilon
@@ -60,16 +50,8 @@ public:
     void computeplanar();
 
     void computeusingheatflux();
-    
+
     const amrex::FArrayBox& instplanar() const { return m_store_xy_vel_temp; }
-
-    amrex::Real mean_windspeed() const { return m_mean_windspeed; }
-
-    amrex::Real surface_temp_flux() const { return m_surf_temp_flux; }
-
-    amrex::Real surface_temp() const { return m_surf_temp; }
-
-    bool use_fch() const { return m_use_fch; }
 
 private:
 

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -247,31 +247,31 @@ void ABLWallFunction::computeusingheatflux()
     // Initialize variables
     amrex::Real psi_m = 0.0;
     amrex::Real psi_h = 0.0;
-    m_utau = m_mo.kappa * m_mo.vmag_mean /
+    m_mo.utau = m_mo.kappa * m_mo.vmag_mean /
              (std::log(m_mo.zref / m_mo.z0) - psi_m);
 
     int iter = 0;
     do {
-        utau_iter = m_utau;
+        utau_iter = m_mo.utau;
         if (m_tempflux) {
             m_mo.surf_temp = m_mo.surf_temp_flux *
                               (std::log(m_mo.zref / m_mo.z0) - psi_h) /
-                              (m_utau * m_mo.kappa) +
+                              (m_mo.utau * m_mo.kappa) +
                           m_mo.theta_mean;
         } else {
-            m_mo.surf_temp_flux = -(m_mo.theta_mean - m_mo.surf_temp) * m_utau *
+            m_mo.surf_temp_flux = -(m_mo.theta_mean - m_mo.surf_temp) * m_mo.utau *
                                m_mo.kappa /
                                (std::log(m_mo.zref / m_mo.z0) - psi_h);
         }
-        amrex::Real obukhov_length = -m_utau * m_utau * m_utau * m_mo.theta_mean /
+        amrex::Real obukhov_length = -m_mo.utau * m_mo.utau * m_mo.utau * m_mo.theta_mean /
                            (m_mo.kappa * g * m_mo.surf_temp_flux);
         zeta = m_mo.zref / obukhov_length;
         psi_m = mo_psi_m(zeta);
         psi_h = mo_psi_h(zeta);
-        m_utau = m_mo.kappa * m_mo.vmag_mean /
+        m_mo.utau = m_mo.kappa * m_mo.vmag_mean /
                  (std::log(m_mo.zref / m_mo.z0) - psi_m);
         iter += 1;
-    } while ((std::abs(utau_iter - m_utau) > 1e-5) && iter <= m_max_iter);
+    } while ((std::abs(utau_iter - m_mo.utau) > 1e-5) && iter <= m_max_iter);
 
     auto xy_arr = m_store_xy_vel_temp.array();
 

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -242,36 +242,36 @@ void ABLWallFunction::computeusingheatflux()
 
     amrex::Real g = utils::vec_mag(m_gravity.data());
     amrex::Real zeta = 0.0;
-    amrex::Real m_utau_iter = 0.0;
+    amrex::Real utau_iter = 0.0;
 
     // Initialize variables
-    m_psi_m = 0.0;
-    m_psi_h = 0.0;
+    amrex::Real psi_m = 0.0;
+    amrex::Real psi_h = 0.0;
     m_utau = m_kappa * m_mean_windspeed /
-             (std::log(m_log_law_height / m_z0) - m_psi_m);
+             (std::log(m_log_law_height / m_z0) - psi_m);
 
     int iter = 0;
     do {
-        m_utau_iter = m_utau;
+        utau_iter = m_utau;
         if (m_tempflux) {
             m_surf_temp = m_surf_temp_flux *
-                              (std::log(m_log_law_height / m_z0) - m_psi_h) /
+                              (std::log(m_log_law_height / m_z0) - psi_h) /
                               (m_utau * m_kappa) +
                           m_mean_pot_temp;
         } else {
             m_surf_temp_flux = -(m_mean_pot_temp - m_surf_temp) * m_utau *
                                m_kappa /
-                               (std::log(m_log_law_height / m_z0) - m_psi_h);
+                               (std::log(m_log_law_height / m_z0) - psi_h);
         }
-        m_obukhov_length = -m_utau * m_utau * m_utau * m_mean_pot_temp /
+        amrex::Real obukhov_length = -m_utau * m_utau * m_utau * m_mean_pot_temp /
                            (m_kappa * g * m_surf_temp_flux);
-        zeta = m_log_law_height / m_obukhov_length;
-        m_psi_m = mo_psi_m(zeta);
-        m_psi_h = mo_psi_h(zeta);
+        zeta = m_log_law_height / obukhov_length;
+        psi_m = mo_psi_m(zeta);
+        psi_h = mo_psi_h(zeta);
         m_utau = m_kappa * m_mean_windspeed /
-                 (std::log(m_log_law_height / m_z0) - m_psi_m);
+                 (std::log(m_log_law_height / m_z0) - psi_m);
         iter += 1;
-    } while ((std::abs(m_utau_iter - m_utau) > 1e-5) && iter <= m_max_iter);
+    } while ((std::abs(utau_iter - m_utau) > 1e-5) && iter <= m_max_iter);
 
     auto xy_arr = m_store_xy_vel_temp.array();
 

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -127,7 +127,7 @@ void ABLWallFunction::update_umean(
                       m_surf_temp_rate *
                           (time.current_time() - m_surf_temp_rate_tstart) /
                           3600.0;
-#if 0
+#if 1
     {
         m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
         m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -71,6 +71,9 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
                           "Assuming Neutral Stratification"
                        << std::endl;
     }
+
+    m_mo.alg_type = m_tempflux ? MOData::HEAT_FLUX : MOData::SURFACE_TEMPERATURE;
+    m_mo.gravity = utils::vec_mag(m_gravity.data());
 }
 
 //! Return Monin-Obukhov Similarity function psi_m

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -242,39 +242,7 @@ void ABLWallFunction::computeplanar()
 
 void ABLWallFunction::computeusingheatflux()
 {
-
-    amrex::Real g = utils::vec_mag(m_gravity.data());
-    amrex::Real zeta = 0.0;
-    amrex::Real utau_iter = 0.0;
-
-    // Initialize variables
-    amrex::Real psi_m = 0.0;
-    amrex::Real psi_h = 0.0;
-    m_mo.utau = m_mo.kappa * m_mo.vmag_mean /
-             (std::log(m_mo.zref / m_mo.z0) - psi_m);
-
-    int iter = 0;
-    do {
-        utau_iter = m_mo.utau;
-        if (m_tempflux) {
-            m_mo.surf_temp = m_mo.surf_temp_flux *
-                              (std::log(m_mo.zref / m_mo.z0) - psi_h) /
-                              (m_mo.utau * m_mo.kappa) +
-                          m_mo.theta_mean;
-        } else {
-            m_mo.surf_temp_flux = -(m_mo.theta_mean - m_mo.surf_temp) * m_mo.utau *
-                               m_mo.kappa /
-                               (std::log(m_mo.zref / m_mo.z0) - psi_h);
-        }
-        amrex::Real obukhov_length = -m_mo.utau * m_mo.utau * m_mo.utau * m_mo.theta_mean /
-                           (m_mo.kappa * g * m_mo.surf_temp_flux);
-        zeta = m_mo.zref / obukhov_length;
-        psi_m = mo_psi_m(zeta);
-        psi_h = mo_psi_h(zeta);
-        m_mo.utau = m_mo.kappa * m_mo.vmag_mean /
-                 (std::log(m_mo.zref / m_mo.z0) - psi_m);
-        iter += 1;
-    } while ((std::abs(utau_iter - m_mo.utau) > 1e-5) && iter <= m_max_iter);
+    m_mo.update_fluxes();
 
     auto xy_arr = m_store_xy_vel_temp.array();
 

--- a/amr-wind/wind_energy/CMakeLists.txt
+++ b/amr-wind/wind_energy/CMakeLists.txt
@@ -7,4 +7,5 @@ target_sources(${amr_wind_lib_name}
   ABLWallFunction.cpp
   ABLFillInflow.cpp
   ABLBoundaryPlane.cpp
+  MOData.cpp
   )

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -3,6 +3,18 @@
 
 namespace amr_wind {
 
+/*
+ * van der Laan, P., Kelly, M. C., & Sørensen, N. N. (2017). A new k-epsilon
+ * model consistent with Monin-Obukhov similarity theory. Wind Energy,
+ * 20(3), 479–489. https://doi.org/10.1002/we.2017
+ *
+ * Consistent with Dyer (1974) formulation from page 57, Chapter 2, Modeling
+ * the vertical ABL structure in Modelling of Atmospheric Flow Fields,
+ * Demetri P Lalas and Corrado F Ratto, January 1996,
+ * https://doi.org/10.1142/2975.
+ */
+
+
 amrex::Real MOData::calc_psi_m(amrex::Real zeta)
 {
     if (zeta > 0) {

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -1,0 +1,72 @@
+#include "amr-wind/wind_energy/MOData.h"
+
+namespace amr_wind {
+
+amrex::Real MOData::calc_psi_m(amrex::Real zeta)
+{
+    if (zeta > 0) {
+        return -gamma_m * zeta;
+    } else {
+        amrex::Real x = std::sqrt(std::sqrt(1 - beta_m * zeta));
+        return 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
+            2.0 * std::atan(x) + utils::half_pi();
+    }
+}
+
+amrex::Real MOData::calc_psi_h(amrex::Real zeta)
+{
+    if (zeta > 0) {
+        return -gamma_h * zeta;
+    } else {
+        amrex::Real x = std::sqrt(1 - beta_m * zeta);
+        return std::log(0.5 * (1 + x));
+    }
+}
+
+void MOData::update_fluxes(int max_iters)
+{
+    amrex::Real zeta = 0.0;
+    amrex::Real utau_iter = 0.0;
+
+    // Initialize variables
+    amrex::Real psi_m = 0.0;
+    amrex::Real psi_h = 0.0;
+    utau = kappa * vmag_mean / (std::log(zref / z0) - psi_m);
+
+    int iter = 0;
+    do {
+        utau_iter = utau;
+        switch (alg_type) {
+        case HEAT_FLUX:
+            surf_temp = surf_temp_flux * (std::log(zref / z0) - psi_h) /
+                            (utau * kappa) +
+                        theta_mean;
+            break;
+
+        case SURFACE_TEMPERATURE:
+            surf_temp_flux = -(theta_mean - surf_temp) * utau * kappa /
+                             (std::log(zref / z0) - psi_h);
+            break;
+        }
+
+        obukhov_len = -utau * utau * utau * theta_mean /
+                      (kappa * gravity * surf_temp_flux);
+        zeta = zref / obukhov_len;
+        psi_m = calc_psi_m(zeta);
+        psi_h = calc_psi_h(zeta);
+        utau = kappa * vmag_mean / (std::log(zref / z0) - psi_m);
+        ++iter;
+    } while ((std::abs(utau_iter - utau) > 1e-5) && iter <= max_iters);
+
+    if (iter >= max_iters) {
+        amrex::Print()
+            << "MOData::update_fluxes: Convergence criteria not met after "
+            << max_iters << " iterations"
+            << "\nObuhov length = " << obukhov_len << " zeta = " << zeta
+            << "\npsi_m = " << psi_m << " psi_h = " << psi_h
+            << "\nutau = " << utau << " Tsurf = " << surf_temp
+            << " q = " << surf_temp_flux << std::endl;
+    }
+}
+
+}

--- a/amr-wind/wind_energy/MOData.h
+++ b/amr-wind/wind_energy/MOData.h
@@ -1,0 +1,43 @@
+#ifndef MODATA_H
+#define MODATA_H
+
+#include "amr-wind/utilities/trig_ops.H"
+
+namespace amr_wind {
+
+struct MOData
+{
+    enum ThetaCalcType {
+        HEAT_FLUX = 0,
+        SURFACE_TEMPERATURE
+    };
+
+    amrex::Real zref{0.0};     ///< Reference height (m)
+    amrex::Real z0{0.1};       ///< Roughness height (m)
+    amrex::Real utau;          ///< Friction velocity (m/s)
+    amrex::Real kappa{0.41};   ///< von Karman constant
+    amrex::Real gravity{9.81}; ///< Acceleration due to gravity (m/s^2)
+    amrex::Real obukhov_len{1.0e16};
+
+    amrex::Real vel_mean[AMREX_SPACEDIM]; ///< Mean velocity (at zref)
+    amrex::Real vmag_mean;                ///< Mean wind speed (at zref)
+    amrex::Real theta_mean;               ///< Mean potential temperature
+
+    amrex::Real surf_temp_flux; ///< Heat flux
+    amrex::Real surf_temp;      ///< Instantaneous surface temperature
+    amrex::Real ref_temp;       ///< Reference temperature
+
+    amrex::Real gamma_m{5.0};
+    amrex::Real gamma_h{5.0};
+    amrex::Real beta_m{16.0};
+
+    ThetaCalcType alg_type{HEAT_FLUX};
+
+    amrex::Real calc_psi_m(amrex::Real zeta);
+    amrex::Real calc_psi_h(amrex::Real zeta);
+    void update_fluxes(int max_iters = 25);
+};
+
+} // namespace amr_wind
+
+#endif /* MODATA_H */


### PR DESCRIPTION
This PR updates the ABL wall shear stress formulation so that does not require
that the finest level cover the entire domain near the ground. The old logic 
using temporary FabArrays to allow arbitrary height sampling is retained, for
future use. 

This change is necessary to allow for blade-resolved simulations in ABL flow.
