### PR TITLE
Add ability to output select components of a field

### DIFF
--- a/amr-wind/utilities/DerivedQuantity.H
+++ b/amr-wind/utilities/DerivedQuantity.H
@@ -23,6 +23,8 @@ public:
     virtual int num_comp() const = 0;
 
     virtual void operator()(ScratchField& fld, const int scomp = 0) = 0;
+
+    virtual void var_names(amrex::Vector<std::string>&);
 };
 
 class DerivedQtyMgr

--- a/amr-wind/utilities/DerivedQuantity.cpp
+++ b/amr-wind/utilities/DerivedQuantity.cpp
@@ -48,6 +48,11 @@ parse_derived_qty(const std::string& key)
 
 } // namespace
 
+void DerivedQty::var_names(amrex::Vector<std::string>& plt_var_names)
+{
+    ioutils::add_var_names(plt_var_names, this->name(), this->num_comp());
+}
+
 DerivedQtyMgr::DerivedQtyMgr(const FieldRepo& repo) : m_repo(repo) {}
 
 DerivedQty& DerivedQtyMgr::create(const std::string& key)
@@ -97,7 +102,7 @@ bool DerivedQtyMgr::contains(const std::string& key) const noexcept
 void DerivedQtyMgr::var_names(amrex::Vector<std::string>& plt_var_names) const noexcept
 {
     for (auto& qty: m_derived_vec) {
-        ioutils::add_var_names(plt_var_names, qty->name(), qty->num_comp());
+        qty->var_names(plt_var_names);
     }
 }
 

--- a/test/test_files/ctv_godunov_plm/ctv_godunov_plm.i
+++ b/test/test_files/ctv_godunov_plm/ctv_godunov_plm.i
@@ -16,6 +16,9 @@ time.cfl              =   0.5        # CFL factor
 time.plot_interval  =  20   # Steps between plot files
 time.checkpoint_interval =   -1  # Steps between checkpoint files
 io.KE_int = 1        # calculate kinetic energy 
+io.output_default_variables = 0
+io.outputs = density p
+io.derived_outputs = "components(velocity,0,1)" "components(gp,0,1)"
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #               PHYSICS                 #
 #.......................................#


### PR DESCRIPTION
Adds a new _derived fields_ variant that can be used to output select
components of a given field. 

An example use-case for this would be the CTV Godunov/PLM test which is
essentially a 2D test run in a 3D domain. On GPUs, this causes indeterministic
results on the z-component leading to regression test failures with tight
tolerance. This pull-request also updates that test so that it only outputs 
(x, y) components for that test. 
