### PR TITLE
Reduce atomic pressure in plane averages with sequential loop

### DIFF
--- a/amr-wind/utilities/DirectionSelector.H
+++ b/amr-wind/utilities/DirectionSelector.H
@@ -43,8 +43,8 @@ using ZDir = DirectionSelector<2>;
 // For example, if we're using ZDir, return a box covering the x-y plane.
 // The IntVect is used to set the constant index in the parallel direction.
 template <typename IndexSelector>
-AMREX_GPU_HOST_DEVICE
-amrex::Box PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
+AMREX_GPU_HOST_DEVICE amrex::Box
+PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect plane_lo, plane_hi;
 
@@ -68,8 +68,8 @@ amrex::Box PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 // For example, if we're using ZDir, return a box covering the z axis.
 // The IntVect is used to set the constant index in the parallel direction.
 template <typename IndexSelector>
-AMREX_GPU_HOST_DEVICE
-amrex::Box ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
+AMREX_GPU_HOST_DEVICE amrex::Box
+ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect line_lo, line_hi;
 

--- a/amr-wind/utilities/DirectionSelector.H
+++ b/amr-wind/utilities/DirectionSelector.H
@@ -7,6 +7,7 @@
 #ifndef DirectionSelector_H
 #define DirectionSelector_H
 
+#include "AMReX_Box.H"
 #include "AMReX_Gpu.H"
 
 /** select index based on direction input */
@@ -37,5 +38,55 @@ struct DirectionSelector<2>
 using XDir = DirectionSelector<0>;
 using YDir = DirectionSelector<1>;
 using ZDir = DirectionSelector<2>;
+
+// Given a box, return a 2D box perpendicular to the selected axis.
+// For example, if we're using ZDir, return a box covering the x-y plane.
+// The IntVect is used to set the constant index in the parallel direction.
+template <typename IndexSelector>
+AMREX_GPU_HOST_DEVICE
+amrex::Box PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
+{
+    amrex::IntVect plane_lo, plane_hi;
+
+    if (std::is_same<IndexSelector, XDir>::value) {
+        plane_lo = {iv[0], bx.smallEnd(1), bx.smallEnd(2)};
+        plane_hi = {iv[0], bx.bigEnd(1), bx.bigEnd(2)};
+    } else if (std::is_same<IndexSelector, YDir>::value) {
+        plane_lo = {bx.smallEnd(0), iv[1], bx.bigEnd(2)};
+        plane_hi = {bx.bigEnd(0), iv[1], bx.bigEnd(2)};
+    } else {
+        plane_lo = {bx.smallEnd(0), bx.smallEnd(1), iv[2]};
+        plane_hi = {bx.bigEnd(0), bx.bigEnd(1), iv[2]};
+    }
+
+    amrex::Box pbx(plane_lo, plane_hi);
+
+    return pbx;
+}
+
+// Given a box, return a 1D box parallel to the selected axis.
+// For example, if we're using ZDir, return a box covering the z axis.
+// The IntVect is used to set the constant index in the parallel direction.
+template <typename IndexSelector>
+AMREX_GPU_HOST_DEVICE
+amrex::Box ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
+{
+    amrex::IntVect line_lo, line_hi;
+
+    if (std::is_same<IndexSelector, XDir>::value) {
+        line_lo = {bx.smallEnd(0), iv[1], iv[2]};
+        line_hi = {bx.bigEnd(0), iv[1], iv[2]};
+    } else if (std::is_same<IndexSelector, YDir>::value) {
+        line_lo = {iv[0], bx.smallEnd(1), iv[2]};
+        line_hi = {iv[0], bx.bigEnd(1), iv[2]};
+    } else {
+        line_lo = {iv[0], iv[1], bx.smallEnd(2)};
+        line_hi = {iv[0], iv[1], bx.bigEnd(2)};
+    }
+
+    amrex::Box lbx(line_lo, line_hi);
+
+    return lbx;
+}
 
 #endif /* DirectionSelector_H */

