### PR TITLE
Fix sampling code to execute without managed memory

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -57,6 +57,10 @@ public:
     //! Write sampled data in binary format
     virtual void impl_write_native();
 
+    int num_total_particles() const { return m_total_particles; }
+
+    const amrex::Vector<std::string>& var_names() const { return m_var_names; }
+
 protected:
     //! Output data based on user-defined format
     virtual void process_output();
@@ -73,6 +77,8 @@ protected:
      *  runs as it can have significant impacts on code performance.
      */
     virtual void write_ascii();
+
+    SamplingContainer& sampling_container() { return *m_scontainer; }
 
 private:
     CFDSim& m_sim;

--- a/unit_tests/aw_test_utils/AmrexTestEnv.H
+++ b/unit_tests/aw_test_utils/AmrexTestEnv.H
@@ -39,21 +39,33 @@ public:
             pp.add("signal_handling", 0);
         });
 
+        // Save managed memory flag for future use
+        {
+            amrex::ParmParse pp("amrex");
+            pp.query("the_arena_is_managed", m_has_managed_memory);
+        }
+
         // Call ParmParse::Finalize immediately to allow unit tests to start
         // with a clean "input file". However, allow user to override this
         // behavior through command line arguments.
-        amrex::ParmParse pp("utest");
-        bool keep_parameters = false;
-        pp.query("keep_parameters", keep_parameters);
+        {
+            amrex::ParmParse pp("utest");
+            bool keep_parameters = false;
+            pp.query("keep_parameters", keep_parameters);
 
-        if (!keep_parameters) amrex::ParmParse::Finalize();
+            if (!keep_parameters) amrex::ParmParse::Finalize();
+        }
     }
 
     void TearDown() override { amrex::Finalize(); }
 
+    bool has_managed_memory() const { return m_has_managed_memory; }
+
 protected:
     int& m_argc;
     char**& m_argv;
+
+    bool m_has_managed_memory{true};
 };
 
 } // namespace amr_wind_tests

--- a/unit_tests/aw_test_utils/pp_utils.H
+++ b/unit_tests/aw_test_utils/pp_utils.H
@@ -27,6 +27,9 @@ void default_time_inputs();
 //! Default inputs for amrex::AmrCore
 void default_mesh_inputs();
 
+//! Flag indicating whether managed memory is enabled
+bool has_managed_memory();
+
 } // namespace pp_utils
 } // namespace amr_wind_tests
 

--- a/unit_tests/aw_test_utils/pp_utils.cpp
+++ b/unit_tests/aw_test_utils/pp_utils.cpp
@@ -1,5 +1,8 @@
+#include "aw_test_utils/AmrexTestEnv.H"
 #include "pp_utils.H"
 #include "AMReX_ParmParse.H"
+
+extern amr_wind_tests::AmrexTestEnv* utest_env;
 
 namespace amr_wind_tests {
 namespace pp_utils {
@@ -9,10 +12,7 @@ bool has_managed_memory()
 #if defined (AMREX_USE_HIP)
     return false;
 #else
-    bool has_managed = true;
-    amrex::ParmParse pp("amrex");
-    pp.query("the_arena_is_managed", has_managed);
-    return has_managed;
+    return utest_env->has_managed_memory();
 #endif
 }
 

--- a/unit_tests/aw_test_utils/pp_utils.cpp
+++ b/unit_tests/aw_test_utils/pp_utils.cpp
@@ -4,6 +4,18 @@
 namespace amr_wind_tests {
 namespace pp_utils {
 
+bool has_managed_memory()
+{
+#if defined (AMREX_USE_HIP)
+    return false;
+#else
+    bool has_managed = true;
+    amrex::ParmParse pp("amrex");
+    pp.query("the_arena_is_managed", has_managed);
+    return has_managed;
+#endif
+}
+
 void default_time_inputs()
 {
     amrex::ParmParse pp("time");

--- a/unit_tests/mms/test_mms_error.cpp
+++ b/unit_tests/mms/test_mms_error.cpp
@@ -29,6 +29,11 @@ void perturb_vel_field(
 
 TEST_F(MMSMeshTest, mms_error)
 {
+#if defined (AMREX_USE_HIP)
+    GTEST_SKIP();
+#else
+    if (!pp_utils::has_managed_memory()) GTEST_SKIP();
+
     populate_parameters();
     utils::populate_mms_params();
 
@@ -71,6 +76,7 @@ TEST_F(MMSMeshTest, mms_error)
     EXPECT_NEAR(u_mms_err, golds[0], tol);
     EXPECT_NEAR(v_mms_err, golds[1], tol);
     EXPECT_NEAR(w_mms_err, golds[2], tol);
+#endif
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/mms/test_mms_init.cpp
+++ b/unit_tests/mms/test_mms_init.cpp
@@ -7,6 +7,11 @@
 namespace amr_wind_tests {
 TEST_F(MMSMeshTest, mms_initialization)
 {
+#if defined (AMREX_USE_HIP)
+    GTEST_SKIP();
+#else
+    if (!pp_utils::has_managed_memory()) GTEST_SKIP();
+
     populate_parameters();
     utils::populate_mms_params();
 
@@ -44,6 +49,7 @@ TEST_F(MMSMeshTest, mms_initialization)
         EXPECT_NEAR(max_vel[1], 0.15852994009080945, tol);
         EXPECT_NEAR(max_vel[2], 0.28208315203480022, tol);
     }
+#endif
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/mms/test_mms_src.cpp
+++ b/unit_tests/mms/test_mms_src.cpp
@@ -14,6 +14,11 @@ using ICNSFields =
 
 TEST_F(MMSMeshTest, mms_forcing)
 {
+#if defined (AMREX_USE_HIP)
+    GTEST_SKIP();
+#else
+    if (!pp_utils::has_managed_memory()) GTEST_SKIP();
+
     constexpr amrex::Real tol = 1.0e-12;
 
     // Initialize parameters
@@ -48,5 +53,6 @@ TEST_F(MMSMeshTest, mms_forcing)
         EXPECT_NEAR(min_val, min_golds[i], tol);
         EXPECT_NEAR(max_val, max_golds[i], tol);
     }
+#endif
 }
 } // namespace amr_wind_tests

--- a/unit_tests/utilities/test_sampling.cpp
+++ b/unit_tests/utilities/test_sampling.cpp
@@ -46,7 +46,12 @@ public:
 
 protected:
     void prepare_netcdf_file() override {}
-    void process_output() override {}
+    void process_output() override
+    {
+        // Test buffer populate for GPU runs
+        std::vector<double> buf(num_total_particles() * var_names().size(), 0.0);
+        sampling_container().populate_buffer(buf);
+    }
 };
 
 } // namespace


### PR DESCRIPTION
- Update `amr_wind::sampling` to execute safely without managed memory
- Add appropriate logic to disable MMS unit tests when running without managed memory