### PR TITLE
Geostrophic Forcing latitude check

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -39,7 +39,7 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.query("latitude", latitude);
         AMREX_ALWAYS_ASSERT(
             amrex::Math::abs(latitude - 90.0) <
-            vs::DTraits<amrex::Real>::eps());
+            static_cast<amrex::Real>(vs::DTraits<float>::eps()));
     }
 
     {

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -48,8 +48,9 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.getarr("geostrophic_wind", m_target_vel);
     }
 
-    m_g_forcing = {-coriolis_factor * m_target_vel[1],
-                   coriolis_factor * m_target_vel[0], 0.0};
+    m_g_forcing = {
+        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0]
+        , 0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -49,8 +49,8 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
     }
 
     m_g_forcing = {
-        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0]
-        , 0.0};
+        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0],
+        0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -2,6 +2,7 @@
 #include "amr-wind/utilities/PlaneAveraging.H"
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/utilities/trig_ops.H"
+#include "amr-wind/core/vs/vstraits.H"
 
 #include "AMReX_ParmParse.H"
 #include "AMReX_Gpu.H"
@@ -34,7 +35,8 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
 
         amrex::Real latitude = 90.0;
         pp.query("latitude", latitude);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(latitude - 90.0) < 1.0e-14);
+        AMREX_ALWAYS_ASSERT(
+            amrex::Math::abs(latitude - 90.0) < vs::DTraits<amrex::Real>::eps());
     }
 
     {
@@ -43,8 +45,9 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.getarr("geostrophic_wind", m_target_vel);
     }
 
-    m_g_forcing = {-coriolis_factor * m_target_vel[1],
-                   coriolis_factor * m_target_vel[0], 0.0};
+    m_g_forcing = {
+        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0],
+        0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -31,6 +31,10 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         amrex::Real rot_time_period = 86400.0;
         pp.query("rotational_time_period", rot_time_period);
         coriolis_factor = 2.0 * utils::two_pi() / rot_time_period;
+
+        amrex::Real latitude = 90.0;
+        pp.query("latitude", latitude);
+        AMREX_ALWAYS_ASSERT(amrex::Math::abs(latitude - 90.0) < 1.0e-14);
     }
 
     {
@@ -39,9 +43,8 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.getarr("geostrophic_wind", m_target_vel);
     }
 
-    m_g_forcing = {
-        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0],
-        0.0};
+    m_g_forcing = {-coriolis_factor * m_target_vel[1],
+                   coriolis_factor * m_target_vel[0], 0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -32,11 +32,14 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         amrex::Real rot_time_period = 86400.0;
         pp.query("rotational_time_period", rot_time_period);
         coriolis_factor = 2.0 * utils::two_pi() / rot_time_period;
+        amrex::Print() << "Geostrophic forcing: Coriolis factor = "
+                       << coriolis_factor << std::endl;
 
         amrex::Real latitude = 90.0;
         pp.query("latitude", latitude);
         AMREX_ALWAYS_ASSERT(
-            amrex::Math::abs(latitude - 90.0) < vs::DTraits<amrex::Real>::eps());
+            amrex::Math::abs(latitude - 90.0) <
+            vs::DTraits<amrex::Real>::eps());
     }
 
     {
@@ -45,9 +48,8 @@ GeostrophicForcing::GeostrophicForcing(const CFDSim&)
         pp.getarr("geostrophic_wind", m_target_vel);
     }
 
-    m_g_forcing = {
-        -coriolis_factor * m_target_vel[1], coriolis_factor * m_target_vel[0],
-        0.0};
+    m_g_forcing = {-coriolis_factor * m_target_vel[1],
+                   coriolis_factor * m_target_vel[0], 0.0};
 }
 
 GeostrophicForcing::~GeostrophicForcing() = default;

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -139,6 +139,10 @@ TEST_F(ABLMeshTest, geostrophic_forcing)
 {
     constexpr amrex::Real tol = 1.0e-12;
     utils::populate_abl_params();
+
+    amrex::ParmParse pp("CoriolisForcing");
+    pp.add("latitude", 90.0);
+
     initialize_mesh();
 
     auto& pde_mgr = sim().pde_manager();


### PR DESCRIPTION
added check for Geostrophic Forcing to make sure that latitude is set to 90 degrees if Coriolis is also used