### PR TITLE
Move cppcheck to cmake target

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-readability-identifier-naming,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-isolate-declaration''
+Checks:          'clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-isolate-declaration''
 WarningsAsErrors: ''
 HeaderFilterRegex: '^((?!/amrex/Src/|/googletest/).)*$'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,6 @@
 ---
-#Checks:          '*,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-braces-around-statements,-fuchsia-default-arguments,-fuchsia-default-arguments-calls,-fuchsia-overloaded-operator,-fuchsia-statically-constructed-objects,-google-runtime-references,-hicpp-no-assembler,-llvm-include-order,-llvmlibc-callee-namespace,-llvmlibc-implementation-in-namespace,-llvmlibc-restrict-system-libc-headers'
-Checks:          'clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-readability-identifier-naming,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-isolate-declaration''
 WarningsAsErrors: ''
-#HeaderFilterRegex: '^.*/(AMReX)/.*\.H$'
 HeaderFilterRegex: '^((?!/amrex/Src/|/googletest/).)*$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none

--- a/.github/problem-matchers/cppcheck.json
+++ b/.github/problem-matchers/cppcheck.json
@@ -1,0 +1,18 @@
+{
+     "__comment": "Modified from vscode-cpptools's Extension/package.json gcc rule",
+     "problemMatcher": [
+         {
+             "owner": "gcc-problem-matcher",
+             "pattern": [
+                 {
+                     "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(error|performance|portability|style|warning):\\s+(.*)$",
+                     "file": 1,
+                     "line": 2,
+                     "column": 3,
+                     "severity": 4,
+                     "message": 5
+                 }
+             ]
+         }
+     ]
+} 