--- a/amr-wind/utilities/ThirdMomentAveraging.cpp
+++ b/amr-wind/utilities/ThirdMomentAveraging.cpp
@@ -175,8 +175,8 @@ void ThirdMomentAveraging::compute_average(
         auto mfab_arr2 = mfab2.const_array(mfi);
         auto mfab_arr3 = mfab3.const_array(mfi);
 
-        amrex::Box pbx = PerpendicularBox<IndexSelector>(
-                         bx, amrex::IntVect{0, 0, 0});
+        amrex::Box pbx =
+            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
         amrex::ParallelFor(
             pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k) noexcept {
@@ -184,7 +184,7 @@ void ThirdMomentAveraging::compute_average(
                 // This reduces the atomic pressure on the destination arrays.
 
                 amrex::Box lbx = ParallelBox<IndexSelector>(
-                                 bx, amrex::IntVect{p_i, p_j, p_k});
+                    bx, amrex::IntVect{p_i, p_j, p_k});
 
                 for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
                     for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {

--- a/amr-wind/utilities/ThirdMomentAveraging.cpp
+++ b/amr-wind/utilities/ThirdMomentAveraging.cpp
@@ -204,7 +204,7 @@ void ThirdMomentAveraging::compute_average(
                                     for (int p = 0; p < ncomp3; ++p) {
 
                                         const amrex::Real up3 =
-                                            mfab_arr3(i, j, k, n) -
+                                            mfab_arr3(i, j, k, p) -
                                             line_avg3[ncomp3 * ind + p];
 
                                         amrex::HostDevice::Atomic::Add(

--- a/amr-wind/utilities/ThirdMomentAveraging.cpp
+++ b/amr-wind/utilities/ThirdMomentAveraging.cpp
@@ -176,9 +176,9 @@ void ThirdMomentAveraging::compute_average(
         auto mfab_arr3 = mfab3.const_array(mfi);
 
         // Construct a box covering only the 2D plane orthogonal to the axis
-        // we're looping over (e.g. for idxOp == ZDir(), the x-y plane). Additionally
-        // construct a 1D box for that axis, which will be the one we loop over in
-        // the ParallelFor.
+        // we're looping over (e.g. for idxOp == ZDir(), the x-y plane).
+        // Additionally construct a 1D box for that axis, which will be the one
+        // we loop over in the ParallelFor.
 
         amrex::IntVect plane_lo, plane_hi;
 
@@ -199,7 +199,6 @@ void ThirdMomentAveraging::compute_average(
             pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k) noexcept {
                 // Loop over the direction perpendicular to the plane.
                 // This reduces the atomic pressure on the destination arrays.
-                // The loop indices parallel to the plane just have a single index.
 
                 amrex::IntVect loop_lo, loop_hi;
 
@@ -225,14 +224,17 @@ void ThirdMomentAveraging::compute_average(
                             int nf = 0;
                             for (int m = 0; m < ncomp1; ++m) {
                                 const amrex::Real up1 =
-                                    mfab_arr1(i, j, k, m) - line_avg1[ncomp1 * ind + m];
+                                    mfab_arr1(i, j, k, m) -
+                                    line_avg1[ncomp1 * ind + m];
                                 for (int n = 0; n < ncomp2; ++n) {
                                     const amrex::Real up2 =
-                                        mfab_arr2(i, j, k, n) - line_avg2[ncomp2 * ind + n];
+                                        mfab_arr2(i, j, k, n) -
+                                        line_avg2[ncomp2 * ind + n];
                                     for (int p = 0; p < ncomp3; ++p) {
 
-                                        const amrex::Real up3 = mfab_arr3(i, j, k, n) -
-                                                                line_avg3[ncomp3 * ind + p];
+                                        const amrex::Real up3 =
+                                            mfab_arr3(i, j, k, n) -
+                                            line_avg3[ncomp3 * ind + p];
 
                                         amrex::HostDevice::Atomic::Add(
                                             &line_fluc[nmoments * ind + nf],
@@ -241,11 +243,9 @@ void ThirdMomentAveraging::compute_average(
                                     }
                                 }
                             }
-
                         }
                     }
                 }
-
             });
     }
 


### PR DESCRIPTION
For a 256x256x64 (single-box) case on an NVIDIA V100, the third moment averaging of velocity takes ~70 ms which is quite expensive for this domain size. The expense is mainly due to many threads performing atomic operations on the same output locations. We can bring down the cost by having fewer threads simultaneously writing to a given output location. A way to achieve this is, instead of doing the whole 3D box in parallel at once, to break down the box into 2D planes and then loop sequentially over the 2D planes. For example, when the axis is the z-axis, loop over the x-y planes from the bottom of the box to the top. This is paired with a ParallelFor that launches only as many threads as needed to span the x-y plane. This brings down the cost to ~20 ms for the case mentioned above.