### PR TITLE
Formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,18 @@ jobs:
             build_type: Debug
 
     steps:
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{github.token}}
     - uses: actions/checkout@v2
       with: 
         submodules: true
-    - name: dependencies
+    - name: Dependencies
       run: ${{matrix.install_deps}}
-    - name: setup
+    - name: Setup
       run: cmake -E make_directory ${{runner.workspace}}/build-ci-${{matrix.build_type}}
-    - name: configure
+    - name: Configure
       working-directory: ${{runner.workspace}}/build-ci-${{matrix.build_type}}
       run: |
         cmake \
@@ -71,9 +75,9 @@ jobs:
           -DAMR_WIND_ENABLE_TESTS:BOOL=ON \
           -DAMR_WIND_TEST_WITH_FCOMPARE:BOOL=OFF \
           ${GITHUB_WORKSPACE}
-    - name: make
+    - name: Make
       working-directory: ${{runner.workspace}}/build-ci-${{matrix.build_type}}
       run: cmake --build . -- -j ${{env.NUM_PROCS}}
-    - name: test
+    - name: Test
       working-directory: ${{runner.workspace}}/build-ci-${{matrix.build_type}}
       run: ctest -j ${{env.NUM_PROCS}} ${{matrix.ctest_args}} --output-on-failure

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
+
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -45,6 +45,10 @@ jobs:
             cuda_pkg: 10-0
             cuda_extra: cuda-curand-dev-10-0 cuda-cupti-10-0
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ jobs:
   Docs:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
       - uses: actions/checkout@v2
       - name: Python
         uses: actions/setup-python@v2

--- a/.github/workflows/dpcpp-ci.yml
+++ b/.github/workflows/dpcpp-ci.yml
@@ -41,6 +41,10 @@ jobs:
             cppexe: dpcpp
             enable_dpcpp: ON
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,19 @@
+name: AMR-Wind Formatting
+
+on:
+  push:
+    branches: [development]
+  pull_request:
+    branches: [development]
+
+jobs:
+  Formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.11
+      with:
+        source: './amr-wind ./unit_tests'
+        exclude: '.'
+        extensions: 'H,h,cpp'
+        clangFormatVersion: 11

--- a/.github/workflows/hip-ci.yml
+++ b/.github/workflows/hip-ci.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     name: HIP/ROCm
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
       - uses: actions/checkout@v2
         with:
           submodules: true

--- a/amr-wind/boundary_conditions/velocity_bcs.H
+++ b/amr-wind/boundary_conditions/velocity_bcs.H
@@ -40,8 +40,7 @@ void register_velocity_dirichlet(
     const std::string inflow_udf = udfs.first;
     const std::string wall_udf = udfs.second;
 
-    if ((inflow_udf == "ConstDirichlet") &&
-        (wall_udf == "ConstDirichlet"))
+    if ((inflow_udf == "ConstDirichlet") && (wall_udf == "ConstDirichlet"))
         return;
 
     if (wall_udf != "ConstDirichlet") {

--- a/amr-wind/convection/incflo_godunov_advection.cpp
+++ b/amr-wind/convection/incflo_godunov_advection.cpp
@@ -191,7 +191,7 @@ void godunov::compute_advection(
             bool vval = vad >= 0.;
             // divu = 0
             // Real cons1 = (iconserv[n]) ? -0.5*l_dt*q(i,j-1,k,n)*divu(i,j-1,k)
-            // : 0.; Real cons2 = (iconserv[n]) ? -0.5*l_dt*q(i,j  ,k,n)*divu(i,j
+            // : 0.; Real cons2 = (iconserv[n]) ? -0.5*l_dt*q(i,j ,k,n)*divu(i,j
             // ,k) : 0.;
             Real lo = Ipy(i, j - 1, k, n); // + cons1;
             Real hi = Imy(i, j, k, n);     // + cons2;

--- a/amr-wind/core/FieldBCOps.H
+++ b/amr-wind/core/FieldBCOps.H
@@ -47,8 +47,7 @@ struct FieldBCNoOp
     constexpr FieldBCNoOp() {}
 
     AMREX_GPU_HOST
-    constexpr FieldBCNoOp(const Field&)
-    {}
+    constexpr FieldBCNoOp(const Field&) {}
 
     FunctorType operator()() const { return *this; }
 
@@ -75,8 +74,7 @@ struct ConstDirichlet
 
     AMREX_GPU_HOST
     ConstDirichlet(const Field& fld)
-        : m_ncomp(fld.num_comp())
-        , m_bcv(fld.bc_values_device())
+        : m_ncomp(fld.num_comp()), m_bcv(fld.bc_values_device())
     {}
 
     AMREX_GPU_HOST
@@ -211,8 +209,7 @@ struct FieldBCDirichlet
 
     FieldBCDirichlet(const Field& fld) : m_field(fld) {}
 
-    inline FunctorType operator()() const
-    { return FunctorType(m_field); }
+    inline FunctorType operator()() const { return FunctorType(m_field); }
 
     const Field& m_field;
 };
@@ -228,14 +225,16 @@ struct BCOpCreator
         : m_field(fld), m_inflow_op(fld), m_wall_op(fld)
     {}
 
-    explicit BCOpCreator(const Field& fld, const InflowOp& inflow_op, const WallOp& wall_op)
+    explicit BCOpCreator(
+        const Field& fld, const InflowOp& inflow_op, const WallOp& wall_op)
         : m_field(fld), m_inflow_op(inflow_op), m_wall_op(wall_op)
     {}
 
     inline FunctorType operator()() const
     {
-        return FunctorType{m_field, m_inflow_op.device_instance(),
-                           m_wall_op.device_instance()};
+        return FunctorType{
+            m_field, m_inflow_op.device_instance(),
+            m_wall_op.device_instance()};
     }
 
     const Field& m_field;

--- a/amr-wind/core/FieldFillPatchOps.H
+++ b/amr-wind/core/FieldFillPatchOps.H
@@ -282,8 +282,7 @@ public:
     }
 
 protected:
-    Functor bc_functor()
-    { return m_op(); }
+    Functor bc_functor() { return m_op(); }
 
     const SimTime& m_time;
     const amrex::AmrCore& m_mesh;

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -335,8 +335,8 @@ public:
     }
 
     //! Return factory instance at a given level
-    inline const amrex::FabFactory<amrex::FArrayBox>& factory(int lev) const
-        noexcept
+    inline const amrex::FabFactory<amrex::FArrayBox>&
+    factory(int lev) const noexcept
     {
         return *m_leveldata[lev]->m_factory;
     }

