### PR TITLE
Sequential loop over axis index for all plane averages

### DIFF
--- a/amr-wind/utilities/DirectionSelector.H
+++ b/amr-wind/utilities/DirectionSelector.H
@@ -52,7 +52,7 @@ PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
         plane_lo = {iv[0], bx.smallEnd(1), bx.smallEnd(2)};
         plane_hi = {iv[0], bx.bigEnd(1), bx.bigEnd(2)};
     } else if (std::is_same<IndexSelector, YDir>::value) {
-        plane_lo = {bx.smallEnd(0), iv[1], bx.bigEnd(2)};
+        plane_lo = {bx.smallEnd(0), iv[1], bx.smallEnd(2)};
         plane_hi = {bx.bigEnd(0), iv[1], bx.bigEnd(2)};
     } else {
         plane_lo = {bx.smallEnd(0), bx.smallEnd(1), iv[2]};
@@ -66,7 +66,8 @@ PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 
 // Given a box, return a 1D box parallel to the selected axis.
 // For example, if we're using ZDir, return a box covering the z axis.
-// The IntVect is used to set the constant index in the parallel direction.
+// The IntVect is used to set the constant indices in the perpendicular
+// direction.
 template <typename IndexSelector>
 AMREX_GPU_HOST_DEVICE amrex::Box
 ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)

--- a/amr-wind/utilities/FieldPlaneAveraging.cpp
+++ b/amr-wind/utilities/FieldPlaneAveraging.cpp
@@ -381,11 +381,11 @@ void VelPlaneAveraging::compute_hvelmag_averages(
                             const int ind = idx_op(i, j, k);
                             const amrex::Real hvelmag = std::sqrt(
                                 fab_arr(i, j, k, h1_idx) *
-                                fab_arr(i, j, k, h1_idx) +
+                                    fab_arr(i, j, k, h1_idx) +
                                 fab_arr(i, j, k, h2_idx) *
-                                fab_arr(i, j, k, h2_idx));
-                            amrex::HostDevice::Atomic::Add(&line_avg[ind],
-                                                           hvelmag * denom);
+                                    fab_arr(i, j, k, h2_idx));
+                            amrex::HostDevice::Atomic::Add(
+                                &line_avg[ind], hvelmag * denom);
                         }
                     }
                 }

--- a/amr-wind/utilities/PlaneAveraging.cpp
+++ b/amr-wind/utilities/PlaneAveraging.cpp
@@ -254,20 +254,16 @@ void PlaneAveraging::fill_line(
                             const int ind = idxOp(i, j, k);
 
                             // velocity fluctuation
-                            const Real up =
-                                vel_arr(i, j, k, 0) -
-                                line_average_[navg_ * ind + u_avg_];
-                            const Real vp =
-                                vel_arr(i, j, k, 1) -
-                                line_average_[navg_ * ind + v_avg_];
-                            const Real wp =
-                                vel_arr(i, j, k, 2) -
-                                line_average_[navg_ * ind + w_avg_];
+                            const Real up = vel_arr(i, j, k, 0) -
+                                            line_average_[navg_ * ind + u_avg_];
+                            const Real vp = vel_arr(i, j, k, 1) -
+                                            line_average_[navg_ * ind + v_avg_];
+                            const Real wp = vel_arr(i, j, k, 2) -
+                                            line_average_[navg_ * ind + w_avg_];
 
                             // temperature fluctuation
-                            const Real Tp =
-                                temp_arr(i, j, k) -
-                                line_average_[navg_ * ind + T_avg_];
+                            const Real Tp = temp_arr(i, j, k) -
+                                            line_average_[navg_ * ind + T_avg_];
 
                             HostDevice::Atomic::Add(
                                 &line_fluctuation_[nfluc_ * ind + uu_],

--- a/amr-wind/utilities/PlaneAveraging.cpp
+++ b/amr-wind/utilities/PlaneAveraging.cpp
@@ -182,25 +182,42 @@ void PlaneAveraging::fill_line(
         auto den_arr = density.const_array(mfi);
         auto mueff_arr = mueff.const_array(mfi);
 
+        amrex::Box pbx =
+            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+
         amrex::ParallelFor(
-            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                const int ind = idxOp(i, j, k);
-                HostDevice::Atomic::Add(
-                    &line_average_[navg_ * ind + u_avg_],
-                    vel_arr(i, j, k, 0) * denom);
-                HostDevice::Atomic::Add(
-                    &line_average_[navg_ * ind + v_avg_],
-                    vel_arr(i, j, k, 1) * denom);
-                HostDevice::Atomic::Add(
-                    &line_average_[navg_ * ind + w_avg_],
-                    vel_arr(i, j, k, 2) * denom);
-                HostDevice::Atomic::Add(
-                    &line_average_[navg_ * ind + T_avg_],
-                    temp_arr(i, j, k, 0) * denom);
-                // nu+nut = (mu+mut)/rho
-                HostDevice::Atomic::Add(
-                    &line_average_[navg_ * ind + nu_avg_],
-                    mueff_arr(i, j, k) / den_arr(i, j, k) * denom);
+            pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k) noexcept {
+                // Loop over the direction perpendicular to the plane.
+                // This reduces the atomic pressure on the destination arrays.
+
+                amrex::Box lbx = ParallelBox<IndexSelector>(
+                    bx, amrex::IntVect{p_i, p_j, p_k});
+
+                for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
+                    for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
+                        for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i) {
+
+                            const int ind = idxOp(i, j, k);
+
+                            HostDevice::Atomic::Add(
+                                &line_average_[navg_ * ind + u_avg_],
+                                vel_arr(i, j, k, 0) * denom);
+                            HostDevice::Atomic::Add(
+                                &line_average_[navg_ * ind + v_avg_],
+                                vel_arr(i, j, k, 1) * denom);
+                            HostDevice::Atomic::Add(
+                                &line_average_[navg_ * ind + w_avg_],
+                                vel_arr(i, j, k, 2) * denom);
+                            HostDevice::Atomic::Add(
+                                &line_average_[navg_ * ind + T_avg_],
+                                temp_arr(i, j, k, 0) * denom);
+                            // nu+nut = (mu+mut)/rho
+                            HostDevice::Atomic::Add(
+                                &line_average_[navg_ * ind + nu_avg_],
+                                mueff_arr(i, j, k) / den_arr(i, j, k) * denom);
+                        }
+                    }
+                }
             });
     }
 
