### PR TITLE
Fix CDash failures (Dec 6 2020)

### DIFF
--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -126,6 +126,13 @@ public:
     //! Register a new PDE instance and return its reference
     PDEBase& register_transport_pde(const std::string& pde_name);
 
+    //! Advance states for all registered PDEs at the beginning of a timestep
+    void advance_states();
+
+    //! Call fillpatch operator on state variables for all registered PDEs
+    void fillpatch_state_fields(
+        const amrex::Real time, const FieldState fstate = FieldState::New);
+
     /** Return the vector containing all registered PDE instances
      *
      *  Note that this does not contain the ICNS system as it is treated
@@ -154,6 +161,9 @@ private:
 
     //! Flag indicating whether Godunov scheme is active
     bool m_use_godunov{false};
+
+    //! Flag indicating whether density is constant for this simulation
+    bool m_constant_density{true};
 };
 
 } // namespace pde

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -95,7 +95,6 @@ public:
     bool regrid_and_update();
     void pre_advance_stage1();
     void pre_advance_stage2();
-    void advance_states();
     void advance();
     void post_advance_work();
 

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -98,6 +98,7 @@ void incflo::init_amr_wind_modules()
     icns().initialize();
     for (auto& eqn : scalar_eqns()) eqn->initialize();
 
+    m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
     m_sim.post_manager().initialize();
 }
 
@@ -170,6 +171,8 @@ bool incflo::regrid_and_update()
             mask_cell.setVal(1);
             mask_node.setVal(1);
         }
+
+        m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
 
         icns().post_regrid_actions();
         for (auto& eqn : scalar_eqns()) eqn->post_regrid_actions();

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -26,25 +26,6 @@ void incflo::pre_advance_stage2()
     for (auto& pp : m_sim.physics()) pp->pre_advance_work();
 }
 
-void incflo::advance_states()
-{
-    if (m_constant_density) {
-        density().advance_states();
-        density()
-            .state(amr_wind::FieldState::Old)
-            .fillpatch(m_time.current_time());
-    }
-
-    auto& vel = icns().fields().field;
-    vel.advance_states();
-    vel.state(amr_wind::FieldState::Old).fillpatch(m_time.current_time());
-    for (auto& eqn : scalar_eqns()) {
-        auto& field = eqn->fields().field;
-        field.advance_states();
-        field.state(amr_wind::FieldState::Old).fillpatch(m_time.current_time());
-    }
-}
-
 /** Advance simulation state by one timestep
  *
  *  Performs the following actions at a given timestep
@@ -65,7 +46,8 @@ void incflo::advance_states()
 void incflo::advance()
 {
     BL_PROFILE("amr-wind::incflo::Advance");
-    advance_states();
+
+    m_sim.pde_manager().advance_states();
 
     ApplyPredictor();
 

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -23,7 +23,7 @@ public:
 
     virtual ~MultiPhase() = default;
 
-    void initialize_fields(int level, const amrex::Geometry& geom) override;
+    void initialize_fields(int, const amrex::Geometry&) override {}
 
     void post_init_actions() override;
 

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -22,11 +22,6 @@ MultiPhase::MultiPhase(CFDSim& sim)
     pp_multiphase.query("viscosity_fluid2", m_mu2);
 }
 
-void MultiPhase::initialize_fields(int level, const amrex::Geometry& geom)
-{
-    set_multiphase_properties(level, geom);
-}
-
 void MultiPhase::post_init_actions()
 {
     const int nlevels = m_sim.repo().num_active_levels();
@@ -35,6 +30,7 @@ void MultiPhase::post_init_actions()
     for (int lev = 0; lev < nlevels; ++lev) {
         set_multiphase_properties(lev, geom[lev]);
     }
+    m_density.fillpatch(m_sim.time().current_time());
 }
 
 void MultiPhase::post_advance_work()
@@ -45,6 +41,7 @@ void MultiPhase::post_advance_work()
     for (int lev = 0; lev < nlevels; ++lev) {
         set_multiphase_properties(lev, geom[lev]);
     }
+    m_density.fillpatch(m_sim.time().new_time());
 }
 
 void MultiPhase::set_multiphase_properties(

--- a/amr-wind/physics/multiphase/VortexPatch.cpp
+++ b/amr-wind/physics/multiphase/VortexPatch.cpp
@@ -95,6 +95,8 @@ void VortexPatch::post_advance_work()
                 });
         }
     }
+
+    m_velocity.fillpatch(time);
 }
 
 } // namespace amr_wind

--- a/amr-wind/physics/multiphase/ZalesakDisk.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDisk.cpp
@@ -101,6 +101,8 @@ void ZalesakDisk::post_advance_work()
                 });
         }
     }
+
+    m_velocity.fillpatch(m_sim.time().current_time());
 }
 
 } // namespace amr_wind


### PR DESCRIPTION
PR #265 introduced a regression in the prescribed ABL boundary inflow regression test ([CDash](https://my.cdash.org/test/17414036)). This was because the order of physics `pre_advance_work` and `advance_states` got swapped. 

This PR fixes the CDash failures as well as removes unnecessary fillpatch call in advance states

- Consolidate `advance_states` and `fillpatch` calls in PDE Manager interface 
- Remove obsolete code from `incflo` interface
- Update Multiphase to ensure that `fillpatch` is called on density after it is modified outside of the time-integration logic