--- a/amr-wind/core/vs/tensorI.H
+++ b/amr-wind/core/vs/tensorI.H
@@ -9,8 +9,7 @@ namespace amr_wind {
 namespace vs {
 
 template <typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-TensorT<T>::TensorT(
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE TensorT<T>::TensorT(
     const VectorT<T>& x,
     const VectorT<T>& y,
     const VectorT<T>& z,
@@ -121,9 +120,9 @@ operator&(const TensorT<T>& t1, const TensorT<T>& t2)
     return t3;
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-TensorT<T> operator+(const TensorT<T>& t1, const TensorT<T>& t2)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE TensorT<T>
+operator+(const TensorT<T>& t1, const TensorT<T>& t2)
 {
     return TensorT<T>{
         t1.vv[0] + t2.vv[0], t1.vv[1] + t2.vv[1], t1.vv[2] + t2.vv[2],
@@ -131,9 +130,9 @@ TensorT<T> operator+(const TensorT<T>& t1, const TensorT<T>& t2)
         t1.vv[6] + t2.vv[6], t1.vv[7] + t2.vv[7], t1.vv[8] + t2.vv[8]};
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-TensorT<T> operator-(const TensorT<T>& t1, const TensorT<T>& t2)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE TensorT<T>
+operator-(const TensorT<T>& t1, const TensorT<T>& t2)
 {
     return TensorT<T>{
         t1.vv[0] - t2.vv[0], t1.vv[1] - t2.vv[1], t1.vv[2] - t2.vv[2],
@@ -141,9 +140,9 @@ TensorT<T> operator-(const TensorT<T>& t1, const TensorT<T>& t2)
         t1.vv[6] - t2.vv[6], t1.vv[7] - t2.vv[7], t1.vv[8] - t2.vv[8]};
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-T operator&&(const TensorT<T>& t1, const TensorT<T>& t2)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T
+operator&&(const TensorT<T>& t1, const TensorT<T>& t2)
 {
     return (
         t1.vv[0] * t2.vv[0] + t1.vv[1] * t2.vv[1] + t1.vv[2] * t2.vv[2] +
@@ -151,16 +150,14 @@ T operator&&(const TensorT<T>& t1, const TensorT<T>& t2)
         t1.vv[6] * t2.vv[6] + t1.vv[7] * t2.vv[7] + t1.vv[8] * t2.vv[8]);
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-T mag_sqr(const TensorT<T>& t)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T mag_sqr(const TensorT<T>& t)
 {
     return (t && t);
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-T mag(const TensorT<T>& t)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T mag(const TensorT<T>& t)
 {
     return std::sqrt(mag_sqr(t));
 }

--- a/amr-wind/core/vs/vector.H
+++ b/amr-wind/core/vs/vector.H
@@ -25,86 +25,104 @@ struct VectorT
     using VType = VectorT<T>;
 
     //! Construct a default vector, all components set to zero
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT() : vv{Traits::zero(), Traits::zero(), Traits::zero()} {}
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT()
+        : vv{Traits::zero(), Traits::zero(), Traits::zero()}
+    {}
 
     /** New vector given the three components
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT(const T& x, const T& y, const T& z) : vv{x, y, z} {}
+    VectorT(const T& x, const T& y, const T& z)
+        : vv{x, y, z}
+    {}
 
     //! Zero vector
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr VectorT<T> zero()
-    { return VectorT<T>{Traits::zero(), Traits::zero(), Traits::zero()}; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T> zero()
+    {
+        return VectorT<T>{Traits::zero(), Traits::zero(), Traits::zero()};
+    }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr VectorT<T> one()
-    { return VectorT<T>{Traits::one(), Traits::one(), Traits::one()}; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T> one()
+    {
+        return VectorT<T>{Traits::one(), Traits::one(), Traits::one()};
+    }
 
     /** Vector along x-axis
      *
      *  \param x Magnitude of vector
      */
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr VectorT<T> ihat(const T& x = Traits::one())
-    { return VectorT<T>{x, Traits::zero(), Traits::zero()}; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T>
+    ihat(const T& x = Traits::one())
+    {
+        return VectorT<T>{x, Traits::zero(), Traits::zero()};
+    }
 
     /** Vector along y-axis
      *
      *  \param y Magnitude of vector
      */
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr VectorT<T> jhat(const T& y = Traits::one())
-    { return VectorT<T>{Traits::zero(), y, Traits::zero()}; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T>
+    jhat(const T& y = Traits::one())
+    {
+        return VectorT<T>{Traits::zero(), y, Traits::zero()};
+    }
 
     /** Vector along z-axis
      *
      *  \param z Magnitude of vector
      */
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr VectorT<T> khat(const T& z = Traits::one())
-    { return VectorT<T>{Traits::zero(), Traits::zero(), z}; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T>
+    khat(const T& z = Traits::one())
+    {
+        return VectorT<T>{Traits::zero(), Traits::zero(), z};
+    }
 
     //! Normalize the vector to unit vector
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT<T>& normalize();
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>& normalize();
 
     //! Return the unit vector parallel to this vector
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT<T> unit() const { return VectorT<T>(*this).normalize(); }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> unit() const
+    {
+        return VectorT<T>(*this).normalize();
+    }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& x() noexcept { return vv[0]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& y() noexcept { return vv[1]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& z() noexcept { return vv[2]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const T& x() const noexcept { return vv[0]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const T& y() const noexcept { return vv[1]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const T& z() const noexcept { return vv[2]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& x() noexcept { return vv[0]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& y() noexcept { return vv[1]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& z() noexcept { return vv[2]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& x() const noexcept
+    {
+        return vv[0];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& y() const noexcept
+    {
+        return vv[1];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& z() const noexcept
+    {
+        return vv[2];
+    }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT<T> operator-() const;
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator-() const;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT<T> operator*=(const T val);
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator*=(const T val);
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    VectorT<T> operator/=(const T val);
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator/=(const T val);
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T& operator[](size_type pos) { return vv[pos]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const T& operator[](size_type pos) const { return vv[pos]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos)
+    {
+        return vv[pos];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T&
+    operator[](size_type pos) const
+    {
+        return vv[pos];
+    }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T* data() noexcept { return vv; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const T* data() const noexcept { return vv; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T* data() noexcept { return vv; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T* data() const noexcept
+    {
+        return vv;
+    }
 
     iterator begin() noexcept { return vv; }
     iterator end() noexcept { return vv + ncomp; }

--- a/amr-wind/core/vs/vectorI.H
+++ b/amr-wind/core/vs/vectorI.H
@@ -8,16 +8,16 @@
 namespace amr_wind {
 namespace vs {
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-VectorT<T> VectorT<T>::operator-() const
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>
+VectorT<T>::operator-() const
 {
     return VectorT<T>{-vv[0], -vv[1], -vv[2]};
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-VectorT<T> VectorT<T>::operator*=(const T fac)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>
+VectorT<T>::operator*=(const T fac)
 {
     vv[0] *= fac;
     vv[1] *= fac;
@@ -25,9 +25,9 @@ VectorT<T> VectorT<T>::operator*=(const T fac)
     return *this;
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-VectorT<T> VectorT<T>::operator/=(const T fac)
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>
+VectorT<T>::operator/=(const T fac)
 {
     vv[0] /= fac;
     vv[1] /= fac;
@@ -36,8 +36,7 @@ VectorT<T> VectorT<T>::operator/=(const T fac)
 }
 
 template <typename T, typename OStream>
-OStream&
-operator<<(OStream& out, const VectorT<T>& vec)
+OStream& operator<<(OStream& out, const VectorT<T>& vec)
 {
     out << "(" << vec.x() << " " << vec.y() << " " << vec.z() << ")";
     return out;
@@ -89,9 +88,10 @@ template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>
 operator^(const VectorT<T>& v1, const VectorT<T>& v2)
 {
-    return VectorT<T>{(v1.y() * v2.z() - v1.z() * v2.y()),
-                      (v1.z() * v2.x() - v1.x() * v2.z()),
-                      (v1.x() * v2.y() - v1.y() * v2.x())};
+    return VectorT<T>{
+        (v1.y() * v2.z() - v1.z() * v2.y()),
+        (v1.z() * v2.x() - v1.x() * v2.z()),
+        (v1.x() * v2.y() - v1.y() * v2.x())};
 }
 
 template <typename T>

--- a/amr-wind/core/vs/vstraits.H
+++ b/amr-wind/core/vs/vstraits.H
@@ -16,8 +16,14 @@ struct DTraits<int>
 {
     static constexpr int zero() noexcept { return 0; }
     static constexpr int one() noexcept { return 1; }
-    static constexpr int max() noexcept { return std::numeric_limits<int>::max(); }
-    static constexpr int min() noexcept { return std::numeric_limits<int>::min(); }
+    static constexpr int max() noexcept
+    {
+        return std::numeric_limits<int>::max();
+    }
+    static constexpr int min() noexcept
+    {
+        return std::numeric_limits<int>::min();
+    }
 };
 
 template <>
@@ -25,8 +31,14 @@ struct DTraits<double>
 {
     static constexpr double zero() noexcept { return 0.0; }
     static constexpr double one() noexcept { return 1.0; }
-    static constexpr double max() noexcept { return std::numeric_limits<double>::max(); }
-    static constexpr double min() noexcept { return std::numeric_limits<double>::min(); }
+    static constexpr double max() noexcept
+    {
+        return std::numeric_limits<double>::max();
+    }
+    static constexpr double min() noexcept
+    {
+        return std::numeric_limits<double>::min();
+    }
     static constexpr double eps() noexcept { return 1.0e-15; }
 };
 
@@ -35,8 +47,14 @@ struct DTraits<float>
 {
     static constexpr float zero() noexcept { return 0.0; }
     static constexpr float one() noexcept { return 1.0; }
-    static constexpr float max() noexcept { return std::numeric_limits<float>::max(); }
-    static constexpr float min() noexcept { return std::numeric_limits<float>::min(); }
+    static constexpr float max() noexcept
+    {
+        return std::numeric_limits<float>::max();
+    }
+    static constexpr float min() noexcept
+    {
+        return std::numeric_limits<float>::min();
+    }
     static constexpr float eps() noexcept { return 1.0e-7; }
 };
 

--- a/amr-wind/equation_systems/AdvOp_Godunov.H
+++ b/amr-wind/equation_systems/AdvOp_Godunov.H
@@ -34,27 +34,29 @@ struct AdvectionOp<
         pp.query("godunov_type", godunov_type);
 
         if (pp.contains("use_ppm") || pp.contains("use_limiter"))
-            amrex::Abort("Godunov: use_ppm and use_limiter are deprecated. Please update input file");
+            amrex::Abort(
+                "Godunov: use_ppm and use_limiter are deprecated. Please "
+                "update input file");
 
-        if(amrex::toLower(godunov_type)=="plm"){
+        if (amrex::toLower(godunov_type) == "plm") {
             godunov_scheme = godunov::scheme::PLM;
-        }else if (amrex::toLower(godunov_type)=="ppm"){
+        } else if (amrex::toLower(godunov_type) == "ppm") {
             godunov_scheme = godunov::scheme::PPM;
-        }else if (amrex::toLower(godunov_type)=="ppm_nolim"){
+        } else if (amrex::toLower(godunov_type) == "ppm_nolim") {
             godunov_scheme = godunov::scheme::PPM_NOLIM;
-        }else if (amrex::toLower(godunov_type)=="weno"){
+        } else if (amrex::toLower(godunov_type) == "weno") {
             godunov_scheme = godunov::scheme::WENO;
-        }else{
-            amrex::Print()<<"For godunov_type select between plm, ppm, ppm_nolim and weno: it defaults to ppm"<<std::endl;
+        } else {
+            amrex::Print() << "For godunov_type select between plm, ppm, "
+                              "ppm_nolim and weno: it defaults to ppm"
+                           << std::endl;
             godunov_scheme = godunov::scheme::PPM;
         }
         // TODO: Need iconserv flag to be adjusted???
         iconserv.resize(PDE::ndim, 1);
     }
 
-    void operator()(
-        const FieldState fstate,
-        const amrex::Real dt)
+    void operator()(const FieldState fstate, const amrex::Real dt)
     {
         static_assert(
             PDE::ndim == 1, "Invalid number of components for scalar");
@@ -101,19 +103,13 @@ struct AdvectionOp<
 
                 amrex::FArrayBox tmpfab(amrex::grow(bx, 1), PDE::ndim * 14);
 
-                godunov::compute_advection(lev, bx, PDE::ndim,
-                                           conv_term(lev).array(mfi),
-                                           (PDE::multiply_rho ? rhotrac : tra_arr),
-                                           u_mac(lev).const_array(mfi),
-                                           v_mac(lev).const_array(mfi),
-                                           w_mac(lev).const_array(mfi),
-                                           src_term(lev).const_array(mfi),
-                                           dof_field.bcrec_device().data(),
-                                           iconserv.data(),
-                                           tmpfab.dataPtr(),
-                                           geom,
-                                           dt,
-                                           godunov_scheme);
+                godunov::compute_advection(
+                    lev, bx, PDE::ndim, conv_term(lev).array(mfi),
+                    (PDE::multiply_rho ? rhotrac : tra_arr),
+                    u_mac(lev).const_array(mfi), v_mac(lev).const_array(mfi),
+                    w_mac(lev).const_array(mfi), src_term(lev).const_array(mfi),
+                    dof_field.bcrec_device().data(), iconserv.data(),
+                    tmpfab.dataPtr(), geom, dt, godunov_scheme);
 
                 amrex::Gpu::streamSynchronize();
             }
@@ -127,7 +123,7 @@ struct AdvectionOp<
     Field& w_mac;
     amrex::Gpu::DeviceVector<int> iconserv;
 
-    godunov::scheme godunov_scheme=godunov::scheme::PPM;
+    godunov::scheme godunov_scheme = godunov::scheme::PPM;
     std::string godunov_type;
 };
 

--- a/amr-wind/equation_systems/AdvOp_MOL.H
+++ b/amr-wind/equation_systems/AdvOp_MOL.H
@@ -31,9 +31,7 @@ struct AdvectionOp<
         , w_mac(fields_in.repo.get_field("w_mac"))
     {}
 
-    void operator()(
-        const FieldState fstate,
-        const amrex::Real)
+    void operator()(const FieldState fstate, const amrex::Real)
     {
         static_assert(
             PDE::ndim == 1, "Invalid number of components for scalar");

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -65,7 +65,8 @@ public:
                 new TurbulenceOp<PDE>(m_sim.turbulence_model(), m_fields));
         }
 
-        m_adv_op.reset(new AdvectionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
+        m_adv_op.reset(
+            new AdvectionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
         m_src_op.init_source_terms(m_sim);
     }
 
@@ -78,7 +79,8 @@ public:
             m_diff_op.reset(
                 new DiffusionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
         }
-        m_adv_op.reset(new AdvectionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
+        m_adv_op.reset(
+            new AdvectionOp<PDE, Scheme>(m_fields, m_sim.has_overset()));
     }
 
     //! Return the object holding the fields necessary for solving this PDE

--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -64,22 +64,22 @@ int PDEMgr::num_ghost_state() const
 
 void PDEMgr::advance_states()
 {
-    if (m_constant_density)
-        m_sim.repo().get_field("density").advance_states();
+    if (m_constant_density) m_sim.repo().get_field("density").advance_states();
 
     icns().fields().field.advance_states();
-    for (auto& eqn: scalar_eqns()) {
+    for (auto& eqn : scalar_eqns()) {
         eqn->fields().field.advance_states();
     }
 }
 
-void PDEMgr::fillpatch_state_fields(const amrex::Real time, const FieldState fstate)
+void PDEMgr::fillpatch_state_fields(
+    const amrex::Real time, const FieldState fstate)
 {
     if (m_constant_density)
         m_sim.repo().get_field("density").state(fstate).fillpatch(time);
 
     icns().fields().field.state(fstate).fillpatch(time);
-    for (auto& eqn: scalar_eqns()) {
+    for (auto& eqn : scalar_eqns()) {
         eqn->fields().field.state(fstate).fillpatch(time);
     }
 }

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -13,7 +13,8 @@ namespace pde {
 class MacProjOp
 {
 public:
-    using FaceFabPtrVec = amrex::Vector<amrex::Array<const amrex::MultiFab*, ICNS::ndim>>;
+    using FaceFabPtrVec =
+        amrex::Vector<amrex::Array<const amrex::MultiFab*, ICNS::ndim>>;
 
     MacProjOp(FieldRepo&, bool);
 
@@ -46,7 +47,9 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         amrex::ParmParse pp("incflo");
         pp.query("godunov_type", godunov_type);
         if (pp.contains("use_ppm") || pp.contains("use_limiter"))
-            amrex::Abort("Godunov: use_ppm and use_limiter are deprecated. Please update input file");
+            amrex::Abort(
+                "Godunov: use_ppm and use_limiter are deprecated. Please "
+                "update input file");
 
         if (amrex::toLower(godunov_type) == "plm") {
             godunov_scheme = godunov::scheme::PLM;
@@ -67,8 +70,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         iconserv.resize(ICNS::ndim, 0);
     }
 
-    void operator()(
-        const FieldState fstate, const amrex::Real dt)
+    void operator()(const FieldState fstate, const amrex::Real dt)
     {
         auto& repo = fields.repo;
         auto& geom = repo.mesh().Geom();
@@ -271,8 +273,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
         , m_macproj_op(fields.repo, has_overset)
     {}
 
-    void operator()(
-        const FieldState fstate, const amrex::Real dt)
+    void operator()(const FieldState fstate, const amrex::Real dt)
     {
 
         auto& repo = fields.repo;
@@ -360,7 +361,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
     MacProjOp m_macproj_op;
 };
 
-}
-}
+} // namespace pde
+} // namespace amr_wind
 
 #endif /* ICNS_ADVECTION_H */

--- a/amr-wind/equation_systems/icns/icns_advection.cpp
+++ b/amr-wind/equation_systems/icns/icns_advection.cpp
@@ -40,9 +40,7 @@ amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM> get_projection_bc(
 } // namespace
 
 MacProjOp::MacProjOp(FieldRepo& repo, bool has_overset)
-    : m_repo(repo)
-    , m_options("mac_proj")
-    , m_has_overset(has_overset)
+    : m_repo(repo), m_options("mac_proj"), m_has_overset(has_overset)
 {}
 
 void MacProjOp::init_projector(const MacProjOp::FaceFabPtrVec& beta) noexcept
@@ -148,7 +146,8 @@ void MacProjOp::operator()(const FieldState fstate, const amrex::Real dt)
             amrex::average_node_to_cellcenter(
                 (*phif)(lev), 0, pressure(lev), 0, 1);
 
-        m_mac_proj->project(phif->vec_ptrs(), m_options.rel_tol, m_options.abs_tol);
+        m_mac_proj->project(
+            phif->vec_ptrs(), m_options.rel_tol, m_options.abs_tol);
 
     } else {
         m_mac_proj->project(m_options.rel_tol, m_options.abs_tol);

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -39,8 +39,9 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.getarr("geostrophic_wind", m_target_vel);
     }
 
-    m_g_forcing = {-coriolis_factor * m_target_vel[1],
-                   coriolis_factor * m_target_vel[0], 0.0};
+    m_g_forcing = {
+        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0],
+        0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/amr-wind/fvm/qcriterion.H
+++ b/amr-wind/fvm/qcriterion.H
@@ -74,11 +74,14 @@ struct Qcriterion
                       cm1 * phi(i, j, k - 1, 2)) *
                      idx[2];
 
-                const amrex::Real S2 = 2.0 * std::pow(ux, 2) + 2.0 * std::pow(vy, 2) +
+                const amrex::Real S2 =
+                    2.0 * std::pow(ux, 2) + 2.0 * std::pow(vy, 2) +
                     2.0 * std::pow(wz, 2) + std::pow(uy + vx, 2) +
                     std::pow(vz + wy, 2) + std::pow(wx + uz, 2);
 
-                const amrex::Real W2 = std::pow(uy - vx, 2) + std::pow(vz - wy, 2) + std::pow(wx - uz, 2);
+                const amrex::Real W2 = std::pow(uy - vx, 2) +
+                                       std::pow(vz - wy, 2) +
+                                       std::pow(wx - uz, 2);
 
                 qcritphi(i, j, k) = 0.5 * (W2 - S2);
             });

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -140,7 +140,7 @@ void TiogaInterface::register_solution(
     // Move cell variables into scratch field
     {
         int icomp = 0;
-        for (const auto& cvar: m_cell_vars) {
+        for (const auto& cvar : m_cell_vars) {
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
@@ -153,7 +153,7 @@ void TiogaInterface::register_solution(
     // Move node variables into scratch field
     {
         int icomp = 0;
-        for (const auto& cvar: m_node_vars) {
+        for (const auto& cvar : m_node_vars) {
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
@@ -192,7 +192,7 @@ void TiogaInterface::update_solution()
     // Update cell variables
     {
         int icomp = 0;
-        for (const auto& cvar: m_cell_vars) {
+        for (const auto& cvar : m_cell_vars) {
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             field_ops::copy(fld, *m_qcell, icomp, 0, ncomp, num_ghost);
@@ -204,7 +204,7 @@ void TiogaInterface::update_solution()
     // Update nodal variables
     {
         int icomp = 0;
-        for (const auto& cvar: m_node_vars) {
+        for (const auto& cvar : m_node_vars) {
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             field_ops::copy(fld, *m_qnode, icomp, 0, ncomp, num_ghost);

--- a/amr-wind/physics/TaylorGreenVortex.cpp
+++ b/amr-wind/physics/TaylorGreenVortex.cpp
@@ -28,9 +28,9 @@ void TaylorGreenVortex::initialize_fields(
 
     const auto& problo = geom.ProbLoArray();
     const auto& probhi = geom.ProbHiArray();
-    const amrex::Real Lx = probhi[0]-problo[0];
-    const amrex::Real Ly = probhi[1]-problo[1];
-    const amrex::Real Lz = probhi[2]-problo[2];
+    const amrex::Real Lx = probhi[0] - problo[0];
+    const amrex::Real Ly = probhi[1] - problo[1];
+    const amrex::Real Lz = probhi[2] - problo[2];
 
     for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {
         const auto& vbx = mfi.validbox();
@@ -44,9 +44,11 @@ void TaylorGreenVortex::initialize_fields(
                 const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
                 vel(i, j, k, 0) = std::sin(two_pi() * x / Lx) *
-                                  std::cos(two_pi() * y / Ly) * cos(two_pi() * z / Lz);
+                                  std::cos(two_pi() * y / Ly) *
+                                  cos(two_pi() * z / Lz);
                 vel(i, j, k, 1) = -std::cos(two_pi() * x / Lx) *
-                                  std::sin(two_pi() * y / Ly) * cos(two_pi() * z / Lz);
+                                  std::sin(two_pi() * y / Ly) *
+                                  cos(two_pi() * z / Lz);
                 vel(i, j, k, 2) = 0.0;
             });
     }

--- a/amr-wind/physics/multiphase/DamBreak.H
+++ b/amr-wind/physics/multiphase/DamBreak.H
@@ -44,7 +44,6 @@ private:
 
     //! dam height value
     amrex::Real m_height{0.25};
-
 };
 
 } // namespace amr_wind

--- a/amr-wind/physics/multiphase/DamBreak.cpp
+++ b/amr-wind/physics/multiphase/DamBreak.cpp
@@ -25,7 +25,7 @@ void DamBreak::initialize_fields(int level, const amrex::Geometry& geom)
 {
     auto& velocity = m_velocity(level);
     velocity.setVal(0.0, 0, AMREX_SPACEDIM);
-    
+
     auto& levelset = m_levelset(level);
     const auto& dx = geom.CellSizeArray();
     const auto& problo = geom.ProbLoArray();
@@ -38,20 +38,22 @@ void DamBreak::initialize_fields(int level, const amrex::Geometry& geom)
         const auto& vbx = mfi.validbox();
         auto phi = levelset.array(mfi);
 
-        amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
-            const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+        amrex::ParallelFor(
+            vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
-            if (x - xc < width && z - zc < height) {
-                phi(i, j, k) = amrex::min(width - x, height - z);
-            } else if (x - xc < width && z - zc > height) {
-                phi(i, j, k) = height - (z - zc);
-            } else if (x - xc > width && z - zc < height) {
-                phi(i, j, k) = width - (x - xc);
-            } else {
-                phi(i, j, k) = amrex::min(width - (x - xc), height - (z - zc));
-            }
-    });
+                if (x - xc < width && z - zc < height) {
+                    phi(i, j, k) = amrex::min(width - x, height - z);
+                } else if (x - xc < width && z - zc > height) {
+                    phi(i, j, k) = height - (z - zc);
+                } else if (x - xc > width && z - zc < height) {
+                    phi(i, j, k) = width - (x - xc);
+                } else {
+                    phi(i, j, k) =
+                        amrex::min(width - (x - xc), height - (z - zc));
+                }
+            });
     }
 }
 

--- a/amr-wind/physics/multiphase/VortexPatch.H
+++ b/amr-wind/physics/multiphase/VortexPatch.H
@@ -15,6 +15,7 @@ class VortexPatch : public Physics::Register<VortexPatch>
 {
     static_assert(
         AMREX_SPACEDIM == 3, "VortexPatch requires 3 dimensional mesh");
+
 public:
     static const std::string identifier() { return "VortexPatch"; }
 

--- a/amr-wind/physics/udfs/PowerLawProfile.cpp
+++ b/amr-wind/physics/udfs/PowerLawProfile.cpp
@@ -31,5 +31,5 @@ PowerLawProfile::PowerLawProfile(const Field& fld) : m_op()
     for (int i = 0; i < AMREX_SPACEDIM; ++i) m_op.uvec[i] = vel[i];
 }
 
-}
-}
+} // namespace udf
+} // namespace amr_wind

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -66,8 +66,8 @@ OneEqKsgsM84<Transport>::~OneEqKsgsM84() = default;
 template <typename Transport>
 TurbulenceModel::CoeffsDictType OneEqKsgsM84<Transport>::model_coeffs() const
 {
-    return TurbulenceModel::CoeffsDictType{{"Ce", this->m_Ce},
-                                           {"Ceps", this->m_Ceps}};
+    return TurbulenceModel::CoeffsDictType{
+        {"Ce", this->m_Ce}, {"Ceps", this->m_Ceps}};
 }
 
 template <typename Transport>

--- a/amr-wind/utilities/DerivedQtyDefs.cpp
+++ b/amr-wind/utilities/DerivedQtyDefs.cpp
@@ -34,8 +34,6 @@ void QCriterion::operator()(ScratchField& fld, const int scomp)
     fvm::q_criterion(q_crit, m_vel);
 }
 
-
-
 StrainRateMag::StrainRateMag(
     const FieldRepo& repo, const std::vector<std::string>& args)
     : m_vel(repo.get_field("velocity"))

--- a/amr-wind/utilities/DerivedQuantity.cpp
+++ b/amr-wind/utilities/DerivedQuantity.cpp
@@ -99,8 +99,8 @@ bool DerivedQtyMgr::contains(const std::string& key) const noexcept
     return (it != m_obj_map.end());
 }
 
-void DerivedQtyMgr::var_names(amrex::Vector<std::string>& plt_var_names) const
-    noexcept
+void DerivedQtyMgr::var_names(
+    amrex::Vector<std::string>& plt_var_names) const noexcept
 {
     for (auto& qty : m_derived_vec) {
         qty->var_names(plt_var_names);

--- a/amr-wind/utilities/sampling/PlaneSampler.cpp
+++ b/amr-wind/utilities/sampling/PlaneSampler.cpp
@@ -74,8 +74,8 @@ void PlaneSampler::sampling_locations(SampleLocType& locs) const
 #ifdef AMR_WIND_USE_NETCDF
 void PlaneSampler::define_netcdf_metadata(const ncutils::NCGroup& grp) const
 {
-    const std::vector<int> ijk{m_npts_dir[0], m_npts_dir[1],
-                               static_cast<int>(m_poffsets.size())};
+    const std::vector<int> ijk{
+        m_npts_dir[0], m_npts_dir[1], static_cast<int>(m_poffsets.size())};
     grp.put_attr("sampling_type", identifier());
     grp.put_attr("ijk_dims", ijk);
     grp.put_attr("origin", m_origin);

--- a/amr-wind/utilities/tagging/BoxRefiner.H
+++ b/amr-wind/utilities/tagging/BoxRefiner.H
@@ -27,7 +27,8 @@ public:
     virtual ~BoxRefiner() = default;
 
     void operator()(
-        const amrex::Box&, const amrex::Geometry& geom,
+        const amrex::Box&,
+        const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
 
 protected:
@@ -36,7 +37,7 @@ protected:
     amrex::Gpu::DeviceVector<int> m_face_origin;
 };
 
-}
-}
+} // namespace tagging
+} // namespace amr_wind
 
 #endif /* BOXREFINER_H */

--- a/amr-wind/utilities/tagging/BoxRefiner.cpp
+++ b/amr-wind/utilities/tagging/BoxRefiner.cpp
@@ -87,8 +87,7 @@ BoxRefiner::BoxRefiner(const CFDSim&, const std::string& key)
     const auto face_normals = compute_face_normals(hex_corners);
     // Index of the starting corner for each face in the hex nodes list
     const amrex::Vector<int> face_origin{0, 1, 0, 2, 0, 4};
-    for (int i=0; i < 8; ++i)
-        amrex::Print() << hex_corners[i] << std::endl;
+    for (int i = 0; i < 8; ++i) amrex::Print() << hex_corners[i] << std::endl;
 
     // Setup data on device
     m_hex_corners.resize(8);

--- a/amr-wind/utilities/tagging/CylinderRefiner.H
+++ b/amr-wind/utilities/tagging/CylinderRefiner.H
@@ -25,7 +25,8 @@ public:
     virtual ~CylinderRefiner() = default;
 
     void operator()(
-        const amrex::Box&, const amrex::Geometry& geom,
+        const amrex::Box&,
+        const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
 
 private:

--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -34,7 +34,8 @@ void GeometryRefinement::initialize(const std::string& key)
 void GeometryRefinement::operator()(
     int level, amrex::TagBoxArray& tags, amrex::Real, int)
 {
-    // If the user has requested a particular level then check for it and exit early
+    // If the user has requested a particular level then check for it and exit
+    // early
     if ((m_set_level > 1) && (level != m_set_level)) return;
 
     // If the user has specified a range of levels, check and return early
@@ -53,7 +54,7 @@ void GeometryRefinement::operator()(
         const auto& bx = mfi.tilebox();
         const auto& tag = tags.array(mfi);
 
-        for (const auto& gg: m_geom_refiners) {
+        for (const auto& gg : m_geom_refiners) {
             (*gg)(bx, geom, tag);
         }
     }

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -66,7 +66,6 @@ void QCriterionRefinement::operator()(
 
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-
                 // TODO: ignoring wall stencils for now
                 const auto ux =
                     0.5 * (vel(i + 1, j, k, 0) - vel(i - 1, j, k, 0)) * idx[0];

--- a/amr-wind/utilities/tagging/RefinementCriteria.H
+++ b/amr-wind/utilities/tagging/RefinementCriteria.H
@@ -50,8 +50,8 @@ public:
         int level, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) = 0;
 };
 
-/** A collection of refinement criteria instances that are active during a simulation
- *  \ingroup amr_utils
+/** A collection of refinement criteria instances that are active during a
+ * simulation \ingroup amr_utils
  */
 class RefineCriteriaManager
 {
@@ -62,7 +62,8 @@ public:
 
     void initialize();
 
-    void tag_cells(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow);
+    void
+    tag_cells(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow);
 
 private:
     CFDSim& m_sim;

--- a/amr-wind/utilities/tagging/RefinementCriteria.cpp
+++ b/amr-wind/utilities/tagging/RefinementCriteria.cpp
@@ -32,7 +32,7 @@ void RefineCriteriaManager::initialize()
 void RefineCriteriaManager::tag_cells(
     int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
 {
-    for (auto& rc: m_refiners) {
+    for (auto& rc : m_refiners) {
         (*rc)(lev, tags, time, ngrow);
     }
 }

--- a/amr-wind/utilities/tagging/VorticityRefinement.cpp
+++ b/amr-wind/utilities/tagging/VorticityRefinement.cpp
@@ -61,7 +61,6 @@ void VorticityRefinement::operator()(
 
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-
                 // TODO: ignoring wall stencils for now
                 const auto vx =
                     0.5 * (vel(i + 1, j, k, 1) - vel(i - 1, j, k, 1)) * idx[0];

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -110,9 +110,9 @@ void InletData::read_data(
     const size_t n0 = bx.length(perp[0]);
     const size_t n1 = bx.length(perp[1]);
 
-    amrex::Vector<size_t> start{static_cast<size_t>(idx),
-                                static_cast<size_t>(lo[perp[0]]),
-                                static_cast<size_t>(lo[perp[1]]), 0};
+    amrex::Vector<size_t> start{
+        static_cast<size_t>(idx), static_cast<size_t>(lo[perp[0]]),
+        static_cast<size_t>(lo[perp[1]]), 0};
     amrex::Vector<size_t> count{1, n0, n1, nc};
     amrex::Vector<amrex::Real> buffer(n0 * n1 * nc);
     grp.var(fld->name()).get(buffer.data(), start, count);
@@ -651,8 +651,9 @@ void ABLBoundaryPlane::write_data(
                 lbx, n1, nc, perp, v_offset, fld_arr, buffer.data);
             amrex::Gpu::streamSynchronize();
 
-            buffer.start = {m_out_counter, static_cast<size_t>(lo[perp[0]]),
-                            static_cast<size_t>(lo[perp[1]]), 0};
+            buffer.start = {
+                m_out_counter, static_cast<size_t>(lo[perp[0]]),
+                static_cast<size_t>(lo[perp[1]]), 0};
             buffer.count = {1, n0, n1, nc};
         }
     }

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -154,8 +154,7 @@ void ABLFieldInit::perturb_temperature(
 
 //! Initialize sfs tke field at the beginning of the simulation
 void ABLFieldInit::init_tke(
-    const amrex::Geometry& /* geom */,
-    amrex::MultiFab& tke) const
+    const amrex::Geometry& /* geom */, amrex::MultiFab& tke) const
 {
     tke.setVal(m_tke_init, 1);
 }

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -399,8 +399,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'theta'_r", "v'theta'_r",
-                                                 "w'theta'_r"};
+            amrex::Vector<std::string> var_names{
+                "u'theta'_r", "v'theta'_r", "w'theta'_r"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 m_pa_tu.line_moment(i, l_vec);
                 auto var = grp.var(var_names[i]);
@@ -420,8 +420,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'u'u'_r", "v'v'v'_r",
-                                                 "w'w'w'_r"};
+            amrex::Vector<std::string> var_names{
+                "u'u'u'_r", "v'v'v'_r", "w'w'w'_r"};
             amrex::Vector<int> var_comp{0, 13, 26};
             for (int i = 0; i < var_comp.size(); i++) {
                 m_pa_uuu.line_moment(var_comp[i], l_vec);

--- a/amr-wind/wind_energy/MOData.H
+++ b/amr-wind/wind_energy/MOData.H
@@ -24,11 +24,11 @@ struct MOData
         SURFACE_TEMPERATURE ///< Surface temperature specified
     };
 
-    amrex::Real zref{0.0};     ///< Reference height (m)
-    amrex::Real z0{0.1};       ///< Roughness height (m)
-    amrex::Real utau;          ///< Friction velocity (m/s)
-    amrex::Real kappa{0.41};   ///< von Karman constant
-    amrex::Real gravity{9.81}; ///< Acceleration due to gravity (m/s^2)
+    amrex::Real zref{0.0};           ///< Reference height (m)
+    amrex::Real z0{0.1};             ///< Roughness height (m)
+    amrex::Real utau;                ///< Friction velocity (m/s)
+    amrex::Real kappa{0.41};         ///< von Karman constant
+    amrex::Real gravity{9.81};       ///< Acceleration due to gravity (m/s^2)
     amrex::Real obukhov_len{1.0e16}; ///< Non-dimensional Obukhov length
 
     amrex::Real vel_mean[AMREX_SPACEDIM]; ///< Mean velocity (at zref)
@@ -36,8 +36,8 @@ struct MOData
     amrex::Real theta_mean;               ///< Mean potential temperature
 
     amrex::Real surf_temp_flux{0.0}; ///< Heat flux
-    amrex::Real surf_temp;      ///< Instantaneous surface temperature
-    amrex::Real ref_temp;       ///< Reference temperature
+    amrex::Real surf_temp;           ///< Instantaneous surface temperature
+    amrex::Real ref_temp;            ///< Reference temperature
 
     amrex::Real gamma_m{5.0};
     amrex::Real gamma_h{5.0};

--- a/unit_tests/aw_test_utils/pp_utils.cpp
+++ b/unit_tests/aw_test_utils/pp_utils.cpp
@@ -9,7 +9,7 @@ namespace pp_utils {
 
 bool has_managed_memory()
 {
-#if defined (AMREX_USE_HIP)
+#if defined(AMREX_USE_HIP)
     return false;
 #else
     return utest_env->has_managed_memory();

--- a/unit_tests/core/vs/test_vspace.cpp
+++ b/unit_tests/core/vs/test_vspace.cpp
@@ -123,8 +123,8 @@ void test_device_lists_impl()
     });
 
     amrex::Vector<vs::Vector> hvectors(3);
-    amrex::Vector<vs::Vector> htrue{vs::Vector::ihat(), vs::Vector::jhat(),
-                                    vs::Vector::khat()};
+    amrex::Vector<vs::Vector> htrue{
+        vs::Vector::ihat(), vs::Vector::jhat(), vs::Vector::khat()};
     amrex::Gpu::copy(
         amrex::Gpu::deviceToHost, dvectors.begin(), dvectors.end(),
         hvectors.begin());

--- a/unit_tests/fvm/AnalyticalFunction.H
+++ b/unit_tests/fvm/AnalyticalFunction.H
@@ -291,13 +291,14 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real q_criterion(
     const amrex::Real wy = dphidy_eval(degree, coeffz, x, y, z);
     const amrex::Real wz = dphidz_eval(degree, coeffz, x, y, z);
 
-    const amrex::Real S2 = 2.0 * ux * ux + 2.0 * vy * vy + 2.0 * wz * wz + (uy + vx) * (uy + vx) +
-        (vz + wy) * (vz + wy) + (wx + uz) * (wx + uz);
-    const amrex::Real W2 = (uy - vx) * (uy - vx) + (vz - wy) * (vz - wy) + (wx - uz) * (wx - uz);
+    const amrex::Real S2 = 2.0 * ux * ux + 2.0 * vy * vy + 2.0 * wz * wz +
+                           (uy + vx) * (uy + vx) + (vz + wy) * (vz + wy) +
+                           (wx + uz) * (wx + uz);
+    const amrex::Real W2 =
+        (uy - vx) * (uy - vx) + (vz - wy) * (vz - wy) + (wx - uz) * (wx - uz);
 
-    return 0.5*(W2-S2);
+    return 0.5 * (W2 - S2);
 }
-
 
 } // namespace analytical_function
 

--- a/unit_tests/fvm/test_fvm_ops.cpp
+++ b/unit_tests/fvm/test_fvm_ops.cpp
@@ -283,7 +283,7 @@ amrex::Real q_criterion_test_impl(amr_wind::Field& vel, const int pdegree)
     amrex::Gpu::DeviceVector<amrex::Real> cu(ncoeff, 0.00123);
     amrex::Gpu::DeviceVector<amrex::Real> cv(ncoeff, 0.00213);
     amrex::Gpu::DeviceVector<amrex::Real> cw(ncoeff, 0.00346);
-    
+
     auto& geom = vel.repo().mesh().Geom();
 
     run_algorithm(vel, [&](const int lev, const amrex::MFIter& mfi) {
@@ -606,7 +606,6 @@ TEST_F(FvmOpTest, q_criterion)
 
     EXPECT_NEAR(error_total, 0.0, tol);
 }
-
 
 TEST_F(FvmOpTest, laplacian)
 {

--- a/unit_tests/mms/test_mms_error.cpp
+++ b/unit_tests/mms/test_mms_error.cpp
@@ -29,7 +29,7 @@ void perturb_vel_field(
 
 TEST_F(MMSMeshTest, mms_error)
 {
-#if defined (AMREX_USE_HIP)
+#if defined(AMREX_USE_HIP)
     GTEST_SKIP();
 #else
     if (!pp_utils::has_managed_memory()) GTEST_SKIP();

--- a/unit_tests/mms/test_mms_init.cpp
+++ b/unit_tests/mms/test_mms_init.cpp
@@ -7,7 +7,7 @@
 namespace amr_wind_tests {
 TEST_F(MMSMeshTest, mms_initialization)
 {
-#if defined (AMREX_USE_HIP)
+#if defined(AMREX_USE_HIP)
     GTEST_SKIP();
 #else
     if (!pp_utils::has_managed_memory()) GTEST_SKIP();

--- a/unit_tests/mms/test_mms_src.cpp
+++ b/unit_tests/mms/test_mms_src.cpp
@@ -14,7 +14,7 @@ using ICNSFields =
 
 TEST_F(MMSMeshTest, mms_forcing)
 {
-#if defined (AMREX_USE_HIP)
+#if defined(AMREX_USE_HIP)
     GTEST_SKIP();
 #else
     if (!pp_utils::has_managed_memory()) GTEST_SKIP();

--- a/unit_tests/utilities/test_sampling.cpp
+++ b/unit_tests/utilities/test_sampling.cpp
@@ -49,7 +49,8 @@ protected:
     void process_output() override
     {
         // Test buffer populate for GPU runs
-        std::vector<double> buf(num_total_particles() * var_names().size(), 0.0);
+        std::vector<double> buf(
+            num_total_particles() * var_names().size(), 0.0);
         sampling_container().populate_buffer(buf);
     }
 };
@@ -84,8 +85,7 @@ protected:
 namespace {
 
 void test_scontainer_impl(
-    amr_wind::sampling::SamplingContainer::ParticleVector& pvec,
-    const int npts)
+    amr_wind::sampling::SamplingContainer::ParticleVector& pvec, const int npts)
 {
     using IIx = amr_wind::sampling::IIx;
     using PType = amr_wind::sampling::SamplingContainer::ParticleType;

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -135,7 +135,6 @@ TEST_F(ABLMeshTest, body_force)
     }
 }
 
-
 TEST_F(ABLMeshTest, geostrophic_forcing)
 {
     constexpr amrex::Real tol = 1.0e-12;
@@ -190,8 +189,8 @@ TEST_F(ABLMeshTest, coriolis_const_vel)
 
     // Velocity in x-direction test
     {
-        amrex::Real golds[AMREX_SPACEDIM] = {0.0, -corfac * latfac * vel_comp,
-                                             corfac * latfac * vel_comp};
+        amrex::Real golds[AMREX_SPACEDIM] = {
+            0.0, -corfac * latfac * vel_comp, corfac * latfac * vel_comp};
         vel.setVal(0.0);
         src_term.setVal(0.0);
         vel.setVal(vel_comp, 0);
@@ -214,8 +213,8 @@ TEST_F(ABLMeshTest, coriolis_const_vel)
 
     // Velocity in y-direction test
     {
-        amrex::Real golds[AMREX_SPACEDIM] = {corfac * latfac * vel_comp, 0.0,
-                                             0.0};
+        amrex::Real golds[AMREX_SPACEDIM] = {
+            corfac * latfac * vel_comp, 0.0, 0.0};
         vel.setVal(0.0);
         src_term.setVal(0.0);
         vel.setVal(vel_comp, 1);


### PR DESCRIPTION
This adds a check that `clang-format` has been applied to all source files. It also adds an action to each workflow which cancels previous workflow ones when new pushes originate. I also formatted the source files to pass the format test.

One note about this, is that I wish I could have other workflows depend on the formatting check so it's done first before the heavyweight actions start. This only currently seems possible with lots of archaic code, or by putting all workflows into a single file with dependencies. So my hope is that the cancelling actions will help save resources when the formatting fails quickly and someone pushes the formatted files.