### PR TITLE
Add linting to CI

### DIFF
--- a/.github/problem-matchers/gcc.json
+++ b/.github/problem-matchers/gcc.json
@@ -1,0 +1,18 @@
+{
+     "__comment": "Taken from vscode-cpptools's Extension/package.json gcc rule",
+     "problemMatcher": [
+         {
+             "owner": "gcc-problem-matcher",
+             "pattern": [
+                 {
+                     "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                     "file": 1,
+                     "line": 2,
+                     "column": 3,
+                     "severity": 4,
+                     "message": 5
+                 }
+             ]
+         }
+     ]
+} 

--- a/.github/problem-matchers/sphinx.json
+++ b/.github/problem-matchers/sphinx.json
@@ -1,0 +1,40 @@
+{
+     "problemMatcher": [
+         {
+             "owner": "sphinx-problem-matcher",
+             "pattern": [
+                 {
+                     "regexp": "^(.*):(\\d+):\\s+(\\w*):\\s+(.*)$",
+                     "file": 1,
+                     "line": 2,
+                     "severity": 3,
+                     "message": 4
+                 }
+             ]
+         },
+         {
+             "owner": "sphinx-problem-matcher-loose",
+             "pattern": [
+                 {
+                     "_comment": "A bit of a looser pattern, doesn't look for line numbers, just looks for file names relying on them to start with / and end with .rst",
+                     "regexp": "(\/.*\\.rst):\\s+(\\w*):\\s+(.*)$",
+                     "file": 1,
+                     "severity": 2,
+                     "message": 3
+                 }
+             ]
+         },
+         {
+             "owner": "sphinx-problem-matcher-loose-no-severity",
+             "pattern": [
+                 {
+                     "_comment": "Looks for file names ending with .rst and line numbers but without severity",
+                     "regexp": "^(.*\\.rst):(\\d+):(.*)$",
+                     "file": 1,
+                     "line": 2,
+                     "message": 3
+                 }
+             ]           
+         }
+     ]
+} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
     - name: Dependencies
       run: ${{matrix.install_deps}}
     - name: Setup
-      run: echo "NUM_PROCS=${{matrix.procs}}" >> $GITHUB_ENV
+      run: |
+        echo "::add-matcher::.github/problem-matchers/gcc.json"
+        echo "NUM_PROCS=${{matrix.procs}}" >> $GITHUB_ENV
     - name: Configure
       run: |
         cmake \
@@ -67,7 +69,6 @@ jobs:
           -DAMR_WIND_ENABLE_MPI:BOOL=ON \
           -DAMR_WIND_ENABLE_TESTS:BOOL=ON \
           -DAMR_WIND_TEST_WITH_FCOMPARE:BOOL=OFF \
-          -DAMR_WIND_ENABLE_WERROR:BOOL=ON \
           ${GITHUB_WORKSPACE}
     - name: Make
       working-directory: ${{runner.workspace}}/build-ci-${{matrix.build_type}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           echo "::add-matcher::.github/problem-matchers/sphinx.json"
           sphinx-build -M html ./docs/sphinx ./build_docs/manual
+          # Doxygen output gets parsed wrong by the sphinx problem matcher so unregister it
+          echo "::remove-matcher owner=sphinx-problem-matcher-loose-no-severity::"
+          echo "::remove-matcher owner=sphinx-problem-matcher-loose::"
+          echo "::remove-matcher owner=sphinx-problem-matcher::"
           doxygen ./docs/doxygen/Doxyfile
           mv ./build_docs/manual/html ./documentation
           mv ./build_docs/doxygen/html ./documentation/api_docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Build
         # execute from top-level amr-wind directory
         run: |
+          echo "::add-matcher::.github/problem-matchers/sphinx.json"
           sphinx-build -M html ./docs/sphinx ./build_docs/manual
           doxygen ./docs/doxygen/Doxyfile
           mv ./build_docs/manual/html ./documentation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: build-lint
         run: |
           # Sanitize AMREX_GIT_VERSION define with 3 backslashes and quotes which cppcheck can't parse
-          sed -i.bak 's/\\\\\\"//g' compile_commands.json
+          sed -i '' -e 's/\\\\\\"//g' compile_commands.json
           cppcheck --inline-suppr \
             --suppress=unmatchedSuppression --suppress=syntaxError --suppress=internalAstError \
             --std=c++14 --language=c++ --enable=all --project=compile_commands.json \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,69 @@
+name: AMR-Wind Lint
+
+on:
+  push:
+    branches: [development]
+    paths:
+      - 'cmake/**'
+      - 'amr-wind/**'
+      - 'submods/**'
+      - 'test/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/lint.yml'
+  pull_request:
+    branches: [development]
+    paths:
+      - 'cmake/**'
+      - 'amr-wind/**'
+      - 'submods/**'
+      - 'test/**'
+      - 'unit_tests/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/lint.yml'
+
+jobs:
+  Lint:
+    runs-on: macos-latest
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{github.token}}
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Dependencies
+        run: brew install cppcheck
+      - name: Configure
+        run: |
+          echo "NPROCS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+          cmake \
+          -Bbuild-lint \
+          -DAMR_WIND_ENABLE_MPI:BOOL=OFF \
+          -DAMR_WIND_ENABLE_TESTS:BOOL=ON \
+          -DAMR_WIND_TEST_WITH_FCOMPARE:BOOL=OFF \
+          -DAMR_WIND_ENABLE_MASA:BOOL=OFF \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+          ${{github.workspace}}
+      - name: Check
+        working-directory: build-lint
+        run: |
+          cppcheck --inline-suppr --suppress=unmatchedSuppression \
+            --std=c++14 --language=c++ --enable=all --project=compile_commands.json \
+            -j ${{env.NPROCS}} -i ${{github.workspace}}/submods/amrex/Src \
+            -i ${{github.workspace}}/submods/googletest --output-file=cppcheck.txt
+          # Ignore all submodules for now; might be wrong to assume cppcheck always reports issues using 3 lines
+          awk -v nlines=2 \
+              '/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1' \
+              < cppcheck.txt > amr-wind-static-analysis.txt
+      - name: Report
+        working-directory: build-lint
+        run: |
+          # Might be wrong to assume cppcheck always reports issues using 3 lines
+          WARNINGS_TMP=$(wc -l < amr-wind-static-analysis.txt | xargs echo -n)
+          WARNINGS=$(bc <<< "$WARNINGS_TMP/3")
+          printf "%s warnings\n" "${WARNINGS}" >> amr-wind-static-analysis.txt
+          cat amr-wind-static-analysis.txt
+          # Just report for now and don't fail
+          #exit ${WARNINGS}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Check
         working-directory: build-lint
         run: |
