### PR TITLE
Add capability to output derived fields to PlotFile

### DIFF
--- a/amr-wind/core/CMakeLists.txt
+++ b/amr-wind/core/CMakeLists.txt
@@ -6,5 +6,6 @@ target_sources(${amr_wind_lib_name}
   IntField.cpp
   FieldRepo.cpp
   ScratchField.cpp
+  ViewField.cpp
   MLMGOptions.cpp
   )

--- a/amr-wind/core/Field.H
+++ b/amr-wind/core/Field.H
@@ -11,6 +11,7 @@
 
 #include "amr-wind/incflo_enums.H"
 #include "amr-wind/core/FieldDescTypes.H"
+#include "amr-wind/core/ViewField.H"
 
 namespace amr_wind {
 
@@ -257,6 +258,11 @@ public:
     /** Set components to those in the vector for a multi-component field
      */
     void setVal(const amrex::Vector<amrex::Real>& values, int nghost=0) noexcept;
+
+    /** Return a sub-view of the Field instance
+     */
+    ViewField<Field> subview(const int scomp = 0, const int ncomp = 1)
+    { return {*this, scomp, ncomp}; }
 
     /** Register a custom fillpatch class instance for this field
      *

--- a/amr-wind/core/ScratchField.H
+++ b/amr-wind/core/ScratchField.H
@@ -4,6 +4,7 @@
 #include <string>
 
 #include "amr-wind/core/FieldDescTypes.H"
+#include "amr-wind/core/ViewField.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_Vector.H"
 #include "AMReX_PhysBCFunct.H"
@@ -59,6 +60,11 @@ public:
 
     //! Return a reference to the field repository that created this field
     const FieldRepo& repo() const { return m_repo; }
+
+    /** Return a sub-view of the ScratchField instance
+     */
+    ViewField<ScratchField> subview(const int scomp = 0, const int ncomp = 1)
+    { return {*this, scomp, ncomp}; }
 
     void fillpatch(amrex::Real time) noexcept;
     void fillpatch(amrex::Real time, const amrex::IntVect& ng) noexcept;

--- a/amr-wind/core/ViewField.H
+++ b/amr-wind/core/ViewField.H
@@ -1,0 +1,84 @@
+#ifndef VIEWFIELD_H
+#define VIEWFIELD_H
+
+#include <string>
+
+#include "amr-wind/core/FieldDescTypes.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_Vector.H"
+
+namespace amr_wind {
+
+class FieldRepo;
+
+/** Subview of a Field or a ScratchField
+ *  \ingroup fields
+ *
+ *  A ViewField instance holds MultiFab corresponding to a subview of a Field or
+ *  a ScratchField. As the data is managed by the source Field or ScratchField,
+ *  subview instances cannot be created directly but instead must be created
+ *  using the Field::subview() and ScratchField::subview() methods.
+ */
+template<typename T>
+class ViewField
+{
+public:
+    friend T;
+
+    ViewField(const ViewField&) = delete;
+    ViewField& operator=(const ViewField&) = delete;
+
+    ViewField(ViewField&&) = default;
+    ViewField& operator=(ViewField&&) = default;
+
+    inline const std::string name() const
+    { return m_src.name() + "view"; }
+
+    //! Number of components in this subview
+    inline int num_comp() const { return m_ncomp; }
+
+    inline const amrex::IntVect& num_grow() const
+    { return m_src.num_grow(); }
+
+    inline FieldLoc field_location() const { return m_src.field_location(); }
+
+    //! Return the field data for a given level
+    amrex::MultiFab& operator()(int lev) { return m_data[lev]; }
+    const amrex::MultiFab& operator()(int lev) const { return m_data[lev]; }
+
+    amrex::Vector<amrex::MultiFab*> vec_ptrs() noexcept
+    {
+        return amrex::GetVecOfPtrs(m_data);
+    }
+
+    amrex::Vector<const amrex::MultiFab*> vec_const_ptrs() const noexcept
+    {
+        return amrex::GetVecOfConstPtrs(m_data);
+    }
+
+    //! Return a reference to the field repository that created this field
+    const FieldRepo& repo() const { return m_src.repo(); }
+
+    //! Return a reference to the source field from which this view is derived
+    T& source_field() { return m_src; }
+    const T& source_field() const { return m_src; }
+
+private:
+    ViewField(T& src, const int scomp = 0, const int ncomp = 1);
+
+    //! The base field
+    T& m_src;
+
+    //! Index of the starting component
+    int m_scomp;
+
+    //! Number of sub-components in this view
+    int m_ncomp;
+
+    //! MultiFabs holding the alias views
+    amrex::Vector<amrex::MultiFab> m_data;
+};
+
+}
+
+#endif /* VIEWFIELD_H */

--- a/amr-wind/core/ViewField.cpp
+++ b/amr-wind/core/ViewField.cpp
@@ -1,0 +1,22 @@
+#include "amr-wind/core/ViewField.H"
+#include "amr-wind/core/Field.H"
+#include "amr-wind/core/ScratchField.H"
+#include "amr-wind/core/FieldRepo.H"
+
+namespace amr_wind {
+
+template<typename T>
+ViewField<T>::ViewField(T& src, const int scomp, const int ncomp)
+    : m_src(src), m_scomp(scomp), m_ncomp(ncomp)
+{
+    int nlevels = src.repo().num_active_levels();
+    for (int lev=0; lev < nlevels; ++lev) {
+        m_data.emplace_back(
+            amrex::MultiFab(src(lev), amrex::make_alias, m_scomp, m_ncomp));
+    }
+}
+
+template class ViewField<Field>;
+template class ViewField<ScratchField>;
+
+}

--- a/amr-wind/fvm/fvm.H
+++ b/amr-wind/fvm/fvm.H
@@ -6,6 +6,7 @@
 #include "amr-wind/fvm/gradient.H"
 #include "amr-wind/fvm/laplacian.H"
 #include "amr-wind/fvm/strainrate.H"
+#include "amr-wind/fvm/vorticity_mag.H"
 
 /**
  *  \defgroup fvm Finite-Volume Operators

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -3,6 +3,7 @@
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/equation_systems/PDEBase.H"
 #include "amr-wind/core/field_ops.H"
+#include "amr-wind/utilities/IOManager.H"
 
 namespace amr_wind {
 
@@ -55,7 +56,9 @@ TiogaInterface::TiogaInterface(CFDSim& sim)
     , m_mask_node(sim.repo().declare_int_field(
           "mask_node", 1, sim.pde_manager().num_ghost_state(), 1,
           FieldLoc::NODE))
-{}
+{
+    m_sim.io_manager().register_output_int_var(m_iblank_cell.name());
+}
 // clang-format on
 
 void TiogaInterface::post_init_actions()

--- a/amr-wind/utilities/CMakeLists.txt
+++ b/amr-wind/utilities/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(${amr_wind_lib_name}
       ThirdMomentAveraging.cpp
 
       PostProcessing.cpp
+      DerivedQuantity.cpp
+      DerivedQtyDefs.cpp
    )
 
 add_subdirectory(tagging)

--- a/amr-wind/utilities/DerivedQtyDefs.cpp
+++ b/amr-wind/utilities/DerivedQtyDefs.cpp
@@ -1,0 +1,139 @@
+#include "amr-wind/utilities/DerivedQuantity.H"
+#include "amr-wind/fvm/fvm.H"
+
+namespace amr_wind {
+namespace derived {
+
+struct VorticityMag : public DerivedQty::Register<VorticityMag>
+{
+    static constexpr int ncomp = 1;
+    static std::string identifier() { return "mag_vorticity"; }
+
+    VorticityMag(const FieldRepo& repo, const std::vector<std::string>& args)
+        : m_vel(repo.get_field("velocity"))
+    {
+        AMREX_ALWAYS_ASSERT(args.size() == 0u);
+    }
+
+    std::string name() const override { return identifier(); }
+
+    int num_comp() const override { return ncomp; }
+
+    void operator()(ScratchField& fld, const int scomp = 0) override
+    {
+        AMREX_ASSERT(fld.num_comp() > (scomp));
+        auto vort_mag = fld.subview(scomp, 1);
+        fvm::vorticity_mag(vort_mag, m_vel);
+    }
+
+private:
+    const Field& m_vel;
+};
+
+struct StrainRateMag : public DerivedQty::Register<StrainRateMag>
+{
+    static constexpr int ncomp = 1;
+    static std::string identifier() { return "mag_strainrate"; }
+
+    StrainRateMag(const FieldRepo& repo, const std::vector<std::string>& args)
+        : m_vel(repo.get_field("velocity"))
+    {
+        AMREX_ALWAYS_ASSERT(args.size() == 0u);
+    }
+
+    std::string name() const override { return identifier(); }
+
+    int num_comp() const override { return ncomp; }
+
+    void operator()(ScratchField& fld, const int scomp = 0) override
+    {
+        AMREX_ASSERT(fld.num_comp() > (scomp));
+        auto srate = fld.subview(scomp, 1);
+        fvm::strainrate(srate, m_vel);
+    }
+
+private:
+    const Field& m_vel;
+};
+
+struct Gradient : public DerivedQty::Register<Gradient>
+{
+    static std::string identifier() { return "grad"; }
+
+    Gradient(const FieldRepo& repo, const std::vector<std::string>& args)
+    {
+        AMREX_ALWAYS_ASSERT(args.size() == 1u);
+        m_phi = &repo.get_field(args[0]);
+    }
+
+    std::string name() const override { return "grad_" + m_phi->name(); }
+
+    int num_comp() const override
+    { return AMREX_SPACEDIM * m_phi->num_comp(); }
+
+    void operator()(ScratchField& fld, const int scomp = 0) override
+    {
+        AMREX_ASSERT(fld.num_comp() >= (scomp + num_comp()));
+        auto gradphi = fld.subview(scomp, num_comp());
+        fvm::gradient(gradphi, *m_phi);
+    }
+
+private:
+    const Field* m_phi;
+};
+
+struct Divergence : public DerivedQty::Register<Divergence>
+{
+    static std::string identifier() { return "div"; }
+
+    Divergence(const FieldRepo& repo, const std::vector<std::string>& args)
+    {
+        AMREX_ALWAYS_ASSERT(args.size() == 1u);
+        m_phi = &repo.get_field(args[0]);
+        AMREX_ALWAYS_ASSERT(m_phi->num_comp() == AMREX_SPACEDIM);
+    }
+
+    std::string name() const override { return "div_" + m_phi->name(); }
+
+    int num_comp() const override { return 1; }
+
+    void operator()(ScratchField& fld, const int scomp = 0) override
+    {
+        AMREX_ASSERT(fld.num_comp() >= (scomp + num_comp()));
+        auto divphi = fld.subview(scomp, num_comp());
+        fvm::divergence(divphi, *m_phi);
+    }
+
+private:
+    const Field* m_phi;
+};
+
+struct Laplacian : public DerivedQty::Register<Laplacian>
+{
+    static constexpr int ncomp = 1;
+    static std::string identifier() { return "laplacian"; }
+
+    Laplacian(const FieldRepo& repo, const std::vector<std::string>& args)
+    {
+        AMREX_ALWAYS_ASSERT(args.size() == 1u);
+        m_phi = &repo.get_field(args[0]);
+        AMREX_ALWAYS_ASSERT(m_phi->num_comp() == AMREX_SPACEDIM);
+    }
+
+    std::string name() const override { return "laplacian_" + m_phi->name(); }
+
+    int num_comp() const override { return ncomp; }
+
+    void operator()(ScratchField& fld, const int scomp = 0) override
+    {
+        AMREX_ASSERT(fld.num_comp() >= (scomp + num_comp()));
+        auto lapphi = fld.subview(scomp, num_comp());
+        fvm::laplacian(lapphi, *m_phi);
+    }
+
+private:
+    const Field* m_phi;
+};
+
+} // namespace derived
+} // namespace amr_wind

--- a/amr-wind/utilities/DerivedQuantity.H
+++ b/amr-wind/utilities/DerivedQuantity.H
@@ -1,0 +1,63 @@
+#ifndef DERIVEDQUANTITY_H
+#define DERIVEDQUANTITY_H
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "amr-wind/core/Factory.H"
+#include "amr-wind/core/CollMgr.H"
+#include "amr-wind/CFDSim.H"
+
+namespace amr_wind {
+
+class DerivedQty : public Factory<DerivedQty, const FieldRepo&, std::vector<std::string>&>
+{
+public:
+    static const std::string base_identifier() { return "DerivedQty"; }
+
+    virtual ~DerivedQty() = default;
+
+    virtual std::string name() const = 0;
+
+    virtual int num_comp() const = 0;
+
+    virtual void operator()(ScratchField& fld, const int scomp = 0) = 0;
+};
+
+class DerivedQtyMgr
+{
+public:
+    using TypePtr = std::unique_ptr<DerivedQty>;
+    using TypeVector = amrex::Vector<TypePtr>;
+
+    DerivedQtyMgr(const FieldRepo& repo);
+
+    ~DerivedQtyMgr() = default;
+
+    void operator()(ScratchField& fld, const int scomp = 0);
+
+    void create(const amrex::Vector<std::string>& keys);
+
+    //! Add a derived quantity
+    DerivedQty& create(const std::string& key);
+
+    //! Return the total number of components across all derived quantities
+    int num_comp() const noexcept;
+
+    bool contains(const std::string& key) const noexcept;
+
+    //! Populate a vector of variable names (for output)
+    void var_names(amrex::Vector<std::string>&) const noexcept;
+
+private:
+    const FieldRepo& m_repo;
+
+    TypeVector m_derived_vec;
+
+    std::unordered_map<std::string, int> m_obj_map;
+};
+
+}
+
+#endif /* DERIVEDQUANTITY_H */

--- a/amr-wind/utilities/DerivedQuantity.cpp
+++ b/amr-wind/utilities/DerivedQuantity.cpp
@@ -1,0 +1,104 @@
+#include <string>
+#include <algorithm>
+
+#include "amr-wind/utilities/DerivedQuantity.H"
+#include "amr-wind/utilities/io_utils.H"
+
+namespace amr_wind {
+namespace {
+
+inline std::string strip_spaces(const std::string& inp)
+{
+    std::string str(inp);
+    str.erase(std::remove(str.begin(), str.end(), ' '), str.end());
+    return str;
+}
+
+std::pair<std::string, std::vector<std::string>>
+parse_derived_qty(const std::string& key)
+{
+    auto popen = key.find("(");
+    // If this is not a function type field then return it
+    if (popen == std::string::npos) {
+        return {key, {}};
+    }
+
+    auto pclose = key.find(")");
+    if (pclose == std::string::npos) {
+        amrex::Abort(
+            "Error encountered when parsing derived field name: " + key);
+    }
+
+    // Get the function name
+    auto dname = strip_spaces(key.substr(0, popen));
+
+    // Collect all arguments required for the derived quantity function
+    auto fargs = strip_spaces(key.substr(popen + 1, pclose - popen - 1));
+    if (fargs.back() != ',') fargs += ",";
+    std::vector<std::string> args;
+    size_t start = 0;
+    size_t pos;
+    while ((pos = fargs.find(",", start)) != std::string::npos) {
+        args.push_back(fargs.substr(start, pos - start));
+        start = pos + 1;
+    }
+
+    return {dname, args};
+}
+
+} // namespace
+
+DerivedQtyMgr::DerivedQtyMgr(const FieldRepo& repo) : m_repo(repo) {}
+
+DerivedQty& DerivedQtyMgr::create(const std::string& key)
+{
+    auto qty_name = strip_spaces(key);
+
+    // If this quantity is already registered return early
+    if (contains(qty_name)) return *m_derived_vec[m_obj_map[qty_name]];
+
+    auto tokens = parse_derived_qty(qty_name);
+    m_derived_vec.emplace_back(
+        DerivedQty::create(tokens.first, m_repo, tokens.second));
+    m_obj_map[qty_name] = m_derived_vec.size() - 1;
+
+    return *m_derived_vec.back();
+}
+
+void DerivedQtyMgr::create(const amrex::Vector<std::string>& keys)
+{
+    for (const auto& qty : keys) create(qty);
+}
+
+void DerivedQtyMgr::operator()(ScratchField& fld, const int scomp)
+{
+    AMREX_ALWAYS_ASSERT((scomp + num_comp()) <= fld.num_comp());
+
+    int icomp = scomp;
+    for (auto& qty : m_derived_vec) {
+        (*qty)(fld, icomp);
+        icomp += qty->num_comp();
+    }
+}
+
+int DerivedQtyMgr::num_comp() const noexcept
+{
+    int count = 0;
+    for (const auto& qty : m_derived_vec) count += qty->num_comp();
+    return count;
+}
+
+bool DerivedQtyMgr::contains(const std::string& key) const noexcept
+{
+    auto it = m_obj_map.find(key);
+    return (it != m_obj_map.end());
+}
+
+void DerivedQtyMgr::var_names(amrex::Vector<std::string>& plt_var_names) const noexcept
+{
+    for (auto& qty: m_derived_vec) {
+        ioutils::add_var_names(plt_var_names, qty->name(), qty->num_comp());
+    }
+}
+
+} // namespace amr_wind

--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -11,6 +11,7 @@ namespace amr_wind {
 
 class CFDSim;
 class Field;
+class IntField;
 
 /** Input/Output manager
  *  \ingroup utilities
@@ -52,6 +53,11 @@ public:
         m_pltvars_default.insert(fname);
     }
 
+    void register_output_int_var(const std::string& fname)
+    {
+        m_int_pltvars_default.insert(fname);
+    }
+
     //! Register a variable for restart file
     void register_restart_var(const std::string& fname)
     {
@@ -84,11 +90,17 @@ private:
     //! Default output variables registered automatically in the code
     std::set<std::string> m_pltvars_default;
 
+    //! Default output integer variales registered automatically in the code
+    std::set<std::string> m_int_pltvars_default;
+
     //! Variables for output in checkpoint/restart files
     std::set<std::string> m_chkvars;
 
     //! Final list of fields to be output
     amrex::Vector<Field*> m_plt_fields;
+
+    //! Final list of integer fields to be output
+    amrex::Vector<IntField*> m_int_plt_fields;
 
     //! Final list of fields for restart
     amrex::Vector<Field*> m_chk_fields;

--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -12,6 +12,7 @@ namespace amr_wind {
 class CFDSim;
 class Field;
 class IntField;
+class DerivedQtyMgr;
 
 /** Input/Output manager
  *  \ingroup utilities
@@ -86,6 +87,8 @@ private:
     void write_info_file(const std::string&);
 
     CFDSim& m_sim;
+
+    std::unique_ptr<DerivedQtyMgr> m_derived_mgr;
 
     //! Default output variables registered automatically in the code
     std::set<std::string> m_pltvars_default;

--- a/unit_tests/core/test_field.cpp
+++ b/unit_tests/core/test_field.cpp
@@ -352,4 +352,37 @@ TEST_F(FieldRepoTest, default_fillpatch_op)
     velocity.fillpatch(sim().time().current_time());
 }
 
+TEST_F(FieldRepoTest, field_subviews)
+{
+    initialize_mesh();
+    auto& repo = mesh().field_repo();
+    auto& velocity = repo.declare_field("vel", 3);
+
+    velocity.setVal(10.0, 0, 1);
+    velocity.setVal(20.0, 1, 1);
+    velocity.setVal(30.0, 2, 1);
+    {
+        auto wvel = velocity.subview(2);
+        EXPECT_TRUE(wvel.num_comp() == 1);
+
+        int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            EXPECT_NEAR(wvel(lev).min(0), 30.0, 1.0e-12);
+            EXPECT_NEAR(wvel(lev).max(0), 30.0, 1.0e-12);
+        }
+    }
+
+    {
+        auto vel2d = velocity.subview(0, 2);
+        EXPECT_TRUE(vel2d.num_comp() == 2);
+        int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            EXPECT_NEAR(vel2d(lev).min(0), 10.0, 1.0e-12);
+            EXPECT_NEAR(vel2d(lev).max(0), 10.0, 1.0e-12);
+            EXPECT_NEAR(vel2d(lev).min(1), 20.0, 1.0e-12);
+            EXPECT_NEAR(vel2d(lev).max(1), 20.0, 1.0e-12);
+        }
+    }
+}
+
 } // namespace amr_wind_tests


### PR DESCRIPTION
Introduces a new input file parameter `derived_outputs` that can be used to output fields that are a result of post processing of existing fields

```
io.derived_outputs = mag_vorticity mag_strainrate grad(temperature) div(velocity) 
```