### PR TITLE
Tests: check both abs/rel tol for GPU regression tests

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -64,6 +64,6 @@ jobs:
           cmake -Bbuild-${{matrix.cuda_pkg}} \
             -DAMR_WIND_ENABLE_MPI=OFF \
             -DAMR_WIND_ENABLE_CUDA=ON \
-            -DCUDA_ERROR_CAPTURE_THIS:BOOL=ON \
-            -DCUDA_ARCH=Volta .
+            -DAMReX_CUDA_ERROR_CAPTURE_THIS:BOOL=ON \
+            -DAMReX_CUDA_ARCH=Volta .
           cmake --build build-${{matrix.cuda_pkg}} -- -j $(nproc)

--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -35,7 +35,7 @@ function(add_test_r TEST_NAME)
     # Set some default runtime options for all tests in this category
     set(RUNTIME_OPTIONS "time.max_step=10 amr.plot_file=plt time.plot_interval=10 amrex.throw_exception=1 amrex.signal_handling=0")
     if(AMR_WIND_ENABLE_CUDA)
-      set(FCOMPARE_TOLERANCE "-r 1e-10")
+      set(FCOMPARE_TOLERANCE "-r 1e-10 --abs_tol 1.0e-12")
     endif()
     # Use fcompare to test diffs in plots against gold files
     if(AMR_WIND_TEST_WITH_FCOMPARE)


### PR DESCRIPTION
- Update AMReX to get latest fcompare that supports absolute tolerance checks (AMReX-codes/amrex#1537)

- Change CTestList to add tolerances