+          # Sanitize AMREX_GIT_VERSION define with 3 backslashes and quotes which cppcheck can't parse
+          sed -i.bak 's/\\\\\\"//g' compile_commands.json
           cppcheck --inline-suppr --suppress=unmatchedSuppression \
             --std=c++14 --language=c++ --enable=all --project=compile_commands.json \
             -j ${{env.NPROCS}} -i ${{github.workspace}}/submods/amrex/Src \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,8 @@ jobs:
         run: |
           # Sanitize AMREX_GIT_VERSION define with 3 backslashes and quotes which cppcheck can't parse
           sed -i.bak 's/\\\\\\"//g' compile_commands.json
-          cppcheck --inline-suppr --suppress=unmatchedSuppression \
+          cppcheck --inline-suppr \
+            --suppress=unmatchedSuppression --suppress=syntaxError --suppress=internalAstError \
             --std=c++14 --language=c++ --enable=all --project=compile_commands.json \
             -j ${{env.NPROCS}} -i ${{github.workspace}}/submods/amrex/Src \
             -i ${{github.workspace}}/submods/googletest --output-file=cppcheck.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,7 @@ jobs:
         run: brew install cppcheck
       - name: Configure
         run: |
+          echo "::add-matcher::.github/problem-matchers/gcc.json"
           echo "NPROCS=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
           cmake \
           -Bbuild-lint \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,17 +55,13 @@ jobs:
             --std=c++14 --language=c++ --enable=all --project=compile_commands.json \
             -j ${{env.NPROCS}} -i ${{github.workspace}}/submods/amrex/Src \
             -i ${{github.workspace}}/submods/googletest --output-file=cppcheck.txt
-          # Ignore all submodules for now; might be wrong to assume cppcheck always reports issues using 3 lines
-          awk -v nlines=2 \
-              '/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1' \
-              < cppcheck.txt > amr-wind-static-analysis.txt
       - name: Report
         working-directory: build-lint
         run: |
           # Might be wrong to assume cppcheck always reports issues using 3 lines
-          WARNINGS_TMP=$(wc -l < amr-wind-static-analysis.txt | xargs echo -n)
+          WARNINGS_TMP=$(wc -l < cppcheck.txt | xargs echo -n)
           WARNINGS=$(bc <<< "$WARNINGS_TMP/3")
-          printf "%s warnings\n" "${WARNINGS}" >> amr-wind-static-analysis.txt
-          cat amr-wind-static-analysis.txt
+          printf "%s warnings\n" "${WARNINGS}" >> cppcheck.txt
+          cat cppcheck.txt
           # Just report for now and don't fail
           #exit ${WARNINGS}

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -8,7 +8,7 @@
 #include "amr-wind/utilities/PostProcessing.H"
 #include "amr-wind/overset/OversetManager.H"
 
-using namespace amrex;;
+using namespace amrex;
 
 incflo::incflo()
     : m_sim(*this)

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -8,7 +8,7 @@
 #include "amr-wind/utilities/PostProcessing.H"
 #include "amr-wind/overset/OversetManager.H"
 
-using namespace amrex;
+using namespace amrex;;
 
 incflo::incflo()
     : m_sim(*this)


### PR DESCRIPTION
Let me know if you think this is worthwhile to add. The check takes less than 5 minutes. If it's worth having, I can fix the warnings it's reporting. I got PeleC down to 0 with not too much work.

I think it's at least worth reporting at a certain severity level if not all, but I kind of like having it report everything. It can also generate an HTML report we could deploy to `gh-pages` but I think the text output is more readable. Currently this check doesn't error and just reports. It's using `macos-latest` because ubuntu has a far too old version of `cppcheck` with `apt-get`.