--- a/.github/problem-matchers/cppcheck.json
+++ b/.github/problem-matchers/cppcheck.json
@@ -2,7 +2,7 @@
      "__comment": "Modified from vscode-cpptools's Extension/package.json gcc rule",
      "problemMatcher": [
          {
-             "owner": "gcc-problem-matcher",
+             "owner": "cppcheck-problem-matcher",
              "pattern": [
                  {
                      "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(error|performance|portability|style|warning):\\s+(.*)$",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
           ${{github.workspace}}
       - name: Check
         working-directory: build-cppcheck
-        run: make cppcheck
+        run: make cppcheck-ci
       - name: Full report
         working-directory: build-cppcheck
         run: cat cppcheck/cppcheck-full-report.txt
@@ -56,7 +56,7 @@ jobs:
         working-directory: build-cppcheck
         run: |
           echo "::add-matcher::.github/problem-matchers/cppcheck.json"
-          cat cppcheck-warnings.txt
+          cat cppcheck-ci-report.txt
   clang-tidy:
     runs-on: ubuntu-latest
     steps:
@@ -89,8 +89,8 @@ jobs:
         working-directory: build-clang-tidy
         run: |
           cmake --build . --parallel ${{env.NPROCS}} 2> clang-tidy-full-report.txt
-          cat clang-tidy-full-report.txt | grep "warning:" | grep -v "submods" | sort | uniq -c | sort -nr | \
-            awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-warnings.txt
+          cat clang-tidy-full-report.txt | grep "warning:" | grep -v "submods" | sort | uniq | sort -nr | \
+            awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-ci-report.txt
       - name: Full report
         working-directory: build-clang-tidy
         run: cat clang-tidy-full-report.txt
@@ -98,4 +98,4 @@ jobs:
         working-directory: build-clang-tidy
         run: |
           echo "::add-matcher::.github/problem-matchers/gcc.json"
-          cat clang-tidy-warnings.txt
+          cat clang-tidy-ci-report.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,33 +44,18 @@ jobs:
           -DAMR_WIND_ENABLE_TESTS:BOOL=ON \
           -DAMR_WIND_TEST_WITH_FCOMPARE:BOOL=OFF \
           -DAMR_WIND_ENABLE_MASA:BOOL=OFF \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+          -DAMR_WIND_ENABLE_CPPCHECK:BOOL=OFF \
           ${{github.workspace}}
       - name: Check
         working-directory: build-cppcheck
-        run: |
-          # Using a working directory for cppcheck makes analysis faster
-          mkdir cppcheck-wd
-          # Cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
-          sed -i '' -e 's/isystem /I/g' compile_commands.json
-          cppcheck --inline-suppr \
-            --suppress=unmatchedSuppression --suppress=syntaxError --suppress=internalAstError \
-            --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=compile_commands.json \
-            -j ${{env.NPROCS}} --cppcheck-build-dir=cppcheck-wd -i ${{github.workspace}}/submods/amrex/Src \
-            -i ${{github.workspace}}/submods/googletest --output-file=cppcheck.txt
-          # Warnings in header files are unavoidable, so we filter out submodule headers after analysis
-          # Might be wrong to assume cppcheck always reports issues using 3 lines
-           awk -v nlines=2 '/submods\/amrex/ || /submods\/googletest/ {for (i=0; i<nlines; i++) {getline}; next} 1' \
-            < cppcheck.txt > cppcheck-warnings.txt
+        run: make cppcheck
+      - name: Full report
+        working-directory: build-cppcheck
+        run: cat cppcheck/cppcheck-full-report.txt
       - name: Short report
         working-directory: build-cppcheck
         run: |
-          cat cppcheck-warnings.txt | egrep 'error:|performance:|portability:|style:|warning:' | sort | \
-            awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}'
-      - name: Full report
-        working-directory: build-cppcheck
-        run: |
-          echo "::add-matcher::.github/problem-matchers/gcc.json"
+          echo "::add-matcher::.github/problem-matchers/cppcheck.json"
           cat cppcheck-warnings.txt
   clang-tidy:
     runs-on: ubuntu-latest
@@ -99,17 +84,17 @@ jobs:
           -DAMR_WIND_ENABLE_MASA:BOOL=OFF \
           -DAMR_WIND_ENABLE_ALL_WARNINGS:BOOL=OFF \
           -DAMR_WIND_ENABLE_CLANG_TIDY:BOOL=ON \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
           ${{github.workspace}}
       - name: Check
         working-directory: build-clang-tidy
-        run: cmake --build . -- -j ${{env.NPROCS}} 2> clang-tidy-warnings.txt
-      - name: Short report
-        working-directory: build-clang-tidy
         run: |
-          cat clang-tidy-warnings.txt | grep "warning:" | sort | \
-            awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}'
+          cmake --build . --parallel ${{env.NPROCS}} 2> clang-tidy-full-report.txt
+          cat clang-tidy-full-report.txt | grep "warning:" | grep -v "submods" | sort | uniq -c | sort -nr | \
+            awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-warnings.txt
       - name: Full report
+        working-directory: build-clang-tidy
+        run: cat clang-tidy-full-report.txt
+      - name: Short report
         working-directory: build-clang-tidy
         run: |
           #echo "::add-matcher::.github/problem-matchers/gcc.json"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,5 +97,5 @@ jobs:
       - name: Short report
         working-directory: build-clang-tidy
         run: |
-          #echo "::add-matcher::.github/problem-matchers/gcc.json"
+          echo "::add-matcher::.github/problem-matchers/gcc.json"
           cat clang-tidy-warnings.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           -DAMR_WIND_ENABLE_TESTS:BOOL=ON \
           -DAMR_WIND_TEST_WITH_FCOMPARE:BOOL=OFF \
           -DAMR_WIND_ENABLE_MASA:BOOL=OFF \
-          -DAMR_WIND_ENABLE_CPPCHECK:BOOL=OFF \
+          -DAMR_WIND_ENABLE_CPPCHECK:BOOL=ON \
           ${{github.workspace}}
       - name: Check
         working-directory: build-cppcheck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(amr-wind-utils)
 option(AMR_WIND_ENABLE_ALL_WARNINGS "Show most warnings for most compilers" ON)
 option(AMR_WIND_ENABLE_WERROR "Treat compiler warnings as errors" OFF)
 option(AMR_WIND_ENABLE_CLANG_TIDY "Compile with clang-tidy static analysis" OFF)
+option(AMR_WIND_ENABLE_CPPCHECK "Enable cppcheck static analysis target" OFF)
 option(AMR_WIND_ENABLE_FCOMPARE "Enable building fcompare when not testing" OFF)
 
 #Enabling tests overrides the executable options
@@ -77,7 +78,7 @@ message(STATUS "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
-include(${CMAKE_SOURCE_DIR}/cmake/set_rpath.cmake)
+include(set_rpath)
 
 #Create target names
 set(amr_wind_lib_name "amrwind_obj")
@@ -90,13 +91,13 @@ add_library(${amr_wind_lib_name} OBJECT)
 add_library(${aw_api_lib} SHARED)
 add_executable(${amr_wind_exe_name})
 
-init_clang_tidy()
+init_code_checks()
 if(CLANG_TIDY_EXE)
   set_target_properties(${amr_wind_lib_name} ${aw_api_lib} ${amr_wind_exe_name}
                         PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
 endif()
 
-include(${CMAKE_SOURCE_DIR}/cmake/set_compile_flags.cmake)
+include(set_compile_flags)
 
 if (AMR_WIND_ENABLE_NETCDF)
   set(CMAKE_PREFIX_PATH ${NETCDF_DIR} ${CMAKE_PREFIX_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 cmake_minimum_required (VERSION 3.14 FATAL_ERROR)
 project(AMR-Wind CXX C)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -84,8 +84,8 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E echo "Running cppcheck on project using ${NP} cores..."
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
-          COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
+          COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck/cppcheck_compile_commands.json
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck/cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
           # Filter out submodule source files after analysis
           COMMAND awk -v nlines=2 "/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
           COMMAND cat cppcheck/cppcheck-short-report.txt | egrep "information:|error:|performance:|portability:|style:|warning:" | sort > cppcheck-warnings.txt

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -84,18 +84,26 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E echo "Running cppcheck on project using ${NP} cores..."
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
-          COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck/cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck/cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
-          # Filter out submodule source files after analysis
-          COMMAND awk -v nlines=2 "/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
-          COMMAND cat cppcheck/cppcheck-short-report.txt | egrep "information:|error:|performance:|portability:|style:|warning:" | sort > cppcheck-warnings.txt
-          COMMAND printf "Warnings: " >> cppcheck-warnings.txt
-          COMMAND cat cppcheck-warnings.txt | awk "END{print NR-1}" >> cppcheck-warnings.txt
+          COMMAND sed "s/isystem /I/g" ${CMAKE_BINARY_DIR}/compile_commands.json > cppcheck_compile_commands.json
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
           COMMENT "Run cppcheck on project compile_commands.json"
-          BYPRODUCTS cppcheck-warnings.txt
-          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          BYPRODUCTS cppcheck-full-report.txt
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck
           VERBATIM USES_TERMINAL
       )
+      add_custom_target(cppcheck-ci
+          # Filter out submodule source files after analysis
+          COMMAND awk -v nlines=2 "/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
+          COMMAND cat cppcheck/cppcheck-short-report.txt | egrep "information:|error:|performance:|portability:|style:|warning:" | sort > cppcheck-ci-report.txt
+          COMMAND printf "Warnings: " >> cppcheck-ci-report.txt
+          COMMAND cat cppcheck-ci-report.txt | awk "END{print NR-1}" >> cppcheck-ci-report.txt
+          COMMENT "Filter cppcheck results to only AMR-Wind files with results in cppcheck-ci-report.txt"
+          DEPENDS cppcheck
+          BYPRODUCTS cppcheck-ci-report.txt
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          VERBATIM
+      )
+
     else()
       message(WARNING "cppcheck not found.")
     endif()

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -61,7 +61,7 @@ macro(init_amrex)
   endif()
 endmacro(init_amrex)
 
-macro(init_clang_tidy)
+macro(init_code_checks)
   if(AMR_WIND_ENABLE_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
     if(CLANG_TIDY_EXE)
@@ -70,4 +70,33 @@ macro(init_clang_tidy)
       message(WARNING "clang-tidy not found.")
     endif()
   endif()
-endmacro(init_clang_tidy)
+
+  if(AMR_WIND_ENABLE_CPPCHECK)
+    find_program(CPPCHECK_EXE NAMES "cppcheck")
+    if(CPPCHECK_EXE)
+      message(STATUS "cppcheck found: ${CPPCHECK_EXE}")
+      include(ProcessorCount)
+      ProcessorCount(NP)
+      if(NP EQUAL 0)
+        set(NP 1)
+      endif()
+      add_custom_target(cppcheck
+          COMMAND ${CMAKE_COMMAND} -E echo "Running cppcheck on project using ${NP} cores..."
+          COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd
+          # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
+          COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck_compile_commands.json
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
+          COMMAND awk -v nlines=2 "/submods\/amrex/ || /submods\/googletest/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
+          COMMAND cat cppcheck/cppcheck-short-report.txt | egrep "information:|error:|performance:|portability:|style:|warning:" | sort > cppcheck-warnings.txt
+          COMMAND printf "Warnings: " >> cppcheck-warnings.txt
+          COMMAND cat cppcheck-warnings.txt | awk "END{print NR-1}" >> cppcheck-warnings.txt
+          COMMENT "Run cppcheck on project compile_commands.json"
+          BYPRODUCTS cppcheck-warnings.txt
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          VERBATIM USES_TERMINAL
+      )
+    else()
+      message(WARNING "cppcheck not found.")
+    endif()
+  endif()
+endmacro(init_code_checks)

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -86,7 +86,8 @@ macro(init_code_checks)
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" compile_commands.json > cppcheck_compile_commands.json
           COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck/cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck/cppcheck-full-report.txt -j ${NP}
-          COMMAND awk -v nlines=2 "/submods\/amrex/ || /submods\/googletest/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
+          # Filter out submodule source files after analysis
+          COMMAND awk -v nlines=2 "/submods/ {for (i=0; i<nlines; i++) {getline}; next} 1" < cppcheck/cppcheck-full-report.txt > cppcheck/cppcheck-short-report.txt
           COMMAND cat cppcheck/cppcheck-short-report.txt | egrep "information:|error:|performance:|portability:|style:|warning:" | sort > cppcheck-warnings.txt
           COMMAND printf "Warnings: " >> cppcheck-warnings.txt
           COMMAND cat cppcheck-warnings.txt | awk "END{print NR-1}" >> cppcheck-warnings.txt

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -80,6 +80,7 @@ macro(init_code_checks)
       if(NP EQUAL 0)
         set(NP 1)
       endif()
+      file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck)
       add_custom_target(cppcheck
           COMMAND ${CMAKE_COMMAND} -E echo "Running cppcheck on project using ${NP} cores..."
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd


### PR DESCRIPTION
I would like to make it easier for users to run these new checks locally. Once we settle on a method, I will write some documentation. I will also start addressing `clang-tidy` warnings with some PRs and automatic fixes.

- Move cppcheck to a cmake target
- Update CI accordingly
- Add cppcheck-specific problem matcher
- Reduce a few clang-tidy checks while I address issues
- Generate `compile_commands.json` by default