### PR TITLE
Update links previously for RTD to point to documentation on GitHub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test/Backtrace.*
 test/*plt*/
 test/chk*/
 test/AMR-WindGoldFiles
+.DS_store

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AMR-Wind 
 
-[Website](https://www.exawind.org/) | [User manual](https://amr-wind.readthedocs.io) | [API docs](https://exawind.github.io/amr-wind/index.html) | [Nightly test dashboard](http://my.cdash.org/index.php?project=AMR-Wind) 
+[Website](https://www.exawind.org/) | [User manual](https://exawind.github.io/amr-wind) | [API docs](https://exawind.github.io/amr-wind/api_docs) | [Nightly test dashboard](http://my.cdash.org/index.php?project=AMR-Wind) 
 
-[![Powered by AMReX](https://amrex-codes.github.io/badges/powered%20by-AMReX-red.svg)](https://amrex-codes.github.io/amrex/) [![Build Status](https://github.com/Exawind/amr-wind/workflows/AMR-Wind-CI/badge.svg)](https://github.com/Exawind/amr-wind/actions) [![Docs Status](https://readthedocs.org/projects/pip/badge/?version=latest)](https://amr-wind.readthedocs.io)
+[![Powered by AMReX](https://amrex-codes.github.io/badges/powered%20by-AMReX-red.svg)](https://amrex-codes.github.io/amrex/) [![Build Status](https://github.com/Exawind/amr-wind/workflows/AMR-Wind-CI/badge.svg)](https://github.com/Exawind/amr-wind/actions)
 
 
 AMR-Wind is a massively parallel, block-structured adaptive-mesh, incompressible
@@ -40,9 +40,9 @@ objectives:
 
 ## Documentation
 
-Documentation is organized into a [user manual](https://amr-wind.readthedocs.io)
+Documentation is organized into a [user manual](https://exawind.github.io/amr-wind)
 and a developer-focused [API
-documentation](https://exawind.github.io/amr-wind/index.html). You can either
+documentation](https://exawind.github.io/amr-wind). You can either
 browse the docs online by following the links, or you can generate them locally
 after downloading the code. Please follow the instructions in user manual to
 build documentation locally.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,3 @@
 doxygen_output/*
-sphinx_doc/_build/*
+sphinx/_build/*
 /doxy.log

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -162,7 +162,8 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/sphinx/developer/documentation.rst
+++ b/docs/sphinx/developer/documentation.rst
@@ -19,7 +19,7 @@ ReStructured Text (ReST) and is converted into HTML and PDF formats using a
 python package Sphinx. Since the manuals are written in simple text files, they
 can be version controlled alongside the source code. Documentation is
 automatically generated with new updates to the GitHub repository and deployed
-at `ReadTheDocs site <https://amr-wind.readthedocs.io>`_.
+at `AMR-Wind documentation site <https://exawind.github.io/amr-wind>`_.
 
 Building documentation
 ``````````````````````
@@ -68,7 +68,7 @@ Source code (C++ files) are commented using a special format that allows Doxygen
 to extract the annotated comments and create source code documentation as well
 as inheritance diagrams. API documentation for the latest snapshot of the
 codebase can be browsed online `here
-<https://exawind.github.io/amr-wind/index.html>`_. To build the documentation
+<https://exawind.github.io/amr-wind/api_docs>`_. To build the documentation
 locally, first install ``doxygen`` and ``graphviz`` executables on your system.
 Once they are successfully installed, execute the following command from the
 root directory of ``amr-wind``

--- a/docs/sphinx/user/build.rst
+++ b/docs/sphinx/user/build.rst
@@ -1,3 +1,5 @@
+.. _build:
+
 Compiling AMR-Wind
 ==================
 
@@ -34,7 +36,7 @@ Building from source
 #. If you are on an HPC system that provides Modules Environment, load the
    necessary compiler, MPI, and CMake modules. If targeting GPUs, load CUDA
    modules. You can also use scripts from `exawind-builder
-   <https://exawind-builder.readthedocs.io>`_.
+   <https://exawind.github.io/exawind-builder>`_.
 
 #. Clone a local copy of the git repository
 


### PR DESCRIPTION
These are all I could find. Let me know if you think of any I missed. It's not obvious to me how to convert the RTD badge to GitHub pages so I just removed it. I also fixed some warnings during the sphinx generation.