### PR TITLE
Fix or suppress last cppcheck issues

### DIFF
--- a/amr-wind/core/vs/tensorI.H
+++ b/amr-wind/core/vs/tensorI.H
@@ -153,7 +153,8 @@ operator&&(const TensorT<T>& t1, const TensorT<T>& t2)
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T mag_sqr(const TensorT<T>& t)
 {
-    return (t);
+    // cppcheck-suppress duplicateExpression
+    return (t && t);
 }
 
 template <typename T>

--- a/amr-wind/core/vs/tensorI.H
+++ b/amr-wind/core/vs/tensorI.H
@@ -153,7 +153,7 @@ operator&&(const TensorT<T>& t1, const TensorT<T>& t2)
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T mag_sqr(const TensorT<T>& t)
 {
-    return (t && t);
+    return (t);
 }
 
 template <typename T>

--- a/unit_tests/core/test_simtime.cpp
+++ b/unit_tests/core/test_simtime.cpp
@@ -57,7 +57,8 @@ TEST_F(SimTimeTest, init)
     // Check that the timestep growth is not greater than 10% of the last
     // timestep
     time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
-    EXPECT_NEAR(time.deltaT(), 1.1 * first_dt, tol);
+    EXPECT_NEAR(
+        time.deltaT(), 1.1 * first_dt, tol); // cppcheck-suppress unreadVariable
 }
 
 TEST_F(SimTimeTest, time_loop)
@@ -84,7 +85,8 @@ TEST_F(SimTimeTest, time_loop)
     EXPECT_EQ(regrid_counter, 1);
 
     EXPECT_TRUE(time.write_last_checkpoint());
-    EXPECT_FALSE(time.write_last_plot_file());
+    EXPECT_FALSE(
+        time.write_last_plot_file()); // cppcheck-suppress unreadVariable
 }
 
 TEST_F(SimTimeTest, fixed_dt_loop)
@@ -115,7 +117,8 @@ TEST_F(SimTimeTest, fixed_dt_loop)
     EXPECT_EQ(regrid_counter, 3);
 
     EXPECT_FALSE(time.write_last_checkpoint());
-    EXPECT_FALSE(time.write_last_plot_file());
+    EXPECT_FALSE(
+        time.write_last_plot_file()); // cppcheck-suppress unreadVariable
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/core/test_simtime.cpp
+++ b/unit_tests/core/test_simtime.cpp
@@ -57,8 +57,8 @@ TEST_F(SimTimeTest, init)
     // Check that the timestep growth is not greater than 10% of the last
     // timestep
     time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
-    EXPECT_NEAR(
-        time.deltaT(), 1.1 * first_dt, tol); // cppcheck-suppress unreadVariable
+    // cppcheck-suppress unreadVariable
+    EXPECT_NEAR(time.deltaT(), 1.1 * first_dt, tol);
 }
 
 TEST_F(SimTimeTest, time_loop)
@@ -85,8 +85,8 @@ TEST_F(SimTimeTest, time_loop)
     EXPECT_EQ(regrid_counter, 1);
 
     EXPECT_TRUE(time.write_last_checkpoint());
-    EXPECT_FALSE(
-        time.write_last_plot_file()); // cppcheck-suppress unreadVariable
+    // cppcheck-suppress unreadVariable
+    EXPECT_FALSE(time.write_last_plot_file());
 }
 
 TEST_F(SimTimeTest, fixed_dt_loop)
@@ -117,8 +117,8 @@ TEST_F(SimTimeTest, fixed_dt_loop)
     EXPECT_EQ(regrid_counter, 3);
 
     EXPECT_FALSE(time.write_last_checkpoint());
-    EXPECT_FALSE(
-        time.write_last_plot_file()); // cppcheck-suppress unreadVariable
+    // cppcheck-suppress unreadVariable
+    EXPECT_FALSE(time.write_last_plot_file());
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/core/vs/test_vspace.cpp
+++ b/unit_tests/core/vs/test_vspace.cpp
@@ -156,7 +156,7 @@ TEST(VectorSpace, vector_create)
 
     EXPECT_NEAR(v1.x(), v6.x(), tol);
     EXPECT_NEAR(v1.y(), v6.y(), tol);
-    EXPECT_NEAR(v1.z(), v6.z(), tol);
+    EXPECT_NEAR(v1.z(), v6.z(), tol); // cppcheck-suppress unreadVariable
 
     test_vector_create_impl();
 }
@@ -179,7 +179,9 @@ TEST(VectorSpace, vector_ops)
     EXPECT_NEAR((v1 & v2), 50.0 * v21, tol);
     EXPECT_NEAR((v1 & vs::Vector::khat()), 0.0, tol);
 
-    EXPECT_NEAR(vs::mag_sqr((v1 + v2) - vs::Vector{11.0, 22.0, 0.0}), 0.0, tol);
+    EXPECT_NEAR(
+        vs::mag_sqr((v1 + v2) - vs::Vector{11.0, 22.0, 0.0}), 0.0,
+        tol); // cppcheck-suppress unreadVariable
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/core/vs/test_vspace.cpp
+++ b/unit_tests/core/vs/test_vspace.cpp
@@ -156,7 +156,8 @@ TEST(VectorSpace, vector_create)
 
     EXPECT_NEAR(v1.x(), v6.x(), tol);
     EXPECT_NEAR(v1.y(), v6.y(), tol);
-    EXPECT_NEAR(v1.z(), v6.z(), tol); // cppcheck-suppress unreadVariable
+    // cppcheck-suppress unreadVariable
+    EXPECT_NEAR(v1.z(), v6.z(), tol);
 
     test_vector_create_impl();
 }
@@ -178,10 +179,8 @@ TEST(VectorSpace, vector_ops)
 
     EXPECT_NEAR((v1 & v2), 50.0 * v21, tol);
     EXPECT_NEAR((v1 & vs::Vector::khat()), 0.0, tol);
-
-    EXPECT_NEAR(
-        vs::mag_sqr((v1 + v2) - vs::Vector{11.0, 22.0, 0.0}), 0.0,
-        tol); // cppcheck-suppress unreadVariable
+    // cppcheck-suppress unreadVariable
+    EXPECT_NEAR(vs::mag_sqr((v1 + v2) - vs::Vector{11.0, 22.0, 0.0}), 0.0, tol);
 }
 
 } // namespace amr_wind_tests


### PR DESCRIPTION
Let me rephrase my initial comment. I would prefer to somehow solve these, but I think we might just have to suppress them. This should get to 0 warnings though.