@@ -219,60 +236,89 @@ void PlaneAveraging::fill_line(
         auto vel_arr = velocity.const_array(mfi);
         auto temp_arr = temperature.const_array(mfi);
 
+        amrex::Box pbx =
+            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+
         amrex::ParallelFor(
-            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                const int ind = idxOp(i, j, k);
+            pbx, [=] AMREX_GPU_DEVICE(int p_i, int p_j, int p_k) noexcept {
+                // Loop over the direction perpendicular to the plane.
+                // This reduces the atomic pressure on the destination arrays.
 
-                // velocity fluctuation
-                const Real up =
-                    vel_arr(i, j, k, 0) - line_average_[navg_ * ind + u_avg_];
-                const Real vp =
-                    vel_arr(i, j, k, 1) - line_average_[navg_ * ind + v_avg_];
-                const Real wp =
-                    vel_arr(i, j, k, 2) - line_average_[navg_ * ind + w_avg_];
+                amrex::Box lbx = ParallelBox<IndexSelector>(
+                    bx, amrex::IntVect{p_i, p_j, p_k});
 
-                // temperature fluctuation
-                const Real Tp =
-                    temp_arr(i, j, k) - line_average_[navg_ * ind + T_avg_];
+                for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
+                    for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
+                        for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i) {
 
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + uu_], up * up * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + uv_], up * vp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + uw_], up * wp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + vv_], vp * vp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + vw_], vp * wp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + ww_], wp * wp * denom);
+                            const int ind = idxOp(i, j, k);
 
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + wuu_],
-                    wp * up * up * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + wuv_],
-                    wp * up * vp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + wuw_],
-                    wp * up * wp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + wvv_],
-                    wp * vp * vp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + wvw_],
-                    wp * vp * wp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + www_],
-                    wp * wp * wp * denom);
+                            // velocity fluctuation
+                            const Real up =
+                                vel_arr(i, j, k, 0) -
+                                line_average_[navg_ * ind + u_avg_];
+                            const Real vp =
+                                vel_arr(i, j, k, 1) -
+                                line_average_[navg_ * ind + v_avg_];
+                            const Real wp =
+                                vel_arr(i, j, k, 2) -
+                                line_average_[navg_ * ind + w_avg_];
 
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + Tu_], Tp * up * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + Tv_], Tp * vp * denom);
-                HostDevice::Atomic::Add(
-                    &line_fluctuation_[nfluc_ * ind + Tw_], Tp * wp * denom);
+                            // temperature fluctuation
+                            const Real Tp =
+                                temp_arr(i, j, k) -
+                                line_average_[navg_ * ind + T_avg_];
+
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + uu_],
+                                up * up * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + uv_],
+                                up * vp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + uw_],
+                                up * wp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + vv_],
+                                vp * vp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + vw_],
+                                vp * wp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + ww_],
+                                wp * wp * denom);
+
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + wuu_],
+                                wp * up * up * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + wuv_],
+                                wp * up * vp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + wuw_],
+                                wp * up * wp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + wvv_],
+                                wp * vp * vp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + wvw_],
+                                wp * vp * wp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + www_],
+                                wp * wp * wp * denom);
+
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + Tu_],
+                                Tp * up * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + Tv_],
+                                Tp * vp * denom);
+                            HostDevice::Atomic::Add(
+                                &line_fluctuation_[nfluc_ * ind + Tw_],
+                                Tp * wp * denom);
+                        }
+                    }
+                }
             });
     }
 


### PR DESCRIPTION
Extends the approach from #296 to the remainder of the plane averages. A typical speedup for the updated kernels is 2.5x for a large box on V100.