### PR TITLE
Fix build errors in single precision mode

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -95,7 +95,7 @@ void SimTime::set_current_cfl(
     if (m_is_init) dt_new *= m_init_shrink;
 
     // Limit timestep growth to 10% per timestep
-    if (m_dt[0] > 0.0) dt_new = amrex::min(dt_new, 1.1 * m_dt[0]);
+    if (m_dt[0] > 0.0) dt_new = amrex::min<amrex::Real>(dt_new, 1.1 * m_dt[0]);
 
     // Don't overshoot stop time
     if ((m_stop_time > 0.0) && ((m_cur_time + dt_new) > m_stop_time))

--- a/amr-wind/physics/RayleighTaylorFieldInit.cpp
+++ b/amr-wind/physics/RayleighTaylorFieldInit.cpp
@@ -34,7 +34,7 @@ void RayleighTaylorFieldInit::operator()(
         const amrex::Real y = problo[1] + (j + 0.5) * dx[1];
         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
         const amrex::Real r2d =
-            amrex::min(std::hypot((x - splitx), (y - splity)), 0.5 * L_x);
+            amrex::min<amrex::Real>(std::hypot((x - splitx), (y - splity)), 0.5 * L_x);
         const amrex::Real pertheight =
             0.5 - 0.01 * std::cos(2.0 * pi * r2d / L_x);
 

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -121,7 +121,7 @@ void OneEqKsgsM84<Transport>::update_turbulent_viscosity(
                           gradT_arr(i, j, k, 2) * gravity[2]) *
                         beta;
                     if (stratification > 1e-10)
-                        tlscale_arr(i, j, k) = amrex::min(
+                        tlscale_arr(i, j, k) = amrex::min<amrex::Real>(
                             ds, 0.76 * std::sqrt(
                                            tke_arr(i, j, k) / stratification));
                     else

--- a/amr-wind/utilities/ncutils/nc_interface.H
+++ b/amr-wind/utilities/ncutils/nc_interface.H
@@ -19,6 +19,17 @@
 
 namespace ncutils {
 
+//! Wrapper around NetCDF data types
+struct NCDType
+{
+    static constexpr nc_type Int = NC_INT;
+#ifdef AMREX_USE_FLOAT
+    static constexpr nc_type Real = NC_FLOAT;
+#else
+    static constexpr nc_type Real = NC_DOUBLE;
+#endif
+};
+
 //! Representation of NetCDF dimension
 struct NCDim
 {
@@ -55,6 +66,7 @@ struct NCVar
 
     //! Write out the entire variable
     void put(const double*) const;
+    void put(const float*) const;
     void put(const int*) const;
 
     //! Write out a slice of data
@@ -70,6 +82,19 @@ struct NCVar
         const std::vector<size_t>&,
         const std::vector<size_t>&,
         const std::vector<ptrdiff_t>&) const;
+    //! Write out a slice of data
+    void
+    put(const float*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&) const;
+
+    //! Write out a slice of data with with strides (see hyperslab definition in
+    //! NetCDF)
+    void
+    put(const float*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&,
+        const std::vector<ptrdiff_t>&) const;
     void put(const int*, const std::vector<size_t>&, const std::vector<size_t>&)
         const;
     void
@@ -80,6 +105,7 @@ struct NCVar
 
     //! Read the entire variable from file
     void get(double*) const;
+    void get(float*) const;
     void get(int*) const;
 
     //! Read a chunk of data from the file
@@ -89,6 +115,17 @@ struct NCVar
     //! Read a chunk of data with strides
     void
     get(double*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&,
+        const std::vector<ptrdiff_t>&) const;
+
+    //! Read a chunk of data from the file
+    void
+    get(float*, const std::vector<size_t>&, const std::vector<size_t>&) const;
+
+    //! Read a chunk of data with strides
+    void
+    get(float*,
         const std::vector<size_t>&,
         const std::vector<size_t>&,
         const std::vector<ptrdiff_t>&) const;
@@ -105,10 +142,13 @@ struct NCVar
     void put_attr(const std::string& name, const std::string& value) const;
     void
     put_attr(const std::string& name, const std::vector<double>& value) const;
+    void
+    put_attr(const std::string& name, const std::vector<float>& value) const;
     void put_attr(const std::string& name, const std::vector<int>& value) const;
 
     std::string get_attr(const std::string& name) const;
     void get_attr(const std::string& name, std::vector<double>& value) const;
+    void get_attr(const std::string& name, std::vector<float>& value) const;
     void get_attr(const std::string& name, std::vector<int>& value) const;
     void par_access(const int cmode) const;
 };
@@ -201,10 +241,13 @@ public:
     void put_attr(const std::string& name, const std::string& value) const;
     void
     put_attr(const std::string& name, const std::vector<double>& value) const;
+    void
+    put_attr(const std::string& name, const std::vector<float>& value) const;
     void put_attr(const std::string& name, const std::vector<int>& value) const;
 
     std::string get_attr(const std::string& name) const;
     void get_attr(const std::string& name, std::vector<double>& value) const;
+    void get_attr(const std::string& name, std::vector<float>& value) const;
     void get_attr(const std::string& name, std::vector<int>& value) const;
 
     //! Return a list of all groups defined in this group

--- a/amr-wind/utilities/ncutils/nc_interface.cpp
+++ b/amr-wind/utilities/ncutils/nc_interface.cpp
@@ -67,6 +67,11 @@ void NCVar::put(const double* ptr) const
     check_nc_error(nc_put_var_double(ncid, varid, ptr));
 }
 
+void NCVar::put(const float* ptr) const
+{
+    check_nc_error(nc_put_var_float(ncid, varid, ptr));
+}
+
 void NCVar::put(const int* ptr) const
 {
     check_nc_error(nc_put_var_int(ncid, varid, ptr));
@@ -89,6 +94,25 @@ void NCVar::put(
 {
     check_nc_error(nc_put_vars_double(
         ncid, varid, start.data(), count.data(), stride.data(), dptr));
+}
+
+void NCVar::put(
+    const float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count) const
+{
+    check_nc_error(
+        nc_put_vara_float(ncid, varid, start.data(), count.data(), dptr));
+}
+
+void NCVar::put(
+    const float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count,
+    const std::vector<ptrdiff_t>& stride) const
+{
+    check_nc_error(nc_put_vars_float(
+                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::put(
@@ -115,6 +139,11 @@ void NCVar::get(double* ptr) const
     check_nc_error(nc_get_var_double(ncid, varid, ptr));
 }
 
+void NCVar::get(float* ptr) const
+{
+    check_nc_error(nc_get_var_float(ncid, varid, ptr));
+}
+
 void NCVar::get(int* ptr) const
 {
     check_nc_error(nc_get_var_int(ncid, varid, ptr));
@@ -137,6 +166,25 @@ void NCVar::get(
 {
     check_nc_error(nc_get_vars_double(
         ncid, varid, start.data(), count.data(), stride.data(), dptr));
+}
+
+void NCVar::get(
+    float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count) const
+{
+    check_nc_error(
+        nc_get_vara_float(ncid, varid, start.data(), count.data(), dptr));
+}
+
+void NCVar::get(
+    float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count,
+    const std::vector<ptrdiff_t>& stride) const
+{
+    check_nc_error(nc_get_vars_float(
+                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::get(
@@ -180,6 +228,13 @@ void NCVar::put_attr(
 }
 
 void NCVar::put_attr(
+    const std::string& name, const std::vector<float>& value) const
+{
+    check_nc_error(nc_put_att_float(
+                       ncid, varid, name.data(), NC_FLOAT, value.size(), value.data()));
+}
+
+void NCVar::put_attr(
     const std::string& name, const std::vector<int>& value) const
 {
     check_nc_error(nc_put_att_int(
@@ -202,6 +257,14 @@ void NCVar::get_attr(const std::string& name, std::vector<double>& values) const
     check_nc_error(nc_inq_attlen(ncid, varid, name.data(), &lenp));
     values.resize(lenp);
     check_nc_error(nc_get_att_double(ncid, varid, name.data(), values.data()));
+}
+
+void NCVar::get_attr(const std::string& name, std::vector<float>& values) const
+{
+    size_t lenp;
+    check_nc_error(nc_inq_attlen(ncid, varid, name.data(), &lenp));
+    values.resize(lenp);
+    check_nc_error(nc_get_att_float(ncid, varid, name.data(), values.data()));
 }
 
 void NCVar::get_attr(const std::string& name, std::vector<int>& values) const
@@ -362,6 +425,13 @@ void NCGroup::put_attr(
 }
 
 void NCGroup::put_attr(
+    const std::string& name, const std::vector<float>& value) const
+{
+    check_nc_error(nc_put_att_float(
+        ncid, NC_GLOBAL, name.data(), NC_FLOAT, value.size(), value.data()));
+}
+
+void NCGroup::put_attr(
     const std::string& name, const std::vector<int>& value) const
 {
     check_nc_error(nc_put_att_int(
@@ -386,6 +456,16 @@ void NCGroup::get_attr(
     values.resize(lenp);
     check_nc_error(
         nc_get_att_double(ncid, NC_GLOBAL, name.data(), values.data()));
+}
+
+void NCGroup::get_attr(
+    const std::string& name, std::vector<float>& values) const
+{
+    size_t lenp;
+    check_nc_error(nc_inq_attlen(ncid, NC_GLOBAL, name.data(), &lenp));
+    values.resize(lenp);
+    check_nc_error(
+        nc_get_att_float(ncid, NC_GLOBAL, name.data(), values.data()));
 }
 
 void NCGroup::get_attr(const std::string& name, std::vector<int>& values) const

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -161,16 +161,16 @@ void Sampling::prepare_netcdf_file()
     ncf.put_attr("created_on", ioutils::timestamp());
     ncf.def_dim(nt_name, NC_UNLIMITED);
     ncf.def_dim("ndim", AMREX_SPACEDIM);
-    ncf.def_var("time", NC_DOUBLE, {nt_name});
+    ncf.def_var("time", ncutils::NCDType::Real, {nt_name});
     // Define groups for each sampler
     for (const auto& obj : m_samplers) {
         auto grp = ncf.def_group(obj->label());
 
         grp.def_dim(npart_name, obj->num_points());
         obj->define_netcdf_metadata(grp);
-        grp.def_var("coordinates", NC_DOUBLE, {npart_name, "ndim"});
+        grp.def_var("coordinates", ncutils::NCDType::Real, {npart_name, "ndim"});
         for (const auto& vname : m_var_names)
-            grp.def_var(vname, NC_DOUBLE, two_dim);
+            grp.def_var(vname, ncutils::NCDType::Real, two_dim);
     }
     ncf.exit_def_mode();
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -197,7 +197,7 @@ void Sampling::prepare_netcdf_file()
 void Sampling::write_netcdf()
 {
 #ifdef AMR_WIND_USE_NETCDF
-    std::vector<double> buf(m_total_particles * m_var_names.size(), 0.0);
+    std::vector<amrex::Real> buf(m_total_particles * m_var_names.size(), 0.0);
     m_scontainer->populate_buffer(buf);
 
     if (!amrex::ParallelDescriptor::IOProcessor()) return;

--- a/amr-wind/utilities/sampling/SamplingContainer.H
+++ b/amr-wind/utilities/sampling/SamplingContainer.H
@@ -86,7 +86,7 @@ public:
     void interpolate_fields(const amrex::Vector<Field*> fields);
 
     //! Populate the buffer with data for all the particles
-    void populate_buffer(std::vector<double>& buf);
+    void populate_buffer(std::vector<amrex::Real>& buf);
 
     int num_sampling_particles() const { return m_total_particles; }
 

--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -214,11 +214,11 @@ void SamplingContainer::interpolate_fields(const amrex::Vector<Field*> fields)
     }
 }
 
-void SamplingContainer::populate_buffer(std::vector<double>& buf)
+void SamplingContainer::populate_buffer(std::vector<amrex::Real>& buf)
 {
     BL_PROFILE("amr-wind::SamplingContainer::populate_buffer");
 
-    amrex::Gpu::DeviceVector<double> dbuf(buf.size(), 0.0);
+    amrex::Gpu::DeviceVector<amrex::Real> dbuf(buf.size(), 0.0);
     auto* dbuf_ptr = dbuf.data();
     const int nlevels = m_mesh.finestLevel() + 1;
     for (int lev = 0; lev < nlevels; ++lev) {

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -247,7 +247,7 @@ void ABLBoundaryPlane::write_header()
     ncf.def_dim("pdim", 2);
     ncf.def_dim("vdim", 3);
     ncf.def_dim("nt", NC_UNLIMITED);
-    ncf.def_var("time", NC_DOUBLE, {"nt"});
+    ncf.def_var("time", ncutils::NCDType::Real, {"nt"});
 
     const int nlevels = m_repo.num_active_levels();
     for (amrex::OrientationIter oit; oit; ++oit) {
@@ -282,20 +282,21 @@ void ABLBoundaryPlane::write_header()
             lev_grp.def_dim("ny", minBox.length(1));
             lev_grp.def_dim("nz", minBox.length(2));
 
-            lev_grp.def_var("lengths", NC_DOUBLE, {"pdim"});
-            lev_grp.def_var("lo", NC_DOUBLE, {"pdim"});
-            lev_grp.def_var("hi", NC_DOUBLE, {"pdim"});
-            lev_grp.def_var("dx", NC_DOUBLE, {"pdim"});
+            lev_grp.def_var("lengths", ncutils::NCDType::Real, {"pdim"});
+            lev_grp.def_var("lo", ncutils::NCDType::Real, {"pdim"});
+            lev_grp.def_var("hi", ncutils::NCDType::Real, {"pdim"});
+            lev_grp.def_var("dx", ncutils::NCDType::Real, {"pdim"});
 
             const amrex::Vector<std::string> dirs{"nx", "ny", "nz"};
             for (auto* fld : m_fields) {
                 const std::string name = fld->name();
                 if (fld->num_comp() == 1) {
                     lev_grp.def_var(
-                        name, NC_DOUBLE, {"nt", dirs[perp[0]], dirs[perp[1]]});
+                        name, ncutils::NCDType::Real,
+                        {"nt", dirs[perp[0]], dirs[perp[1]]});
                 } else if (fld->num_comp() == AMREX_SPACEDIM) {
                     lev_grp.def_var(
-                        name, NC_DOUBLE,
+                        name, ncutils::NCDType::Real,
                         {"nt", dirs[perp[0]], dirs[perp[1]], "vdim"});
                 }
             }

--- a/amr-wind/wind_energy/ABLStats.H
+++ b/amr-wind/wind_energy/ABLStats.H
@@ -121,13 +121,13 @@ private:
     amrex::Real m_ref_theta{300.0};
 
     //! Variable to store capping inversion height
-    double m_zi{0.0};
+    amrex::Real m_zi{0.0};
 
     //! Wall-normal direction axis
     int m_normal_dir{2};
 
     //! Cell spacing at the coarsest level
-    double m_dn{0.0};
+    amrex::Real m_dn{0.0};
 
     //! Number of cells in the horizontal direction
     size_t m_ncells_h1{0};

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -212,7 +212,7 @@ void ABLStats::write_ascii()
         abl_forcing = m_abl_forcing->abl_forcing();
     }
 
-    double wstar = 0.0;
+    amrex::Real wstar = 0.0;
     auto Q = m_abl_wall_func.mo().surf_temp_flux;
     if (Q > 1e-10) wstar = std::cbrt(m_gravity * Q * m_zi / m_ref_theta);
     auto L = m_abl_wall_func.mo().obukhov_len;
@@ -285,40 +285,40 @@ void ABLStats::prepare_netcdf_file()
     ncf.def_dim(nt_name, NC_UNLIMITED);
     ncf.def_dim("ndim", AMREX_SPACEDIM);
 
-    ncf.def_var("time", NC_DOUBLE, {nt_name});
-    ncf.def_var("Q", NC_DOUBLE, {nt_name});
-    ncf.def_var("Tsurf", NC_DOUBLE, {nt_name});
-    ncf.def_var("ustar", NC_DOUBLE, {nt_name});
-    ncf.def_var("wstar", NC_DOUBLE, {nt_name});
-    ncf.def_var("L", NC_DOUBLE, {nt_name});
-    ncf.def_var("zi", NC_DOUBLE, {nt_name});
-    ncf.def_var("abl_forcing_x", NC_DOUBLE, {nt_name});
-    ncf.def_var("abl_forcing_y", NC_DOUBLE, {nt_name});
+    ncf.def_var("time", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("Q", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("Tsurf", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("ustar", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("wstar", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("L", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("zi", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("abl_forcing_x", ncutils::NCDType::Real, {nt_name});
+    ncf.def_var("abl_forcing_y", ncutils::NCDType::Real, {nt_name});
 
     auto grp = ncf.def_group("mean_profiles");
     size_t n_levels = m_pa_vel.ncell_line();
     const std::string nlevels_name = "nlevels";
     grp.def_dim("nlevels", n_levels);
     const std::vector<std::string> two_dim{nt_name, nlevels_name};
-    grp.def_var("h", NC_DOUBLE, {nlevels_name});
-    grp.def_var("u", NC_DOUBLE, two_dim);
-    grp.def_var("v", NC_DOUBLE, two_dim);
-    grp.def_var("w", NC_DOUBLE, two_dim);
-    grp.def_var("hvelmag", NC_DOUBLE, two_dim);
-    grp.def_var("theta", NC_DOUBLE, two_dim);
-    grp.def_var("mueff", NC_DOUBLE, two_dim);
-    grp.def_var("u'theta'_r", NC_DOUBLE, two_dim);
-    grp.def_var("v'theta'_r", NC_DOUBLE, two_dim);
-    grp.def_var("w'theta'_r", NC_DOUBLE, two_dim);
-    grp.def_var("u'u'_r", NC_DOUBLE, two_dim);
-    grp.def_var("u'v'_r", NC_DOUBLE, two_dim);
-    grp.def_var("u'w'_r", NC_DOUBLE, two_dim);
-    grp.def_var("v'v'_r", NC_DOUBLE, two_dim);
-    grp.def_var("v'w'_r", NC_DOUBLE, two_dim);
-    grp.def_var("w'w'_r", NC_DOUBLE, two_dim);
-    grp.def_var("u'u'u'_r", NC_DOUBLE, two_dim);
-    grp.def_var("v'v'v'_r", NC_DOUBLE, two_dim);
-    grp.def_var("w'w'w'_r", NC_DOUBLE, two_dim);
+    grp.def_var("h", ncutils::NCDType::Real, {nlevels_name});
+    grp.def_var("u", ncutils::NCDType::Real, two_dim);
+    grp.def_var("v", ncutils::NCDType::Real, two_dim);
+    grp.def_var("w", ncutils::NCDType::Real, two_dim);
+    grp.def_var("hvelmag", ncutils::NCDType::Real, two_dim);
+    grp.def_var("theta", ncutils::NCDType::Real, two_dim);
+    grp.def_var("mueff", ncutils::NCDType::Real, two_dim);
+    grp.def_var("u'theta'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("v'theta'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("w'theta'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("u'u'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("u'v'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("u'w'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("v'v'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("v'w'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("w'w'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("u'u'u'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("v'v'v'_r", ncutils::NCDType::Real, two_dim);
+    grp.def_var("w'w'w'_r", ncutils::NCDType::Real, two_dim);
 
     ncf.exit_def_mode();
 
@@ -350,14 +350,14 @@ void ABLStats::write_netcdf()
         ncf.var("time").put(&time, {nt}, {1});
         auto ustar = m_abl_wall_func.utau();
         ncf.var("ustar").put(&ustar, {nt}, {1});
-        double wstar = 0.0;
+        amrex::Real wstar = 0.0;
         auto Q = m_abl_wall_func.mo().surf_temp_flux;
         ncf.var("Q").put(&Q, {nt}, {1});
         auto Tsurf = m_abl_wall_func.mo().surf_temp;
         ncf.var("Tsurf").put(&Tsurf, {nt}, {1});
         if (Q > 1e-10) wstar = std::cbrt(m_gravity * Q * m_zi / m_ref_theta);
         ncf.var("wstar").put(&wstar, {nt}, {1});
-        double L = m_abl_wall_func.mo().obukhov_len;
+        amrex::Real L = m_abl_wall_func.mo().obukhov_len;
         ncf.var("L").put(&L, {nt}, {1});
         ncf.var("zi").put(&m_zi, {nt}, {1});
 

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -121,12 +121,13 @@ void ABLWallFunction::update_umean(
 {
     const auto& time = m_sim.time();
 
-    if (!m_tempflux)
+    if (!m_tempflux) {
+        const amrex::Real time_delta = amrex::max<amrex::Real>(
+            time.current_time() - m_surf_temp_rate_tstart, 0.0);
         m_mo.surf_temp =
-            m_surf_temp_init +
-            m_surf_temp_rate *
-                amrex::max(time.current_time() - m_surf_temp_rate_tstart, 0.0) /
-                3600.0;
+            m_surf_temp_init + m_surf_temp_rate * time_delta / 3600.0;
+    }
+
 #if 1
     {
         m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);

--- a/unit_tests/fvm/test_fvm_ops.cpp
+++ b/unit_tests/fvm/test_fvm_ops.cpp
@@ -34,11 +34,11 @@ void initialize_scalar(
     // it and it fills the ghosts with wall values
     amrex::ParallelFor(grow(bx, 1), [=] AMREX_GPU_DEVICE(int i, int j, int k) {
         const amrex::Real x = amrex::min(
-            amrex::max(problo[0] + (i + 0.5) * dx[0], problo[0]), probhi[0]);
+            amrex::max<amrex::Real>(problo[0] + (i + 0.5) * dx[0], problo[0]), probhi[0]);
         const amrex::Real y = amrex::min(
-            amrex::max(problo[1] + (j + 0.5) * dx[1], problo[1]), probhi[1]);
+            amrex::max<amrex::Real>(problo[1] + (j + 0.5) * dx[1], problo[1]), probhi[1]);
         const amrex::Real z = amrex::min(
-            amrex::max(problo[2] + (k + 0.5) * dx[2], problo[2]), probhi[2]);
+            amrex::max<amrex::Real>(problo[2] + (k + 0.5) * dx[2], problo[2]), probhi[2]);
 
         scalar_arr(i, j, k) =
             analytical_function::phi_eval(pdegree, c_ptr, x, y, z);
@@ -66,11 +66,11 @@ void initialize_velocity(
     // it and it fills the ghosts with wall values
     amrex::ParallelFor(grow(bx, 1), [=] AMREX_GPU_DEVICE(int i, int j, int k) {
         const amrex::Real x = amrex::min(
-            amrex::max(problo[0] + (i + 0.5) * dx[0], problo[0]), probhi[0]);
+            amrex::max<amrex::Real>(problo[0] + (i + 0.5) * dx[0], problo[0]), probhi[0]);
         const amrex::Real y = amrex::min(
-            amrex::max(problo[1] + (j + 0.5) * dx[1], problo[1]), probhi[1]);
+            amrex::max<amrex::Real>(problo[1] + (j + 0.5) * dx[1], problo[1]), probhi[1]);
         const amrex::Real z = amrex::min(
-            amrex::max(problo[2] + (k + 0.5) * dx[2], problo[2]), probhi[2]);
+            amrex::max<amrex::Real>(problo[2] + (k + 0.5) * dx[2], problo[2]), probhi[2]);
 
         vel_arr(i, j, k, 0) =
             analytical_function::phi_eval(pdegree, cu_ptr, x, y, z);


### PR DESCRIPTION
- [x] Fix errors from `amrex::min` and `amrex::max` template instantiations
- [x] Wait for amrex-codes/amrex#1577 
- [x] Fix `amrex::ReduceRealSum` in `SamplingContainer.cpp` (wait for #263)
- [x] Update NetCDF interface to handle float/double I/O
- [x] Fix inconsistent usage of `double`/`amrex::Real` in `ABLStats.cpp`
- [ ] Streamline `tol`/`eps` usage in code and unit tests