### PR TITLE
Actuator model prototype (5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(AMR_WIND_USE_INTERNAL_AMREX "Add AMReX as subproject" ON)
 option(AMR_WIND_ENABLE_NETCDF "Enable NetCDF library" OFF)
 option(AMR_WIND_ENABLE_MASA "Enable MASA library" OFF)
 option(AMR_WIND_ENABLE_HYPRE "Enable HYPRE integration" OFF)
+option(AMR_WIND_ENABLE_OPENFAST "Enable OpenFAST integration" OFF)
 
 #Options for C++
 set(CMAKE_CXX_STANDARD 14)
@@ -61,6 +62,10 @@ endif()
 
 if(AMR_WIND_TEST_WITH_FCOMPARE)
   set(AMR_WIND_ENABLE_FCOMPARE ON)
+endif()
+
+if (AMR_WIND_ENABLE_OPENFAST)
+  enable_language(Fortran)
 endif()
 
 ########################### AMReX #####################################

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -15,6 +15,7 @@ namespace amr_wind {
 class IOManager;
 class PostProcessManager;
 class OversetManager;
+class ExtSolverMgr;
 
 namespace turbulence {
 class TurbulenceModel;
@@ -88,6 +89,9 @@ public:
         return m_overset_mgr.get();
     }
 
+    ExtSolverMgr& ext_solver_manager() { return *m_ext_solver_mgr; }
+    const ExtSolverMgr& ext_solver_manager() const { return *m_ext_solver_mgr; }
+
     bool has_overset() const { return static_cast<bool>(m_overset_mgr); }
 
     //! Instantiate the turbulence model based on user inputs
@@ -117,6 +121,8 @@ private:
     std::unique_ptr<PostProcessManager> m_post_mgr;
 
     std::unique_ptr<OversetManager> m_overset_mgr;
+
+    std::unique_ptr<ExtSolverMgr> m_ext_solver_mgr;
 };
 
 } // namespace amr_wind

--- a/amr-wind/CFDSim.cpp
+++ b/amr-wind/CFDSim.cpp
@@ -3,6 +3,7 @@
 #include "amr-wind/utilities/IOManager.H"
 #include "amr-wind/utilities/PostProcessing.H"
 #include "amr-wind/overset/OversetManager.H"
+#include "amr-wind/core/ExtSolver.H"
 
 #ifdef AMREX_USE_DPCPP
 #include "amr-wind/turbulence/turbulence_utils.H"
@@ -19,6 +20,7 @@ CFDSim::CFDSim(amrex::AmrCore& mesh)
     , m_pde_mgr(*this)
     , m_io_mgr(new IOManager(*this))
     , m_post_mgr(new PostProcessManager(*this))
+    , m_ext_solver_mgr(new ExtSolverMgr)
 {}
 
 CFDSim::~CFDSim() = default;

--- a/amr-wind/core/ExtSolver.H
+++ b/amr-wind/core/ExtSolver.H
@@ -1,0 +1,39 @@
+#ifndef EXTSOLVER_H
+#define EXTSOLVER_H
+
+#include "amr-wind/core/Factory.H"
+#include "amr-wind/core/CollMgr.H"
+
+namespace amr_wind {
+
+class CFDSim;
+
+class ExtSolver : public Factory<ExtSolver, CFDSim&>
+{
+public:
+    static std::string base_identifier() { return "ExtSolver"; }
+
+    virtual ~ExtSolver() = default;
+};
+
+class ExtSolverMgr : public CollMgr<ExtSolverMgr, ExtSolver>
+{
+public:
+    template <typename T>
+    T& get()
+    {
+        AMREX_ASSERT(contains(T::identifier()));
+        return dynamic_cast<T&>(operator()(T::identifier()));
+    }
+
+    template <typename T>
+    const T& get() const
+    {
+        AMREX_ASSERT(contains(T::identifier()));
+        return dynamic_cast<const T&>(operator()(T::identifier()));
+    }
+};
+
+} // namespace amr_wind
+
+#endif /* EXTSOLVER_H */

--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -109,6 +109,18 @@ public:
     AMREX_FORCE_INLINE
     int regrid_interval() const { return m_regrid_interval; }
 
+    AMREX_FORCE_INLINE
+    amrex::Real start_time() const { return m_start_time; }
+
+    AMREX_FORCE_INLINE
+    amrex::Real stop_time() const { return m_stop_time; }
+
+    AMREX_FORCE_INLINE
+    int start_time_index() const { return m_start_time_index; }
+
+    AMREX_FORCE_INLINE
+    int stop_time_index() const { return m_stop_time_index; }
+
     //! Read user defined options from input file
     void parse_parameters();
 

--- a/amr-wind/core/Slice.H
+++ b/amr-wind/core/Slice.H
@@ -11,8 +11,23 @@ namespace utils {
 template <typename T>
 struct Slice
 {
-    T* ptr_begin;
-    T* ptr_end;
+    using value_type = T;
+    using size_t = std::size_t;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = T&;
+    using pointer = T*;
+    using iterator = T*;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reference = const T&;
+    using const_pointer = const T*;
+    using const_iterator = const T*;
+    using const_reverse_iterator = const std::reverse_iterator<iterator>;
+
+    pointer ptr_begin;
+    pointer ptr_end;
+
+    explicit Slice() : ptr_begin(nullptr), ptr_end(nullptr) {}
 
     explicit Slice(T* pbegin, const size_t n)
         : ptr_begin(pbegin), ptr_end(pbegin + n)
@@ -20,27 +35,28 @@ struct Slice
 
     explicit Slice(T* pbegin, T* pend) : ptr_begin(pbegin), ptr_end(pend) {}
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](const size_t idx)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE reference
+    operator[](const size_t idx)
     {
         return *(ptr_begin + idx);
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T&
-    operator[](const size_t idx) const
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const_reference
+    operator[](const size_type idx) const
     {
         return *(ptr_begin + idx);
     }
 
-    size_t size() const { return std::distance(ptr_begin, ptr_end); }
+    size_type size() const { return (ptr_end - ptr_begin); }
 
-    T* data() { return ptr_begin; }
-    T* begin() { return ptr_begin; }
-    T* end() { return ptr_end; }
-    const T* data() const { return ptr_begin; }
-    const T* begin() const { return ptr_begin; }
-    const T* end() const { return ptr_end; }
-    const T* cbegin() const { return ptr_begin; }
-    const T* cend() const { return ptr_end; }
+    pointer data() { return ptr_begin; }
+    iterator begin() { return ptr_begin; }
+    iterator end() { return ptr_end; }
+    const_iterator data() const { return ptr_begin; }
+    const_iterator begin() const { return ptr_begin; }
+    const_iterator end() const { return ptr_end; }
+    const_iterator cbegin() const { return ptr_begin; }
+    const_iterator cend() const { return ptr_end; }
 };
 
 template <typename T>

--- a/amr-wind/utilities/ncutils/nc_interface.H
+++ b/amr-wind/utilities/ncutils/nc_interface.H
@@ -19,6 +19,17 @@
 
 namespace ncutils {
 
+//! Wrapper around NetCDF data types
+struct NCDType
+{
+    static constexpr nc_type Int = NC_INT;
+#ifdef AMREX_USE_FLOAT
+    static constexpr nc_type Real = NC_FLOAT;
+#else
+    static constexpr nc_type Real = NC_DOUBLE;
+#endif
+};
+
 //! Representation of NetCDF dimension
 struct NCDim
 {
@@ -55,6 +66,7 @@ struct NCVar
 
     //! Write out the entire variable
     void put(const double*) const;
+    void put(const float*) const;
     void put(const int*) const;
 
     //! Write out a slice of data
@@ -70,6 +82,19 @@ struct NCVar
         const std::vector<size_t>&,
         const std::vector<size_t>&,
         const std::vector<ptrdiff_t>&) const;
+    //! Write out a slice of data
+    void
+    put(const float*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&) const;
+
+    //! Write out a slice of data with with strides (see hyperslab definition in
+    //! NetCDF)
+    void
+    put(const float*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&,
+        const std::vector<ptrdiff_t>&) const;
     void put(const int*, const std::vector<size_t>&, const std::vector<size_t>&)
         const;
     void
@@ -80,6 +105,7 @@ struct NCVar
 
     //! Read the entire variable from file
     void get(double*) const;
+    void get(float*) const;
     void get(int*) const;
 
     //! Read a chunk of data from the file
@@ -89,6 +115,17 @@ struct NCVar
     //! Read a chunk of data with strides
     void
     get(double*,
+        const std::vector<size_t>&,
+        const std::vector<size_t>&,
+        const std::vector<ptrdiff_t>&) const;
+
+    //! Read a chunk of data from the file
+    void
+    get(float*, const std::vector<size_t>&, const std::vector<size_t>&) const;
+
+    //! Read a chunk of data with strides
+    void
+    get(float*,
         const std::vector<size_t>&,
         const std::vector<size_t>&,
         const std::vector<ptrdiff_t>&) const;
@@ -105,10 +142,13 @@ struct NCVar
     void put_attr(const std::string& name, const std::string& value) const;
     void
     put_attr(const std::string& name, const std::vector<double>& value) const;
+    void
+    put_attr(const std::string& name, const std::vector<float>& value) const;
     void put_attr(const std::string& name, const std::vector<int>& value) const;
 
     std::string get_attr(const std::string& name) const;
     void get_attr(const std::string& name, std::vector<double>& value) const;
+    void get_attr(const std::string& name, std::vector<float>& value) const;
     void get_attr(const std::string& name, std::vector<int>& value) const;
     void par_access(const int cmode) const;
 };
@@ -201,10 +241,13 @@ public:
     void put_attr(const std::string& name, const std::string& value) const;
     void
     put_attr(const std::string& name, const std::vector<double>& value) const;
+    void
+    put_attr(const std::string& name, const std::vector<float>& value) const;
     void put_attr(const std::string& name, const std::vector<int>& value) const;
 
     std::string get_attr(const std::string& name) const;
     void get_attr(const std::string& name, std::vector<double>& value) const;
+    void get_attr(const std::string& name, std::vector<float>& value) const;
     void get_attr(const std::string& name, std::vector<int>& value) const;
 
     //! Return a list of all groups defined in this group

--- a/amr-wind/utilities/ncutils/nc_interface.cpp
+++ b/amr-wind/utilities/ncutils/nc_interface.cpp
@@ -67,6 +67,11 @@ void NCVar::put(const double* ptr) const
     check_nc_error(nc_put_var_double(ncid, varid, ptr));
 }
 
+void NCVar::put(const float* ptr) const
+{
+    check_nc_error(nc_put_var_float(ncid, varid, ptr));
+}
+
 void NCVar::put(const int* ptr) const
 {
     check_nc_error(nc_put_var_int(ncid, varid, ptr));
@@ -89,6 +94,25 @@ void NCVar::put(
 {
     check_nc_error(nc_put_vars_double(
         ncid, varid, start.data(), count.data(), stride.data(), dptr));
+}
+
+void NCVar::put(
+    const float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count) const
+{
+    check_nc_error(
+        nc_put_vara_float(ncid, varid, start.data(), count.data(), dptr));
+}
+
+void NCVar::put(
+    const float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count,
+    const std::vector<ptrdiff_t>& stride) const
+{
+    check_nc_error(nc_put_vars_float(
+                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::put(
@@ -115,6 +139,11 @@ void NCVar::get(double* ptr) const
     check_nc_error(nc_get_var_double(ncid, varid, ptr));
 }
 
+void NCVar::get(float* ptr) const
+{
+    check_nc_error(nc_get_var_float(ncid, varid, ptr));
+}
+
 void NCVar::get(int* ptr) const
 {
     check_nc_error(nc_get_var_int(ncid, varid, ptr));
@@ -137,6 +166,25 @@ void NCVar::get(
 {
     check_nc_error(nc_get_vars_double(
         ncid, varid, start.data(), count.data(), stride.data(), dptr));
+}
+
+void NCVar::get(
+    float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count) const
+{
+    check_nc_error(
+        nc_get_vara_float(ncid, varid, start.data(), count.data(), dptr));
+}
+
+void NCVar::get(
+    float* dptr,
+    const std::vector<size_t>& start,
+    const std::vector<size_t>& count,
+    const std::vector<ptrdiff_t>& stride) const
+{
+    check_nc_error(nc_get_vars_float(
+                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::get(
@@ -180,6 +228,13 @@ void NCVar::put_attr(
 }
 
 void NCVar::put_attr(
+    const std::string& name, const std::vector<float>& value) const
+{
+    check_nc_error(nc_put_att_float(
+                       ncid, varid, name.data(), NC_FLOAT, value.size(), value.data()));
+}
+
+void NCVar::put_attr(
     const std::string& name, const std::vector<int>& value) const
 {
     check_nc_error(nc_put_att_int(
@@ -202,6 +257,14 @@ void NCVar::get_attr(const std::string& name, std::vector<double>& values) const
     check_nc_error(nc_inq_attlen(ncid, varid, name.data(), &lenp));
     values.resize(lenp);
     check_nc_error(nc_get_att_double(ncid, varid, name.data(), values.data()));
+}
+
+void NCVar::get_attr(const std::string& name, std::vector<float>& values) const
+{
+    size_t lenp;
+    check_nc_error(nc_inq_attlen(ncid, varid, name.data(), &lenp));
+    values.resize(lenp);
+    check_nc_error(nc_get_att_float(ncid, varid, name.data(), values.data()));
 }
 
 void NCVar::get_attr(const std::string& name, std::vector<int>& values) const
@@ -362,6 +425,13 @@ void NCGroup::put_attr(
 }
 
 void NCGroup::put_attr(
+    const std::string& name, const std::vector<float>& value) const
+{
+    check_nc_error(nc_put_att_float(
+        ncid, NC_GLOBAL, name.data(), NC_FLOAT, value.size(), value.data()));
+}
+
+void NCGroup::put_attr(
     const std::string& name, const std::vector<int>& value) const
 {
     check_nc_error(nc_put_att_int(
@@ -386,6 +456,16 @@ void NCGroup::get_attr(
     values.resize(lenp);
     check_nc_error(
         nc_get_att_double(ncid, NC_GLOBAL, name.data(), values.data()));
+}
+
+void NCGroup::get_attr(
+    const std::string& name, std::vector<float>& values) const
+{
+    size_t lenp;
+    check_nc_error(nc_inq_attlen(ncid, NC_GLOBAL, name.data(), &lenp));
+    values.resize(lenp);
+    check_nc_error(
+        nc_get_att_float(ncid, NC_GLOBAL, name.data(), values.data()));
 }
 
 void NCGroup::get_attr(const std::string& name, std::vector<int>& values) const

--- a/amr-wind/utilities/ncutils/nc_interface.cpp
+++ b/amr-wind/utilities/ncutils/nc_interface.cpp
@@ -112,7 +112,7 @@ void NCVar::put(
     const std::vector<ptrdiff_t>& stride) const
 {
     check_nc_error(nc_put_vars_float(
-                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
+        ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::put(
@@ -184,7 +184,7 @@ void NCVar::get(
     const std::vector<ptrdiff_t>& stride) const
 {
     check_nc_error(nc_get_vars_float(
-                       ncid, varid, start.data(), count.data(), stride.data(), dptr));
+        ncid, varid, start.data(), count.data(), stride.data(), dptr));
 }
 
 void NCVar::get(
@@ -231,7 +231,7 @@ void NCVar::put_attr(
     const std::string& name, const std::vector<float>& value) const
 {
     check_nc_error(nc_put_att_float(
-                       ncid, varid, name.data(), NC_FLOAT, value.size(), value.data()));
+        ncid, varid, name.data(), NC_FLOAT, value.size(), value.data()));
 }
 
 void NCVar::put_attr(

--- a/amr-wind/wind_energy/actuator/ActParser.H
+++ b/amr-wind/wind_energy/actuator/ActParser.H
@@ -25,6 +25,11 @@ public:
     const amrex::ParmParse& default_params() const { return pp_default; }
     const amrex::ParmParse& params() const { return pp; }
 
+    bool contains(const std::string& name) const
+    {
+        return pp.contains(name.c_str()) || pp_default.contains(name.c_str());
+    }
+
     //! Provide special accessor for obtaining vectors from ParmParse namespaces
     void get(const std::string& name, vs::Vector& value) const
     {

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -61,8 +61,7 @@ void Actuator::post_init_actions()
         AMREX_ALWAYS_ASSERT(num_actuators() == nact);
     }
 
-    for (auto& act : m_actuators)
-        act->init_actuator_source();
+    for (auto& act : m_actuators) act->init_actuator_source();
 
     setup_container();
     update_positions();

--- a/amr-wind/wind_energy/actuator/ActuatorModel.H
+++ b/amr-wind/wind_energy/actuator/ActuatorModel.H
@@ -39,7 +39,9 @@ public:
 
     virtual void read_inputs(const utils::ActParser&) = 0;
 
-    virtual void setup_actuator_source(amrex::Vector<int>&) = 0;
+    virtual void determine_influenced_procs(amrex::Vector<int>&) = 0;
+
+    virtual void init_actuator_source() = 0;
 
     virtual int num_velocity_points() const = 0;
 
@@ -116,7 +118,8 @@ public:
         m_out_op.read_io_options(pp);
     }
 
-    void setup_actuator_source(amrex::Vector<int>& act_proc_count) override;
+    void
+    determine_influenced_procs(amrex::Vector<int>& act_proc_count) override;
 
     int num_velocity_points() const override;
 
@@ -153,10 +156,16 @@ public:
     }
 
     void write_outputs() override { m_out_op.write_outputs(); }
+
+    void init_actuator_source() override
+    {
+        ops::InitDataOp<ActTrait, SrcTrait>()(m_data);
+        m_src_op.initialize();
+    }
 };
 
 template <typename ActTrait, typename SrcTrait>
-void ActModel<ActTrait, SrcTrait>::setup_actuator_source(
+void ActModel<ActTrait, SrcTrait>::determine_influenced_procs(
     amrex::Vector<int>& act_proc_count)
 {
     ops::determine_root_proc<ActTrait>(m_data, act_proc_count);
@@ -167,8 +176,6 @@ void ActModel<ActTrait, SrcTrait>::setup_actuator_source(
         AMREX_ALWAYS_ASSERT(info.root_proc > -1);
         AMREX_ALWAYS_ASSERT(plist.find(info.root_proc) != plist.end());
     }
-    ops::InitDataOp<ActTrait, SrcTrait>()(m_data);
-    m_src_op.initialize();
 }
 
 template <typename ActTrait, typename SrcTrait>
@@ -177,7 +184,7 @@ int ActModel<ActTrait, SrcTrait>::num_velocity_points() const
     auto& info = m_data.info();
     auto& grid = m_data.grid();
 
-    return (info.actuator_in_proc) ? grid.vel.size() : 0;
+    return (info.sample_vel_in_proc) ? grid.vel.size() : 0;
 }
 
 } // namespace actuator

--- a/amr-wind/wind_energy/actuator/CMakeLists.txt
+++ b/amr-wind/wind_energy/actuator/CMakeLists.txt
@@ -8,3 +8,4 @@ target_sources(${amr_wind_lib_name}
 
 add_subdirectory(aero)
 add_subdirectory(wing)
+add_subdirectory(turbine)

--- a/amr-wind/wind_energy/actuator/actuator_opsI.H
+++ b/amr-wind/wind_energy/actuator/actuator_opsI.H
@@ -34,50 +34,11 @@ void determine_root_proc(
     typename T::DataType& data, amrex::Vector<int>& act_proc_count)
 {
     auto& info = data.info();
-    auto& plist = info.procs;
-    bool assigned = false;
 
-    plist =
+    info.procs =
         utils::determine_influenced_procs(data.sim().mesh(), info.bound_box);
 
-    // If any of the influenced procs is free (i.e., doesn't have a turbine
-    // assigned to it) elect it as the root proc for this turbine and return
-    // early.
-    for (auto ip : plist) {
-        if (act_proc_count[ip] < 1) {
-            info.root_proc = ip;
-            ++act_proc_count[ip];
-            assigned = true;
-            break;
-        }
-    }
-
-    // If we found a root proc there is nothing more to do, so return early
-    if (assigned) {
-        const int iproc = amrex::ParallelDescriptor::MyProc();
-        auto in_proc = info.procs.find(iproc);
-        info.actuator_in_proc = (in_proc != info.procs.end());
-        return;
-    }
-
-    // If we have reached here, then we have more turbines than processes
-    // available. We will assign the current turbine to the process that is
-    // managing the lowest number of turbines.
-
-    // Determine the MPI rank that contains the fewest turbines
-    auto it = std::min_element(act_proc_count.begin(), act_proc_count.end());
-    // Make it the root process for this turbine
-    info.root_proc = std::distance(act_proc_count.begin(), it);
-    // Make sure the root process is part of the process list
-    plist.insert(info.root_proc);
-    // Increment turbine count with the global tracking array
-    ++(*it);
-
-    {
-        const int iproc = amrex::ParallelDescriptor::MyProc();
-        auto in_proc = info.procs.find(iproc);
-        info.actuator_in_proc = (in_proc != info.procs.end());
-    }
+    utils::determine_root_proc(data.info(), act_proc_count);
 }
 
 } // namespace ops

--- a/amr-wind/wind_energy/actuator/actuator_types.H
+++ b/amr-wind/wind_energy/actuator/actuator_types.H
@@ -57,9 +57,11 @@ struct ActSrcDisk : ActSrcType
 };
 
 using RealList = amrex::Vector<amrex::Real>;
+using RealSlice = ::amr_wind::utils::Slice<amrex::Real>;
 using VecList = amrex::Vector<amr_wind::vs::Vector>;
-using VecSlice = utils::Slice<amr_wind::vs::Vector>;
+using VecSlice = ::amr_wind::utils::Slice<amr_wind::vs::Vector>;
 using TensorList = amrex::Vector<amr_wind::vs::Tensor>;
+using TensorSlice = ::amr_wind::utils::Slice<amr_wind::vs::Tensor>;
 using DeviceVecList = amrex::Gpu::DeviceVector<amr_wind::vs::Vector>;
 using DeviceTensorList = amrex::Gpu::DeviceVector<amr_wind::vs::Tensor>;
 
@@ -130,9 +132,16 @@ struct ActInfo
     //! Root process where this turbine is active
     int root_proc{-1};
 
+    //! Flag indicating whether this is root proc
+    bool is_root_proc{false};
+
     //! Flag indicating whether this actuator component is active in the current
     //! MPI rank
     bool actuator_in_proc{false};
+
+    //! Flag indicating whether this process requires velocities sampled at
+    //! actuator point
+    bool sample_vel_in_proc{false};
 
     ActInfo(const std::string& label_in, const int id_in)
         : label(label_in), id(id_in)

--- a/amr-wind/wind_energy/actuator/actuator_utils.H
+++ b/amr-wind/wind_energy/actuator/actuator_utils.H
@@ -9,6 +9,9 @@
 
 namespace amr_wind {
 namespace actuator {
+
+struct ActInfo;
+
 namespace utils {
 
 /** Return a set of process IDs (MPI ranks) that contain AMR boxes that interact
@@ -23,6 +26,8 @@ namespace utils {
  */
 std::set<int> determine_influenced_procs(
     const amrex::AmrCore& mesh, const amrex::RealBox& rbox);
+
+void determine_root_proc(ActInfo&, amrex::Vector<int>&);
 
 /** Return the Gaussian smearing factor
  *

--- a/amr-wind/wind_energy/actuator/actuator_utils.cpp
+++ b/amr-wind/wind_energy/actuator/actuator_utils.cpp
@@ -1,4 +1,5 @@
 #include "amr-wind/wind_energy/actuator/actuator_utils.H"
+#include "amr-wind/wind_energy/actuator/actuator_types.H"
 
 namespace amr_wind {
 namespace actuator {
@@ -59,6 +60,61 @@ std::set<int> determine_influenced_procs(
     }
 
     return procs;
+}
+
+void determine_root_proc(ActInfo& info, amrex::Vector<int>& act_proc_count)
+{
+    auto& plist = info.procs;
+    bool assigned = false;
+
+    // If any of the influenced procs is free (i.e., doesn't have a turbine
+    // assigned to it) elect it as the root proc for this turbine and return
+    // early.
+    for (auto ip : plist) {
+        if (act_proc_count[ip] < 1) {
+            info.root_proc = ip;
+            ++act_proc_count[ip];
+            assigned = true;
+            break;
+        }
+    }
+
+    // If we found a root proc there is nothing more to do, so return early
+    if (assigned) {
+        const int iproc = amrex::ParallelDescriptor::MyProc();
+        auto in_proc = info.procs.find(iproc);
+        info.actuator_in_proc = (in_proc != info.procs.end());
+        info.is_root_proc = (info.root_proc == iproc);
+
+        // By default we request all processes where turbine is active to have
+        // velocities sampled. Individual actuator instances can override this
+        info.sample_vel_in_proc = info.actuator_in_proc;
+        return;
+    }
+
+    // If we have reached here, then we have more turbines than processes
+    // available. We will assign the current turbine to the process that is
+    // managing the lowest number of turbines.
+
+    // Determine the MPI rank that contains the fewest turbines
+    auto it = std::min_element(act_proc_count.begin(), act_proc_count.end());
+    // Make it the root process for this turbine
+    info.root_proc = std::distance(act_proc_count.begin(), it);
+    // Make sure the root process is part of the process list
+    plist.insert(info.root_proc);
+    // Increment turbine count with the global tracking array
+    ++(*it);
+
+    {
+        const int iproc = amrex::ParallelDescriptor::MyProc();
+        auto in_proc = info.procs.find(iproc);
+        info.actuator_in_proc = (in_proc != info.procs.end());
+        info.is_root_proc = (info.root_proc == iproc);
+
+        // By default we request all processes where turbine is active to have
+        // velocities sampled. Individual actuator instances can override this
+        info.sample_vel_in_proc = info.actuator_in_proc;
+    }
 }
 
 } // namespace utils

--- a/amr-wind/wind_energy/actuator/turbine/CMakeLists.txt
+++ b/amr-wind/wind_energy/actuator/turbine/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${amr_wind_lib_name} PRIVATE
+  turbine_utils.cpp
+  )
+
+add_subdirectory(fast)

--- a/amr-wind/wind_energy/actuator/turbine/fast/CMakeLists.txt
+++ b/amr-wind/wind_energy/actuator/turbine/fast/CMakeLists.txt
@@ -1,0 +1,17 @@
+if (AMR_WIND_ENABLE_OPENFAST)
+  find_package(OpenFAST REQUIRED)
+
+  target_compile_definitions(${amr_wind_lib_name} PUBLIC AMR_WIND_USE_OPENFAST)
+  target_include_directories(${amr_wind_lib_name} PUBLIC ${OpenFAST_INCLUDE_DIRS})
+  target_link_libraries(${amr_wind_lib_name} PUBLIC ${OpenFAST_LIBRARIES})
+endif()
+
+target_sources(${amr_wind_lib_name} PRIVATE
+  FastIface.cpp
+  )
+
+if (AMR_WIND_ENABLE_OPENFAST)
+  target_sources(${amr_wind_lib_name} PRIVATE
+    TurbineFast.cpp
+    )
+endif()

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
@@ -1,0 +1,82 @@
+#ifndef FASTIFACE_H
+#define FASTIFACE_H
+
+#include "amr-wind/core/ExtSolver.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/fast_types.H"
+#include <map>
+#include <vector>
+
+namespace ncutils {
+class NCFile;
+}
+
+namespace amr_wind {
+class CFDSim;
+}
+
+namespace exw_fast {
+
+class FastIface : public ::amr_wind::ExtSolver::Register<FastIface>
+{
+public:
+    static std::string identifier() { return "OpenFAST"; }
+
+    FastIface(const ::amr_wind::CFDSim& sim);
+
+    virtual ~FastIface();
+
+    void parse_inputs(const amr_wind::CFDSim&, const std::string&);
+
+    int register_turbine(FastTurbine& data);
+
+    void init_turbine(const int local_id);
+
+    void init_solution(const int local_id);
+
+    void advance_turbine(const int local_id);
+
+    void save_restart(const int local_id);
+
+    int num_local_turbines() const { return m_turbine_data.size(); }
+
+protected:
+    void allocate_fast_turbines();
+
+    void fast_init_turbine(FastTurbine&);
+
+    void fast_restart_turbine(FastTurbine&);
+
+    void fast_replay_turbine(FastTurbine&);
+
+    void prepare_netcdf_file(FastTurbine&);
+
+    void write_velocity_data(FastTurbine&);
+
+    void read_velocity_data(FastTurbine&, ncutils::NCFile&, const size_t tid);
+
+    //! Global to local index lookup map
+    std::map<int, int> m_turbine_map;
+
+    std::vector<FastTurbine*> m_turbine_data;
+
+    std::string m_output_dir{"fast_velocity_data"};
+
+    double m_dt_cfd{0.0};
+
+    // Not using amrex::Real. Instead use explicit types from FAST API
+    double m_start_time{0.0};
+    double m_stop_time;
+    SimMode m_sim_mode{SimMode::init};
+
+    int m_num_sc_inputs{0};
+    int m_num_sc_outputs{0};
+
+    char m_errmsg[fast_strlen()];
+
+    bool m_is_initialized{false};
+};
+
+} // namespace exw_fast
+
+#endif /* FASTIFACE_H */

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -1,0 +1,371 @@
+#include "amr-wind/wind_energy/actuator/turbine/fast/FastIface.H"
+#include "amr-wind/CFDSim.H"
+#include "amr-wind/core/SimTime.H"
+#include "amr-wind/utilities/io_utils.H"
+#include "amr-wind/utilities/ncutils/nc_interface.H"
+
+#include "AMReX.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_FileSystem.H"
+
+#include <algorithm>
+#include <cmath>
+
+namespace exw_fast {
+namespace {
+
+template <typename FType, class... Args>
+inline void fast_func(const FType&& func, Args... args)
+{
+    int ierr;
+    char err_msg[fast_strlen()];
+    func(std::forward<Args>(args)..., &ierr, err_msg);
+    if (ierr >= ErrID_Fatal) {
+        std::string prefix = "FastIface: Error calling OpenFAST function: \n";
+        amrex::Abort(prefix + std::string(err_msg));
+    }
+}
+
+inline void copy_filename(const std::string& inp, char* out)
+{
+    const int str_len = static_cast<int>(inp.size());
+    if (str_len >= fast_strlen()) {
+        amrex::Abort(
+            "FastIface: Filename greater than maximum allowable length: " +
+            inp);
+    }
+    const int len = std::min(fast_strlen() - 1, str_len);
+    std::copy(inp.data(), inp.data() + len, out);
+    out[len] = '\0';
+}
+
+} // namespace
+
+FastIface::FastIface(const amr_wind::CFDSim&) {}
+
+FastIface::~FastIface()
+{
+    int ierr;
+    char err_msg[fast_strlen()];
+    FAST_DeallocateTurbines(&ierr, err_msg);
+
+    if (ierr != ErrID_None) {
+        amrex::OutStream() << "\nFastIface: Error deallocating turbine data\n"
+                           << err_msg << std::endl;
+    }
+}
+
+void FastIface::parse_inputs(
+    const amr_wind::CFDSim& sim, const std::string& inp_name)
+{
+    amrex::ParmParse pp(inp_name);
+
+    const auto& time = sim.time();
+    // Check that the user has not enabled adaptive timestepping
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !time.adaptive_timestep(),
+        "Adaptive time-stepping not supported when OpenFAST is enabled");
+
+    m_dt_cfd = time.deltaT();
+
+    // Set OpenFAST end time to be at least as long as the CFD time. User
+    // can choose a longer duration in input file.
+    const amrex::Real stop1 = time.stop_time() > 0.0
+                                  ? time.stop_time()
+                                  : std::numeric_limits<amrex::Real>::max();
+    const amrex::Real stop2 = time.stop_time_index() > 0
+                                  ? time.stop_time_index() * time.deltaT()
+                                  : std::numeric_limits<amrex::Real>::max();
+    const amrex::Real cfd_stop = amrex::min(stop1, stop2);
+    m_stop_time = cfd_stop;
+
+    pp.query("start_time", m_start_time);
+    pp.query("stop_time", m_stop_time);
+
+    // Ensure that the user specified m_stop_time is not shorter than CFD sim
+    AMREX_ALWAYS_ASSERT(m_stop_time > (cfd_stop - 1.0e-6));
+
+    if (m_start_time > 0.0) {
+        m_sim_mode = SimMode::replay;
+
+        std::string sim_mode{"replay"};
+        pp.query("sim_mode", sim_mode);
+        if (sim_mode == "replay") {
+            m_sim_mode = SimMode::replay;
+        } else if (sim_mode == "restart") {
+            m_sim_mode = SimMode::restart;
+        } else {
+            amrex::Abort(
+                "Invalid simulation mode when start time > 0 provided: " +
+                sim_mode);
+        }
+    }
+}
+
+int FastIface::register_turbine(FastTurbine& data)
+{
+    BL_PROFILE("amr-wind::FastIface::register_turbine");
+    AMREX_ALWAYS_ASSERT(!m_is_initialized);
+    const int local_id = m_turbine_data.size();
+    const int gid = data.tid_global;
+    m_turbine_map[gid] = local_id;
+    data.tid_local = local_id;
+    m_turbine_data.emplace_back(&data);
+
+    return local_id;
+}
+
+void FastIface::allocate_fast_turbines()
+{
+    BL_PROFILE("amr-wind::FastIface::allocate_turbines");
+    int nturbines = m_turbine_data.size();
+    fast_func(FAST_AllocateTurbines, &nturbines);
+    m_is_initialized = true;
+}
+
+void FastIface::init_solution(const int local_id)
+{
+    BL_PROFILE("amr-wind::FastIface::init_solution");
+    AMREX_ALWAYS_ASSERT(local_id < static_cast<int>(m_turbine_data.size()));
+    AMREX_ALWAYS_ASSERT(m_is_initialized);
+
+    auto& fi = *m_turbine_data[local_id];
+    fast_func(FAST_OpFM_Solution0, &fi.tid_local);
+    fi.is_solution0 = false;
+}
+
+void FastIface::advance_turbine(const int local_id)
+{
+    BL_PROFILE("amr-wind::FastIface::advance_turbine");
+    AMREX_ASSERT(local_id < static_cast<int>(m_turbine_data.size()));
+
+    auto& fi = *m_turbine_data[local_id];
+    AMREX_ASSERT(!fi.is_solution0);
+    {
+        const auto& tmax = fi.stop_time;
+        const auto& telapsed = (fi.time_index + fi.num_substeps) * fi.dt_fast;
+        if (telapsed > (tmax + 1.0e-8)) {
+            // clang-format off
+            amrex::OutStream()
+                << "\nWARNING: FastIface:\n"
+                << "  Elapsed simulation time will exceed max "
+                << "time set for OpenFAST"
+                << std::endl << std::endl;
+            // clang-format on
+        }
+    }
+
+    write_velocity_data(fi);
+    for (int i = 0; i < fi.num_substeps; ++i, ++fi.time_index) {
+        fast_func(FAST_OpFM_Step, &fi.tid_local);
+    }
+}
+
+void FastIface::init_turbine(const int local_id)
+{
+    AMREX_ALWAYS_ASSERT(local_id < static_cast<int>(m_turbine_data.size()));
+    if (!m_is_initialized) allocate_fast_turbines();
+    auto& fi = *m_turbine_data[local_id];
+
+    switch (fi.sim_mode) {
+    case SimMode::init: {
+        fast_init_turbine(fi);
+        prepare_netcdf_file(fi);
+        break;
+    }
+
+    case SimMode::replay: {
+        fast_init_turbine(fi);
+        fast_replay_turbine(fi);
+        break;
+    }
+
+    case SimMode::restart: {
+        fast_restart_turbine(fi);
+        break;
+    }
+    }
+}
+
+void FastIface::fast_init_turbine(FastTurbine& fi)
+{
+    BL_PROFILE("amr-wind::FastIface::init_turbine");
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        amrex::FileSystem::Exists(fi.input_file),
+        "FastIface: Cannot find OpenFAST input file: " + fi.input_file);
+
+    int abort_lev;
+    char inp_file[fast_strlen()];
+    copy_filename(fi.input_file, inp_file);
+
+    fast_func(
+        FAST_OpFM_Init, &fi.tid_local, &fi.stop_time, inp_file, &fi.tid_global,
+        &m_num_sc_inputs, &m_num_sc_outputs, &fi.num_pts_blade,
+        &fi.num_pts_tower, fi.base_pos, &abort_lev, &fi.dt_fast, &fi.num_blades,
+        &fi.num_blade_elem, &fi.to_cfd, &fi.from_cfd, &fi.to_sc, &fi.from_sc);
+
+    // Determine the number of substeps for FAST per CFD timestep
+    fi.num_substeps = static_cast<int>(std::floor(fi.dt_cfd / fi.dt_fast));
+
+    AMREX_ALWAYS_ASSERT(fi.num_substeps > 0);
+    // Check that the time step sizes are consistent and FAST advances at an
+    // integral multiple of CFD timestep
+    double dt_err =
+        fi.dt_cfd / (static_cast<double>(fi.num_substeps) * fi.dt_fast) - 1.0;
+    if (dt_err > 1.0e-4) {
+        amrex::Abort(
+            "FastIFace: OpenFAST timestep is not an integral "
+            "multiple of CFD timestep");
+    }
+}
+
+void FastIface::fast_replay_turbine(FastTurbine& fi)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    BL_PROFILE("amr-wind::FastIface::replay_turbine");
+
+    // Determine the number of timesteps we should advance this turbine
+    const auto num_steps =
+        static_cast<int>(std::floor(fi.start_time / fi.dt_fast));
+    // Compute the number of CFD steps to read velocity data
+    const auto num_cfd_steps = num_steps / fi.num_substeps;
+
+    // Ensure that the NetCDF file exists and contains the required number of
+    // timesteps for restart.
+    const std::string fname = m_output_dir + "/" + fi.tlabel + ".nc";
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        amrex::FileSystem::Exists(fname),
+        "FastIface: Cannot find OpenFAST velocity data file: " + fname);
+
+    auto ncf = ncutils::NCFile::open(fname, NC_NOWRITE);
+    {
+        const int nt = static_cast<int>(ncf.dim("num_time_steps").len());
+        AMREX_ALWAYS_ASSERT(nt >= num_cfd_steps);
+    }
+
+    // Replay OpenFAST simulation for the desired number of timesteps to mimic
+    // restart
+    fi.time_index = 0;
+    read_velocity_data(fi, ncf, 0);
+    fast_func(FAST_OpFM_Solution0, &fi.tid_local);
+    fi.is_solution0 = false;
+
+    for (int ic = 0; ic < num_cfd_steps; ++ic) {
+        read_velocity_data(fi, ncf, ic);
+        for (int i = 0; i < fi.num_substeps; ++i, ++fi.time_index) {
+            fast_func(FAST_OpFM_Step, &fi.tid_local);
+        }
+    }
+    AMREX_ALWAYS_ASSERT(fi.time_index == num_steps);
+#else
+    amrex::ignore_unused(fi);
+    amrex::Abort(
+        "FastIface::replay_turbine: AMR-Wind was not compiled with NetCDF "
+        "support");
+#endif
+}
+
+void FastIface::fast_restart_turbine(FastTurbine&)
+{
+    BL_PROFILE("amr-wind::FastIface::restart_turbine");
+}
+
+#ifdef AMR_WIND_USE_OPENFAST
+
+void FastIface::prepare_netcdf_file(FastTurbine& fi)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    BL_PROFILE("amr-wind::FastIface::prepare_netcdf_file");
+    if (!amrex::UtilCreateDirectory(m_output_dir, 0755)) {
+        amrex::CreateDirectoryFailed(m_output_dir);
+    }
+
+    const std::string fname = m_output_dir + "/" + fi.tlabel + ".nc";
+    auto ncf = ncutils::NCFile::create(fname, NC_CLOBBER | NC_NETCDF4);
+    const std::string nt_name = "num_time_steps";
+    const std::string np_name = "num_vel_points";
+    ncf.enter_def_mode();
+    ncf.put_attr("title", "AMR-Wind OpenFAST velocity data");
+    ncf.put_attr("AMR-Wind_version", amr_wind::ioutils::amr_wind_version());
+    ncf.put_attr("created_on", amr_wind::ioutils::timestamp());
+    ncf.def_dim(nt_name, NC_UNLIMITED);
+    ncf.def_dim(np_name, fi.from_cfd.u_Len);
+    ncf.def_dim("ndim", AMREX_SPACEDIM);
+    ncf.def_var("time", NC_FLOAT, {nt_name});
+    ncf.def_var("xco", NC_FLOAT, {np_name});
+    ncf.def_var("yco", NC_FLOAT, {np_name});
+    ncf.def_var("zco", NC_FLOAT, {np_name});
+    ncf.def_var("uvel", NC_FLOAT, {nt_name, np_name});
+    ncf.def_var("vvel", NC_FLOAT, {nt_name, np_name});
+    ncf.def_var("wvel", NC_FLOAT, {nt_name, np_name});
+    ncf.exit_def_mode();
+
+    {
+        const size_t npts = static_cast<size_t>(fi.from_cfd.u_Len);
+        auto xco = ncf.var("xco");
+        xco.put(fi.to_cfd.pxVel, {0}, {npts});
+        auto yco = ncf.var("yco");
+        yco.put(fi.to_cfd.pyVel, {0}, {npts});
+        auto zco = ncf.var("zco");
+        zco.put(fi.to_cfd.pzVel, {0}, {npts});
+    }
+#else
+    amrex::ignore_unused(fi);
+    amrex::OutputStream()
+        << "WARNING: FastIface: NetCDF support was not enabled during compile "
+           "time. FastIface cannot support restart."
+        << std::endl;
+#endif
+}
+
+void FastIface::write_velocity_data(FastTurbine& fi)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    BL_PROFILE("amr-wind::FastIface::write_velocity_data");
+    const std::string fname = m_output_dir + "/" + fi.tlabel + ".nc";
+    auto ncf = ncutils::NCFile::open(fname, NC_WRITE);
+    const std::string nt_name = "num_time_steps";
+    const size_t nt = ncf.dim(nt_name).len();
+    const size_t npts = static_cast<size_t>(fi.from_cfd.u_Len);
+
+    const double time = fi.time_index * fi.dt_fast;
+    ncf.var("time").put(&time, {nt}, {1});
+    const auto& uu = fi.from_cfd;
+    ncf.var("uvel").put(uu.u, {nt, 0}, {1, npts});
+    ncf.var("vvel").put(uu.v, {nt, 0}, {1, npts});
+    ncf.var("wvel").put(uu.w, {nt, 0}, {1, npts});
+#else
+    amrex::ignore_unused(fi);
+#endif
+}
+
+void FastIface::read_velocity_data(
+    FastTurbine& fi, ncutils::NCFile& ncf, const size_t tid)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    const size_t nt = static_cast<size_t>(tid);
+    const size_t npts = static_cast<size_t>(fi.from_cfd.u_Len);
+
+    auto& uu = fi.from_cfd;
+    ncf.var("uvel").get(uu.u, {nt, 0}, {1, npts});
+    ncf.var("vvel").get(uu.v, {nt, 0}, {1, npts});
+    ncf.var("wvel").get(uu.w, {nt, 0}, {1, npts});
+#else
+    amrex::ignore_unused(fi);
+    amrex::Abort(
+        "FastIface::read_velocity_data: AMR-Wind was not compiled with NetCDF "
+        "support");
+#endif
+}
+
+#else
+
+void FastIface::prepare_netcdf_file(FastTurbine&) {}
+void FastIface::write_velocity_data(FastTurbine&) {}
+void FastIface::read_velocity_data(FastTurbine&, ncutils::NCFile&, const size_t)
+{}
+
+#endif
+
+} // namespace exw_fast

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -17,7 +17,7 @@ namespace {
 template <typename FType, class... Args>
 inline void fast_func(const FType&& func, Args... args)
 {
-    int ierr;
+    int ierr = ErrID_None;
     char err_msg[fast_strlen()];
     func(std::forward<Args>(args)..., &ierr, err_msg);
     if (ierr >= ErrID_Fatal) {
@@ -45,7 +45,7 @@ FastIface::FastIface(const amr_wind::CFDSim&) {}
 
 FastIface::~FastIface()
 {
-    int ierr;
+    int ierr = ErrID_None;
     char err_msg[fast_strlen()];
     FAST_DeallocateTurbines(&ierr, err_msg);
 

--- a/amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.H
@@ -1,0 +1,35 @@
+#ifndef TURBINEFAST_H
+#define TURBINEFAST_H
+
+#include "amr-wind/wind_energy/actuator/turbine/turbine_types.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/fast_types.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/FastIface.H"
+#include "amr-wind/core/ExtSolver.H"
+
+namespace amr_wind {
+namespace actuator {
+
+struct TurbineFastData : public TurbineBaseData
+{
+    amrex::Real density{1.0};
+
+    ::exw_fast::FastTurbine fast_data;
+    ::exw_fast::FastIface* fast{nullptr};
+
+    MPI_Comm tcomm{MPI_COMM_NULL};
+};
+
+struct TurbineFast : public TurbineType
+{
+    using InfoType = TurbineInfo;
+    using GridType = ActGrid;
+    using MetaType = TurbineFastData;
+    using DataType = ActDataHolder<TurbineFast>;
+
+    static const std::string identifier() { return "TurbineFast"; }
+};
+
+} // namespace actuator
+} // namespace amr_wind
+
+#endif /* TURBINEFAST_H */

--- a/amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.cpp
@@ -1,0 +1,11 @@
+#include "amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H"
+#include "amr-wind/wind_energy/actuator/ActuatorModel.H"
+
+namespace amr_wind {
+namespace actuator {
+
+template class ActModel<TurbineFast, ActSrcLine>;
+
+} // namespace actuator
+} // namespace amr_wind

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
@@ -1,0 +1,86 @@
+#ifndef FAST_TYPES_H
+#define FAST_TYPES_H
+
+#include "amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H"
+
+#include <string>
+
+namespace exw_fast {
+
+enum class SimMode : int {
+    init = 0, ///< Clean start
+    replay,   ///< Replay using velocities stored in file
+    restart   ///< Restart using FAST checkpoint files
+};
+
+/** Representation of a turbine for exchanging data with FAST
+ */
+struct FastTurbine
+{
+    static constexpr int ndim = 3;
+
+    //! Unique string identifier for this turbine
+    std::string tlabel;
+
+    //! Local ID for this turbine (provided by FAST interface)
+    int tid_local;
+
+    //! Global ID for this turbine (set by Turbine instance)
+    int tid_global;
+
+    //! Number of actuator points per blade
+    int num_pts_blade;
+
+    //! Number of actuator points for tower
+    int num_pts_tower;
+
+    //! Position of tower base in global coordinate system
+    float base_pos[ndim];
+
+    SimMode sim_mode{SimMode::init};
+
+    //! OpenFAST input file
+    std::string input_file;
+
+    //! Checkpoint file name
+    std::string checkpoint_file;
+
+    //! Number of blades
+    int num_blades;
+
+    //! Total number of elements along the blade
+    int num_blade_elem;
+
+    //! Start time for this turbine
+    double start_time{0.0};
+
+    //! End time for this turbine
+    double stop_time;
+
+    //! Timestep for CFD
+    double dt_cfd;
+
+    //! Timestep for FAST using per-turbine to check input files
+    double dt_fast;
+
+    //! Number of sub-steps of fast per CFD timestep
+    int num_substeps;
+
+    //! Time step index for FAST
+    int time_index{0};
+
+    //! Does FAST need solution0
+    bool is_solution0{true};
+
+    // Data structures that are used to exchange between fast/cfd
+
+    exw_fast::OpFM_InputType to_cfd;
+    exw_fast::OpFM_OutputType from_cfd;
+
+    exw_fast::SC_InputType to_sc;
+    exw_fast::SC_OutputType from_sc;
+};
+
+} // namespace exw_fast
+
+#endif /* FAST_TYPES_H */

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
@@ -1,0 +1,54 @@
+#ifndef FAST_WRAPPER_H
+#define FAST_WRAPPER_H
+
+namespace exw_fast {
+#ifdef AMR_WIND_USE_OPENFAST
+extern "C" {
+#include "FAST_Library.h"
+}
+
+extern void exw_fast_output_redirect(char*);
+
+inline constexpr int fast_strlen() { return INTERFACE_STRING_LENGTH; }
+
+#else
+
+#define ErrID_None 0
+#define ErrID_Info 1
+#define ErrID_Warn 2
+#define ErrID_Severe 3
+#define ErrID_Fatal 4
+
+struct OpFM_InputType
+{};
+struct OpFM_OutputType
+{};
+struct SC_InputType
+{};
+struct SC_OutputType
+{};
+
+inline constexpr int fast_strlen() { return 1025; }
+
+inline void exw_fast_output_redirect(char*) {}
+
+inline void FAST_AllocateTurbines(int*, int*, char*) {}
+inline void FAST_DeallocateTurbines(int*, char*) {}
+inline void FAST_OpFM_Solution0(int*, int*, char*) {}
+inline void FAST_OpFM_Step(int*, int*, char*) {}
+
+// clang-format off
+inline void FAST_OpFM_Init(
+    int*, double*, const char*, int*, int*, int*, int*, int*, float*,
+    int*, double*, int*, int*, OpFM_InputType*, OpFM_OutputType*,
+    SC_InputType*, SC_OutputType*, int*, char*) {}
+
+inline void FAST_OpFM_Restart(
+    int*, char*, int*, double*, int*, int*, int*,
+    OpFM_InputType*, OpFM_OutputType*,
+    SC_InputType*, SC_OutputType*, int*, char*) {}
+// clang-format on
+#endif
+} // namespace exw_fast
+
+#endif /* FAST_WRAPPER_H */

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -1,0 +1,550 @@
+#ifndef TURBINE_FAST_OPS_H
+#define TURBINE_FAST_OPS_H
+
+#include "amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.H"
+#include "amr-wind/wind_energy/actuator/turbine/turbine_utils.H"
+#include "amr-wind/wind_energy/actuator/actuator_ops.H"
+#include "amr-wind/wind_energy/actuator/actuator_utils.H"
+
+namespace amr_wind {
+namespace actuator {
+namespace ops {
+
+template <typename SrcTrait>
+struct ReadInputsOp<TurbineFast, SrcTrait>
+{
+    void operator()(TurbineFast::DataType& data, const utils::ActParser& pp)
+    {
+        // Data common to any turbine actuator simulation
+        utils::read_inputs(data.meta(), data.info(), pp);
+
+        auto& tdata = data.meta();
+
+        // Get density value for normalization
+        pp.query("density", tdata.density);
+
+        // Initialize OpenFAST specific data
+        const auto& tinfo = data.info();
+        auto& tf = data.meta().fast_data;
+        for (int i = 0; i < AMREX_SPACEDIM; ++i)
+            tf.base_pos[i] = static_cast<float>(tinfo.base_pos[i]);
+
+        tf.tlabel = tinfo.label;
+        tf.tid_global = tinfo.id;
+        tf.num_blades = tdata.num_blades;
+        tf.num_pts_blade = tdata.num_pts_blade;
+        tf.num_pts_tower = tdata.num_pts_tower;
+        tf.dt_cfd = data.sim().time().deltaT();
+
+        pp.get("openfast_input_file", tf.input_file);
+        pp.get("openfast_start_time", tf.start_time);
+        pp.get("openfast_stop_time", tf.stop_time);
+
+        std::string sim_mode = (tf.start_time > 0.0) ? "replay" : "init";
+        pp.query("openfast_sim_mode", sim_mode);
+        if (sim_mode == "init") {
+            tf.sim_mode = ::exw_fast::SimMode::init;
+        } else if (sim_mode == "replay") {
+            tf.sim_mode = ::exw_fast::SimMode::replay;
+        } else if (sim_mode == "restart") {
+            tf.sim_mode = ::exw_fast::SimMode::restart;
+        } else {
+            amrex::Abort(
+                "Actuator: Invalid OpenFAST simulation mode: " + sim_mode);
+        }
+
+        // If we are using OpenFAST restart file, require that the user provide
+        // the path to the checkpoint file.
+        if (tf.sim_mode == ::exw_fast::SimMode::restart) {
+            pp.get("openfast_restart_file", tf.checkpoint_file);
+        }
+
+        perform_checks(data);
+    }
+
+    void perform_checks(typename TurbineFast::DataType& data)
+    {
+        const auto& time = data.sim().time();
+        // Ensure that we are using fixed timestepping scheme
+        AMREX_ALWAYS_ASSERT(!time.adaptive_timestep());
+    }
+};
+
+template <>
+inline void determine_root_proc<TurbineFast>(
+    typename TurbineFast::DataType& data, amrex::Vector<int>& act_proc_count)
+{
+    namespace utils = ::amr_wind::actuator::utils;
+    auto& info = data.info();
+    info.procs =
+        utils::determine_influenced_procs(data.sim().mesh(), info.bound_box);
+
+    utils::determine_root_proc(info, act_proc_count);
+
+    // TODO: This function is doing a lot more than advertised by the name.
+    // Should figure out a better way to perform the extra work.
+
+    // For OpenFAST we only need velocities sampled in root process
+    info.sample_vel_in_proc = info.is_root_proc;
+
+    // Initialize the OpenFAST object and register this turbine in the root
+    // process
+    if (info.is_root_proc) {
+        auto& tdata = data.meta();
+        auto& ext_mgr = data.sim().ext_solver_manager();
+        ext_mgr.create("OpenFAST", data.sim());
+        tdata.fast = &(ext_mgr.get<::exw_fast::FastIface>());
+        tdata.fast->register_turbine(tdata.fast_data);
+    }
+}
+
+template <typename SrcTrait>
+struct InitDataOp<TurbineFast, SrcTrait>
+{
+    void operator()(TurbineFast::DataType& data)
+    {
+        BL_PROFILE("amr-wind::InitDataOp<TurbineFast>");
+
+        // Ensure that FAST simulation time is set properly before doing any
+        // initialization tasks. We perform this check here to account for
+        // restart which is only known after reading the checkpoint file.
+        check_fast_sim_time(data);
+
+        auto& info = data.info();
+        auto& tdata = data.meta();
+
+        // Initialize our communicator for broadcasting data
+        amrex::ParallelDescriptor::Comm_dup(
+            amrex::ParallelDescriptor::Communicator(), tdata.tcomm);
+
+        int sz_info[3]{0, 0, 0};
+        if (info.is_root_proc) {
+            tdata.fast->init_turbine(tdata.fast_data.tid_local);
+
+            const auto& tf = tdata.fast_data;
+            sz_info[0] = tf.num_blades;
+            sz_info[1] = tf.to_cfd.fx_Len;
+            sz_info[2] = tf.from_cfd.u_Len;
+        }
+
+        // Broadcast data to everyone
+        amrex::ParallelDescriptor::Bcast(
+            sz_info, 3, info.root_proc, tdata.tcomm);
+
+        {
+            tdata.num_blades = sz_info[0];
+            data.grid().resize(sz_info[1], sz_info[2]);
+            tdata.chord.resize(sz_info[1]);
+        }
+
+        if (info.is_root_proc) {
+            // copy chord data
+            int npts = sz_info[1];
+            const auto& fchord = tdata.fast_data.to_cfd.forceNodesChord;
+            for (int i = 0; i < npts; ++i) {
+                tdata.chord[i] = static_cast<amrex::Real>(fchord[i]);
+            }
+        }
+
+        amrex::ParallelDescriptor::Bcast(
+            tdata.chord.data(), tdata.chord.size(), info.root_proc,
+            tdata.tcomm);
+
+        make_component_views(data);
+        init_epsilon(data);
+    }
+
+    void make_component_views(typename TurbineFast::DataType& data)
+    {
+        auto& grid = data.grid();
+        auto& tdata = data.meta();
+        const int num_blades = tdata.num_blades;
+        const int num_pts_blade = tdata.num_pts_blade;
+
+        for (int ib = 0; ib < num_blades; ++ib) {
+            ComponentView cv;
+
+            const auto start = ib * num_pts_blade + 1;
+            // clang-format off
+            cv.pos = ::amr_wind::utils::slice(
+                grid.pos, start, num_pts_blade);
+            cv.force = ::amr_wind::utils::slice(
+                grid.force, start, num_pts_blade);
+            cv.epsilon = ::amr_wind::utils::slice(
+                grid.epsilon, start, num_pts_blade);
+            cv.orientation = ::amr_wind::utils::slice(
+                grid.orientation, start, num_pts_blade);
+            cv.chord = ::amr_wind::utils::slice(
+                tdata.chord, start, num_pts_blade);
+            // clang-format on
+
+            tdata.blades.emplace_back(std::move(cv));
+        }
+        {
+            const int num_pts_tower = tdata.num_pts_tower;
+            const int ntwr_start = num_blades * num_pts_blade + 1;
+            auto& cv = tdata.tower;
+
+            cv.pos =
+                ::amr_wind::utils::slice(grid.pos, ntwr_start, num_pts_tower);
+            cv.force =
+                ::amr_wind::utils::slice(grid.force, ntwr_start, num_pts_tower);
+            cv.epsilon = ::amr_wind::utils::slice(
+                grid.epsilon, ntwr_start, num_pts_tower);
+            cv.orientation = ::amr_wind::utils::slice(
+                grid.orientation, ntwr_start, num_pts_tower);
+            cv.chord = ::amr_wind::utils::slice(
+                tdata.chord, ntwr_start, num_pts_tower);
+        }
+    }
+
+    void init_epsilon(typename TurbineFast::DataType& data)
+    {
+        auto& tdata = data.meta();
+
+        // Swap order of epsilon based on FAST turbine orientation
+        swap_epsilon(tdata.eps_inp);
+        swap_epsilon(tdata.eps_min);
+        swap_epsilon(tdata.eps_chord);
+        swap_epsilon(tdata.eps_tower);
+
+        {
+            const auto& cd = tdata.nacelle_cd;
+            const auto& area = tdata.nacelle_area;
+            const auto eps =
+                std::sqrt(2.0 / ::amr_wind::utils::pi() * cd * area);
+
+            auto& nac_eps = data.grid().epsilon[0];
+            nac_eps.x() = amrex::max(eps, 1.0);
+            nac_eps.y() = amrex::max(eps, 1.0);
+            nac_eps.z() = amrex::max(eps, 1.0);
+        }
+
+        for (int ib = 0; ib < tdata.num_blades; ++ib) {
+            auto& cv = tdata.blades[ib];
+
+            for (int i = 0; i < tdata.num_pts_blade; ++i) {
+                const auto eps_crd = tdata.eps_chord * cv.chord[i];
+
+                for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+                    cv.epsilon[i][n] = amrex::max(
+                        tdata.eps_min[n], tdata.eps_inp[n], eps_crd[n]);
+                }
+            }
+        }
+        {
+            auto& cv = tdata.tower;
+            for (int i = 0; i < tdata.num_pts_tower; ++i) {
+                for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+                    cv.epsilon[i][n] = amrex::max(
+                        tdata.eps_min[n], tdata.eps_inp[n], tdata.eps_tower[n]);
+                }
+            }
+        }
+    }
+
+    inline void swap_epsilon(vs::Vector& eps)
+    {
+        const auto x = eps.x();
+        const auto y = eps.y();
+        eps.x() = y;
+        eps.y() = x;
+    }
+
+    void check_fast_sim_time(typename TurbineFast::DataType& data)
+    {
+        const auto& time = data.sim().time();
+
+        // Set OpenFAST end time to be at least as long as the CFD time. User
+        // can choose a longer duration in input file.
+        const amrex::Real stop1 = time.stop_time() > 0.0
+                                      ? time.stop_time()
+                                      : std::numeric_limits<amrex::Real>::max();
+        const amrex::Real stop2 = time.stop_time_index() > -1
+                                      ? time.stop_time_index() * time.deltaT()
+                                      : std::numeric_limits<amrex::Real>::max();
+        const amrex::Real cfd_stop = amrex::min(stop1, stop2);
+        const amrex::Real cfd_start = time.current_time();
+        const amrex::Real cfd_sim = cfd_stop - cfd_start - 1.0e-6;
+
+        // Ensure that the user specified stop_time is not shorter than CFD sim
+        const auto& tf = data.meta().fast_data;
+        const amrex::Real fast_sim = tf.stop_time - tf.start_time;
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            fast_sim > cfd_sim,
+            "OpenFAST simulation time is shorter than AMR-Wind duration");
+    }
+};
+
+template <typename SrcTrait>
+struct UpdatePosOp<TurbineFast, SrcTrait>
+{
+    void operator()(typename TurbineFast::DataType& data)
+    {
+        // Return early if this is not the root process for this turbine
+        //
+        // This is handled in Actuator class, but we add a check here just as a
+        // safeguard
+        if (!data.info().is_root_proc) return;
+
+        const auto& tdata = data.meta();
+        const auto& bp = data.info().base_pos;
+        const auto& pxvel = tdata.fast_data.to_cfd.pxVel;
+        const auto& pyvel = tdata.fast_data.to_cfd.pyVel;
+        const auto& pzvel = tdata.fast_data.to_cfd.pzVel;
+        auto& vel_pos = data.grid().vel_pos;
+        const int nvpts = vel_pos.size();
+        for (int i = 0; i < nvpts; ++i) {
+            vel_pos[i].x() = static_cast<amrex::Real>(pxvel[i]) + bp.x();
+            vel_pos[i].y() = static_cast<amrex::Real>(pyvel[i]) + bp.y();
+            vel_pos[i].z() = static_cast<amrex::Real>(pzvel[i]) + bp.z();
+        }
+    }
+};
+
+template <typename SrcTrait>
+struct UpdateVelOp<TurbineFast, SrcTrait>
+{
+    void operator()(typename TurbineFast::DataType& data)
+    {
+        // Return early if this is not the root process for this turbine
+        //
+        // This is handled in Actuator class, but we add a check here just as a
+        // safeguard
+        if (!data.info().is_root_proc) return;
+
+        auto& from_cfd = data.meta().fast_data.from_cfd;
+        auto& uvel = from_cfd.u;
+        auto& vvel = from_cfd.v;
+        auto& wvel = from_cfd.w;
+        const auto& vel = data.grid().vel;
+        const int nvpts = vel.size();
+
+        for (int i = 0; i < nvpts; ++i) {
+            uvel[i] = static_cast<float>(vel[i].x());
+            vvel[i] = static_cast<float>(vel[i].y());
+            wvel[i] = static_cast<float>(vel[i].z());
+        }
+    }
+};
+
+template <typename SrcTrait>
+struct ComputeForceOp<TurbineFast, SrcTrait>
+{
+    void operator()(typename TurbineFast::DataType& data)
+    {
+        // Advance OpenFAST by specified number of sub-steps
+        fast_step(data);
+        // Broadcast data to all the processes that contain patches influenced
+        // by this turbine
+        scatter_data(data);
+    }
+
+    void fast_step(typename TurbineFast::DataType& data)
+    {
+        if (!data.info().is_root_proc) return;
+
+        auto& meta = data.meta();
+        auto& tf = data.meta().fast_data;
+        if (tf.is_solution0) {
+            meta.fast->init_solution(tf.tid_local);
+        } else {
+            meta.fast->advance_turbine(tf.tid_local);
+        }
+
+        // Populate nacelle force into the OpenFAST data structure so that it
+        // gets broadcasted to all influenced processes in subsequent scattering
+        // of data.
+        compute_nacelle_force(data);
+    }
+
+    void compute_nacelle_force(typename TurbineFast::DataType& data)
+    {
+        if (!data.info().is_root_proc) return;
+
+        const auto& cd = data.meta().nacelle_cd;
+        const auto& area = data.meta().nacelle_area;
+        const auto& cd_area = cd * area;
+        const auto& fcfd = data.meta().fast_data.from_cfd;
+        const auto& tcfd = data.meta().fast_data.to_cfd;
+        const auto& rho = data.meta().density;
+
+        const auto& eps = data.grid().epsilon[0].x();
+        vs::Vector vel{fcfd.u[0], fcfd.v[0], fcfd.w[0]};
+        amrex::Real correction = 0.0;
+        if (eps > 0.0) {
+            amrex::Real fac =
+                1.0 -
+                (cd_area) / (2.0 * ::amr_wind::utils::two_pi() * eps * eps);
+            correction = 1.0 / fac;
+        }
+        amrex::Real coeff =
+            0.5 * rho * cd_area * vs::mag(vel) * correction * correction;
+
+        tcfd.fx[0] = static_cast<float>(coeff * fcfd.u[0]);
+        tcfd.fy[0] = static_cast<float>(coeff * fcfd.v[0]);
+        tcfd.fz[0] = static_cast<float>(coeff * fcfd.w[0]);
+    }
+
+    void scatter_data(typename TurbineFast::DataType& data)
+    {
+        if (!data.info().actuator_in_proc) return;
+
+        // Create an MPI transfer buffer that packs all data in one contiguous
+        // array. 3 floats for the position vector, 3 floats for the force
+        // vector, and 9 floats for the orientation matrix = 15 floats per
+        // actuator node.
+        const int dsize = data.grid().pos.size() * 15;
+        amrex::Vector<float> buf(dsize);
+
+        // Copy data into MPI send/recv buffer from the OpenFAST data structure.
+        // Note, other procs do not have a valid data in those pointers.
+        if (data.info().is_root_proc) {
+            const auto& tocfd = data.meta().fast_data.to_cfd;
+            auto it = buf.begin();
+            std::copy(tocfd.fx, tocfd.fx + tocfd.fx_Len, it);
+            std::advance(it, tocfd.fx_Len);
+            std::copy(tocfd.fy, tocfd.fy + tocfd.fy_Len, it);
+            std::advance(it, tocfd.fy_Len);
+            std::copy(tocfd.fz, tocfd.fz + tocfd.fz_Len, it);
+            std::advance(it, tocfd.fz_Len);
+
+            std::copy(tocfd.pxForce, tocfd.pxForce + tocfd.pxForce_Len, it);
+            std::advance(it, tocfd.pxForce_Len);
+            std::copy(tocfd.pyForce, tocfd.pyForce + tocfd.pyForce_Len, it);
+            std::advance(it, tocfd.pyForce_Len);
+            std::copy(tocfd.pzForce, tocfd.pzForce + tocfd.pzForce_Len, it);
+            std::advance(it, tocfd.pzForce_Len);
+
+            // clang-format off
+            std::copy(tocfd.pOrientation,
+                      tocfd.pOrientation + tocfd.pOrientation_Len, it);
+            // clang-format on
+        }
+
+        // Broadcast data to all influenced procs from the root process
+        const auto& procs = data.info().procs;
+        const int tag = 1001;
+        if (data.info().is_root_proc) {
+            for (const int ip : procs) {
+                if (ip == data.info().root_proc) continue;
+
+                amrex::ParallelDescriptor::Send(
+                    buf.data(), dsize, ip, tag, data.meta().tcomm);
+            }
+        } else {
+            amrex::ParallelDescriptor::Recv(
+                buf.data(), dsize, data.info().root_proc, tag,
+                data.meta().tcomm);
+        }
+
+        // Populate the actuator grid data structures with data from the MPI
+        // send/recv buffer.
+        {
+            const auto& bp = data.info().base_pos;
+            auto& grid = data.grid();
+            const auto& npts = grid.pos.size();
+            const auto& rho = data.meta().density;
+            const size_t ifx = 0;
+            const size_t ify = ifx + npts;
+            const size_t ifz = ify + npts;
+            const size_t ipx = ifz + npts;
+            const size_t ipy = ipx + npts;
+            const size_t ipz = ipy + npts;
+            const size_t iori = ipz + npts;
+
+            for (int i = 0; i < npts; ++i) {
+                // Aerodynamic force vectors. Flip sign to get force on fluid.
+                // Divide by density as the source term computation will
+                // multiply by density before adding to momentum equation.
+                //
+                grid.force[i].x() =
+                    -static_cast<amrex::Real>(buf[ifx + i]) / rho;
+                grid.force[i].y() =
+                    -static_cast<amrex::Real>(buf[ify + i]) / rho;
+                grid.force[i].z() =
+                    -static_cast<amrex::Real>(buf[ifz + i]) / rho;
+
+                // Position vectors of the actuator nodes. Add shift to base
+                // locations.
+                grid.pos[i].x() =
+                    static_cast<amrex::Real>(buf[ipx + i]) + bp.x();
+                grid.pos[i].y() =
+                    static_cast<amrex::Real>(buf[ipy + i]) + bp.y();
+                grid.pos[i].z() =
+                    static_cast<amrex::Real>(buf[ipz + i]) + bp.z();
+
+                // Copy over the orientation matrix
+                //
+                // Note that we transpose the orientation matrix when copying
+                // from OpenFAST to AMR-Wind Tensor data structure. This is done
+                // so that post-multiplication of vector transforms from global
+                // to local reference frame.
+                const size_t off = iori + i * AMREX_SPACEDIM * AMREX_SPACEDIM;
+                for (int j = 0; j < AMREX_SPACEDIM; ++j)
+                    for (int k = 0; k < AMREX_SPACEDIM; ++k)
+                        grid.orientation[i][j * AMREX_SPACEDIM + k] =
+                            static_cast<amrex::Real>(
+                                buf[off + j + k * AMREX_SPACEDIM]);
+            }
+
+            // Extract the rotor center of rotation
+            auto& meta = data.meta();
+            meta.rot_center = grid.pos[0];
+
+            // Rotor non-rotating reference frame
+            const auto xvec = grid.orientation[0].x().unit();
+            const auto yvec = vs::Vector::khat() ^ xvec;
+            const auto zvec = xvec ^ yvec;
+            meta.rotor_frame.rows(xvec, yvec.unit(), zvec.unit());
+        }
+    }
+};
+
+template <typename SrcTrait>
+struct ProcessOutputsOp<TurbineFast, SrcTrait>
+{
+private:
+    typename TurbineFast::DataType& m_data;
+
+    //! Path to the output directory (specified by Actuator physics class)
+    std::string m_out_dir{""};
+
+    //! NetCDF output filename for this turbine
+    std::string m_nc_filename{""};
+
+    //! Output frequency (specified in input file)
+    int m_out_freq{10};
+
+public:
+    ProcessOutputsOp(typename TurbineFast::DataType& data) : m_data(data) {}
+
+    void read_io_options(const utils::ActParser& pp)
+    {
+        pp.query("output_frequency", m_out_freq);
+    }
+
+    void prepare_outputs(const std::string& out_dir)
+    {
+        m_nc_filename = out_dir + "/" + m_data.info().label + ".nc";
+        utils::prepare_netcdf_file(
+            m_nc_filename, m_data.meta(), m_data.info(), m_data.grid());
+    }
+
+    void write_outputs()
+    {
+        const auto& time = m_data.sim().time();
+        const int tidx = time.time_index();
+        if ((m_out_freq > 0) && (tidx % m_out_freq != 0)) return;
+
+        utils::write_netcdf(
+            m_nc_filename, m_data.meta(), m_data.info(), m_data.grid(),
+            time.new_time());
+    }
+};
+
+} // namespace ops
+} // namespace actuator
+} // namespace amr_wind
+
+#endif /* TURBINE_FAST_OPS_H */

--- a/amr-wind/wind_energy/actuator/turbine/turbine_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_types.H
@@ -17,7 +17,9 @@ struct TurbineInfo : public ActInfo
     //! Hub height of this turbine
     amrex::Real hub_height{0.0};
 
-    TurbineInfo(const std::string& label, const int id) : ActInfo(label, id) {}
+    TurbineInfo(const std::string& label_in, const int id_in)
+        : ActInfo(label_in, id_in)
+    {}
 };
 
 struct ComponentView

--- a/amr-wind/wind_energy/actuator/turbine/turbine_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_types.H
@@ -1,0 +1,88 @@
+#ifndef TURBINE_TYPES_H
+#define TURBINE_TYPES_H
+
+#include "amr-wind/wind_energy/actuator/actuator_types.H"
+
+namespace amr_wind {
+namespace actuator {
+
+struct TurbineInfo : public ActInfo
+{
+    //! Base location of this turbine
+    vs::Vector base_pos;
+
+    //! Rotor diameter for this turbine
+    amrex::Real rotor_diameter{0.0};
+
+    //! Hub height of this turbine
+    amrex::Real hub_height{0.0};
+
+    TurbineInfo(const std::string& label, const int id) : ActInfo(label, id) {}
+};
+
+struct ComponentView
+{
+    VecSlice pos;
+    VecSlice force;
+    VecSlice epsilon;
+    TensorSlice orientation;
+
+    VecSlice vel_pos;
+    VecSlice vel;
+
+    RealSlice chord;
+};
+
+struct TurbineBaseData
+{
+    //! Number of blades
+    int num_blades{3};
+
+    //! Number of actuator nodes per blade
+    int num_pts_blade;
+
+    //! Number of actuator nodes for tower
+    int num_pts_tower;
+
+    RealList chord;
+
+    //! Center of rotation for the rotor
+    vs::Vector rot_center;
+
+    /** Reference frame for the rotor plane
+     *
+     *  x - Pointing downwind along shaft/rotation axis
+     *  y - lateral direction
+     *  z - normal direction (pointing mostly along z-direction)
+     */
+    vs::Tensor rotor_frame;
+
+    //! General epsilon provided
+    vs::Vector eps_inp;
+
+    //! Gaussian smearing factor for the blade
+    vs::Vector eps_chord;
+
+    //! Minimum epsilon when using chord based epsilon
+    vs::Vector eps_min;
+
+    //! Gaussian smearing factor for tower
+    vs::Vector eps_tower;
+
+    //! Drag coefficient for nacelle
+    amrex::Real nacelle_cd{0.0};
+
+    //! Wetted surface area for nacelle
+    amrex::Real nacelle_area{0.0};
+
+    std::vector<ComponentView> blades;
+    ComponentView tower;
+};
+
+struct TurbineType : public ActuatorType
+{};
+
+} // namespace actuator
+} // namespace amr_wind
+
+#endif /* TURBINE_TYPES_H */

--- a/amr-wind/wind_energy/actuator/turbine/turbine_utils.H
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_utils.H
@@ -1,0 +1,30 @@
+#ifndef TURBINE_UTILS_H
+#define TURBINE_UTILS_H
+
+#include "amr-wind/wind_energy/actuator/turbine/turbine_types.H"
+#include "amr-wind/wind_energy/actuator/ActParser.H"
+
+namespace amr_wind {
+namespace actuator {
+namespace utils {
+void read_inputs(
+    TurbineBaseData& tdata, TurbineInfo& info, const utils::ActParser& pp);
+
+void prepare_netcdf_file(
+    const std::string&,
+    const TurbineBaseData&,
+    const TurbineInfo&,
+    const ActGrid&);
+
+void write_netcdf(
+    const std::string&,
+    const TurbineBaseData&,
+    const TurbineInfo&,
+    const ActGrid&,
+    const amrex::Real);
+
+} // namespace utils
+} // namespace actuator
+} // namespace amr_wind
+
+#endif /* TURBINE_UTILS_H */

--- a/amr-wind/wind_energy/actuator/turbine/turbine_utils.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_utils.cpp
@@ -1,0 +1,148 @@
+#include "amr-wind/wind_energy/actuator/turbine/turbine_utils.H"
+#include "amr-wind/utilities/ncutils/nc_interface.H"
+#include "amr-wind/utilities/io_utils.H"
+
+namespace amr_wind {
+namespace actuator {
+namespace utils {
+
+void read_inputs(
+    TurbineBaseData& tdata, TurbineInfo& tinfo, const utils::ActParser& pp)
+{
+    pp.query("num_blades", tdata.num_blades);
+    pp.get("num_points_blade", tdata.num_pts_blade);
+    pp.get("num_points_tower", tdata.num_pts_tower);
+    pp.query("nacelle_area", tdata.nacelle_area);
+    pp.query("nacelle_drag_coeff", tdata.nacelle_cd);
+
+    if (!pp.contains("epsilon") && !pp.contains("epsilon_chord")) {
+        amrex::Abort(
+            "Actuator turbine simulations require specification of one or both "
+            "of 'epsilon' or 'epsilon_chord'");
+    }
+
+    pp.query("epsilon", tdata.eps_inp);
+    pp.query("epsilon_chord", tdata.eps_chord);
+    pp.query("epsilon_min", tdata.eps_min);
+    pp.query("epsilon_tower", tdata.eps_tower);
+
+    pp.get("base_position", tinfo.base_pos);
+    pp.get("rotor_diameter", tinfo.rotor_diameter);
+    pp.get("hub_height", tinfo.hub_height);
+
+    // clang-format off
+    const auto& bp = tinfo.base_pos;
+    const auto& rad = 0.5 * tinfo.rotor_diameter;
+    const auto& hh = tinfo.hub_height;
+    tinfo.bound_box = amrex::RealBox(
+        bp.x() - 1.25 * rad, bp.y() - 1.25 * rad, bp.z() - 1.25 * rad,
+        bp.x() + 1.25 * rad, bp.y() + 1.25 * rad, bp.z() + 1.25 * rad + hh
+    );
+    // clang-format on
+}
+
+void prepare_netcdf_file(
+    const std::string& ncfile,
+    const TurbineBaseData& meta,
+    const TurbineInfo& info,
+    const ActGrid& grid)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    // Only root process handles I/O
+    if (!info.is_root_proc) return;
+
+    auto ncf = ncutils::NCFile::create(ncfile, NC_CLOBBER | NC_NETCDF4);
+    const std::string nt_name = "num_time_steps";
+    const std::string np_name = "num_actuator_points";
+    const std::string nvel_name = "num_vel_points";
+    const std::vector<std::string> two_dim{nt_name, np_name};
+
+    ncf.enter_def_mode();
+    ncf.put_attr("title", "AMR-Wind turbine actuator output");
+    ncf.put_attr("version", ioutils::amr_wind_version());
+    ncf.put_attr("created_on", ioutils::timestamp());
+    ncf.def_dim(nt_name, NC_UNLIMITED);
+    ncf.def_dim("ndim", AMREX_SPACEDIM);
+    ncf.def_dim("mat_dim", AMREX_SPACEDIM * AMREX_SPACEDIM);
+
+    auto grp = ncf.def_group(info.label);
+    grp.put_attr("num_blades", std::vector<int>{meta.num_blades});
+    grp.put_attr("num_points_blade", std::vector<int>{meta.num_pts_blade});
+    grp.put_attr("num_points_tower", std::vector<int>{meta.num_pts_tower});
+    grp.put_attr("rotor_diameter", std::vector<double>{info.rotor_diameter});
+    grp.put_attr("hub_height", std::vector<double>{info.hub_height});
+    // clang-format off
+    grp.put_attr("base_location", std::vector<double>{
+            info.base_pos.x(), info.base_pos.y(), info.base_pos.z()});
+    // clang-format on
+
+    const size_t nfpts = grid.force.size();
+    const size_t nvpts = grid.vel.size();
+    grp.def_dim(np_name, nfpts);
+    grp.def_dim(nvel_name, nvpts);
+    grp.def_var("time", NC_DOUBLE, {nt_name});
+    grp.def_var("chord", NC_DOUBLE, {np_name});
+    grp.def_var("epsilon", NC_DOUBLE, {np_name, "ndim"});
+    grp.def_var("rot_center", NC_DOUBLE, {nt_name, "ndim"});
+    grp.def_var("rotor_frame", NC_DOUBLE, {nt_name, "mat_dim"});
+    grp.def_var("xyz", NC_DOUBLE, {nt_name, np_name, "ndim"});
+    grp.def_var("force", NC_DOUBLE, {nt_name, np_name, "ndim"});
+    grp.def_var("orientation", NC_DOUBLE, {nt_name, np_name, "mat_dim"});
+    grp.def_var("vel_xyz", NC_DOUBLE, {nt_name, nvel_name, "ndim"});
+    grp.def_var("vel", NC_DOUBLE, {nt_name, nvel_name, "ndim"});
+    ncf.exit_def_mode();
+
+    {
+        auto chord = grp.var("chord");
+        chord.put(&(meta.chord[0]), {0}, {nfpts});
+        auto eps = grp.var("epsilon");
+        eps.put(&(grid.epsilon[0][0]), {0, 0}, {nfpts, AMREX_SPACEDIM});
+    }
+
+#else
+    amrex::ignore_unused(ncfile, meta, info, grid);
+#endif
+}
+
+void write_netcdf(
+    const std::string& ncfile,
+    const TurbineBaseData& meta,
+    const TurbineInfo& info,
+    const ActGrid& grid,
+    const amrex::Real time)
+{
+#ifdef AMR_WIND_USE_NETCDF
+    // Only root process handles I/O
+    if (!info.is_root_proc) return;
+
+    auto ncf = ncutils::NCFile::open(ncfile, NC_WRITE);
+    const std::string nt_name = "num_time_steps";
+    const std::string np_name = "num_actuator_points";
+    const std::string nvel_name = "num_vel_points";
+    // Index of next timestep
+    const size_t nt = ncf.dim(nt_name).len();
+    const size_t nfpts = grid.force.size();
+    const size_t nvpts = grid.vel.size();
+
+    auto grp = ncf.group(info.label);
+    grp.var("time").put(&time, {nt}, {1});
+    grp.var("rot_center").put(&(meta.rot_center[0]), {nt, 0}, {1, 3});
+    grp.var("rotor_frame").put(&(meta.rotor_frame[0]), {nt, 0}, {1, 9});
+    grp.var("xyz").put(
+        &(grid.pos[0][0]), {nt, 0, 0}, {1, nfpts, AMREX_SPACEDIM});
+    grp.var("force").put(
+        &(grid.force[0][0]), {nt, 0, 0}, {1, nfpts, AMREX_SPACEDIM});
+    grp.var("orientation")
+        .put(&(grid.orientation[0][0]), {nt, 0, 0}, {1, nfpts, 9});
+    grp.var("vel_xyz").put(
+        &(grid.vel_pos[0][0]), {nt, 0, 0}, {1, nvpts, AMREX_SPACEDIM});
+    grp.var("vel").put(
+        &(grid.vel[0][0]), {nt, 0, 0}, {1, nvpts, AMREX_SPACEDIM});
+#else
+    amrex::ignore_unused(ncfile, meta, info, grid, time);
+#endif
+}
+
+} // namespace utils
+} // namespace actuator
+} // namespace amr_wind

--- a/unit_tests/wind_energy/actuator/CMakeLists.txt
+++ b/unit_tests/wind_energy/actuator/CMakeLists.txt
@@ -3,3 +3,10 @@ target_sources(${amr_wind_unit_test_exe_name} PRIVATE
   test_actuator_flat_plate.cpp
   test_airfoil.cpp
   )
+
+if (AMR_WIND_ENABLE_OPENFAST)
+  target_sources(${amr_wind_unit_test_exe_name} PRIVATE
+    test_fast_iface.cpp
+    test_turbine_fast.cpp
+    )
+endif()

--- a/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
@@ -208,7 +208,8 @@ TEST_F(ActFlatPlateTest, act_model_init)
     }
 
     amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
-    flat_plate.setup_actuator_source(act_proc_count);
+    flat_plate.determine_influenced_procs(act_proc_count);
+    flat_plate.init_actuator_source();
 
     const auto& info = flat_plate.info();
     EXPECT_EQ(info.root_proc, 0);

--- a/unit_tests/wind_energy/actuator/test_fast_iface.cpp
+++ b/unit_tests/wind_energy/actuator/test_fast_iface.cpp
@@ -79,7 +79,7 @@ TEST_F(FastIfaceTest, fast_init)
     fast.init_solution(fi.tid_local);
     EXPECT_FALSE(fi.is_solution0);
 
-    for (int i=0; i < 2; ++i) {
+    for (int i = 0; i < 2; ++i) {
         fast.advance_turbine(fi.tid_local);
     }
     EXPECT_EQ(fi.time_index, 20);
@@ -131,6 +131,5 @@ TEST_F(FastIfaceTest, fast_replay)
     GTEST_SKIP();
 #endif
 }
-
 
 } // namespace amr_wind_tests

--- a/unit_tests/wind_energy/actuator/test_fast_iface.cpp
+++ b/unit_tests/wind_energy/actuator/test_fast_iface.cpp
@@ -1,0 +1,136 @@
+#include "aw_test_utils/MeshTest.H"
+#include "aw_test_utils/pp_utils.H"
+
+#include "amr-wind/wind_energy/actuator/turbine/fast/FastIface.H"
+
+#include <algorithm>
+
+#define AW_ENABLE_OPENFAST_UTEST 0
+
+namespace amr_wind_tests {
+namespace {
+class FastIfaceTest : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{32, 32, 32}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", 16);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{128.0, 128.0, 256.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+        }
+    }
+};
+
+} // namespace
+
+TEST_F(FastIfaceTest, fast_init)
+{
+    initialize_mesh();
+    pp_utils::default_time_inputs();
+    {
+        amrex::ParmParse pp("time");
+        pp.add("fixed_dt", 0.0625);
+    }
+    sim().time().parse_parameters();
+
+    const int iproc = amrex::ParallelDescriptor::MyProc();
+    ::exw_fast::FastTurbine fi;
+    fi.tlabel = "T001";
+    fi.tid_local = -1;
+    fi.tid_global = iproc;
+    fi.num_pts_blade = 5;
+    fi.num_pts_tower = 5;
+    fi.base_pos[0] = 64.0f;
+    fi.base_pos[1] = 64.0f;
+    fi.base_pos[2] = 0.0f;
+    fi.input_file = "./fast_inp/nrel5mw.fst";
+    fi.start_time = 0.0;
+    fi.stop_time = 0.625;
+
+    ::exw_fast::FastIface fast(sim());
+    fast.parse_inputs(sim(), "OpenFAST");
+    fast.register_turbine(fi);
+
+    EXPECT_EQ(fi.tid_local, 0);
+
+#if AW_ENABLE_OPENFAST_UTEST
+    fast.init_turbine(fi.tid_local);
+    EXPECT_NEAR(fi.dt_fast, 0.00625, 1.0e-12);
+    EXPECT_EQ(fi.num_substeps, 10);
+    EXPECT_EQ(fi.num_blades, 3);
+    EXPECT_TRUE(fi.is_solution0);
+
+    std::fill(fi.from_cfd.u, fi.from_cfd.u + fi.from_cfd.u_Len, 6.0);
+    std::fill(fi.from_cfd.v, fi.from_cfd.v + fi.from_cfd.v_Len, 0.0);
+    std::fill(fi.from_cfd.w, fi.from_cfd.w + fi.from_cfd.w_Len, 0.0);
+    fast.init_solution(fi.tid_local);
+    EXPECT_FALSE(fi.is_solution0);
+
+    for (int i=0; i < 2; ++i) {
+        fast.advance_turbine(fi.tid_local);
+    }
+    EXPECT_EQ(fi.time_index, 20);
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST_F(FastIfaceTest, fast_replay)
+{
+    initialize_mesh();
+    pp_utils::default_time_inputs();
+    {
+        amrex::ParmParse pp("time");
+        pp.add("fixed_dt", 0.0625);
+    }
+    sim().time().parse_parameters();
+
+    const int iproc = amrex::ParallelDescriptor::MyProc();
+    ::exw_fast::FastTurbine fi;
+    fi.tlabel = "T001";
+    fi.tid_local = -1;
+    fi.tid_global = iproc;
+    fi.num_pts_blade = 5;
+    fi.num_pts_tower = 5;
+    fi.base_pos[0] = 64.0f;
+    fi.base_pos[1] = 64.0f;
+    fi.base_pos[2] = 0.0f;
+    fi.input_file = "./fast_inp/nrel5mw1.fst";
+    fi.start_time = 0.125;
+    fi.stop_time = 0.625;
+    fi.sim_mode = ::exw_fast::SimMode::replay;
+
+    ::exw_fast::FastIface fast(sim());
+    fast.parse_inputs(sim(), "OpenFAST");
+    fast.register_turbine(fi);
+
+    EXPECT_EQ(fi.tid_local, 0);
+    EXPECT_TRUE(fi.is_solution0);
+
+#if AW_ENABLE_OPENFAST_UTEST
+    fast.init_turbine(fi.tid_local);
+    EXPECT_EQ(fi.time_index, 20);
+    EXPECT_FALSE(fi.is_solution0);
+
+    fast.advance_turbine(fi.tid_local);
+    EXPECT_EQ(fi.time_index, 30);
+#else
+    GTEST_SKIP();
+#endif
+}
+
+
+} // namespace amr_wind_tests

--- a/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
+++ b/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
@@ -1,0 +1,142 @@
+#include "aw_test_utils/MeshTest.H"
+#include "test_act_utils.H"
+
+#include "amr-wind/wind_energy/actuator/turbine/fast/TurbineFast.H"
+#include "amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H"
+#include "amr-wind/wind_energy/actuator/ActParser.H"
+#include "amr-wind/wind_energy/actuator/Actuator.H"
+
+#define AW_ENABLE_OPENFAST_UTEST 0
+
+namespace amr_wind_tests {
+namespace {
+
+class ActTurbineFastTest : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{32, 32, 32}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", 16);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{128.0, 128.0, 256.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+        }
+        {
+            amrex::ParmParse pp("Actuator");
+            pp.add("type", std::string("TurbineFastLine"));
+        }
+        {
+            amrex::ParmParse pp("Actuator.TurbineFastLine");
+            pp.addarr(
+                "base_position", amrex::Vector<amrex::Real>{64.0, 64.0, 0.0});
+            pp.add("rotor_diameter", 126.0);
+            pp.add("hub_height", 90.0);
+            pp.add("num_points_blade", 5);
+            pp.add("num_points_tower", 5);
+            pp.addarr("epsilon", amrex::Vector<amrex::Real>{3.0, 3.0, 3.0});
+            pp.addarr(
+                "epsilon_chord", amrex::Vector<amrex::Real>{3.0, 3.0, 3.0});
+
+            pp.add("openfast_input_file", std::string("fast_inp/nrel5mw.fst"));
+            pp.add("openfast_start_time", 0.0);
+            pp.add("openfast_stop_time", 0.625);
+
+            pp.add("nacelle_drag_coeff", 1.0);
+            pp.add("nacelle_area", 100.0);
+        }
+    }
+};
+
+class ActTurbPhyTest : public ::amr_wind::actuator::Actuator
+{
+public:
+    ActTurbPhyTest(::amr_wind::CFDSim& sim)
+        : ::amr_wind::actuator::Actuator(sim)
+    {}
+
+protected:
+    void prepare_outputs() override {}
+};
+
+} // namespace
+
+TEST_F(ActTurbineFastTest, test_ops)
+{
+    namespace act = ::amr_wind::actuator;
+
+    initialize_mesh();
+    act::utils::ActParser pp("Actuator.TurbineFastLine", "Actuator.T1");
+    act::ActDataHolder<act::TurbineFast> data(sim(), "T1", 0);
+    {
+        using ReadOp = act::ops::ReadInputsOp<act::TurbineFast, act::ActSrcLine>;
+        ReadOp op;
+        op(data, pp);
+    }
+
+    amrex::Vector<int> act_proc_count(::amrex::ParallelDescriptor::NProcs(), 0);
+    act::ops::determine_root_proc<act::TurbineFast>(data, act_proc_count);
+
+#ifdef AW_ENABLE_OPENFAST_UTEST
+    {
+        using InitOp = act::ops::InitDataOp<act::TurbineFast, act::ActSrcLine>;
+        InitOp op;
+        op(data);
+    }
+
+    EXPECT_EQ(data.meta().num_blades, 3);
+    {
+        // Check all slice views
+        const auto& grid = data.grid();
+        const auto& blades = data.meta().blades;
+        const auto& tower = data.meta().tower;
+        EXPECT_EQ(std::distance(grid.pos.data(), blades[0].pos.data()), 1);
+        EXPECT_EQ(std::distance(grid.pos.data(), tower.pos.data()), 16);
+        EXPECT_EQ(blades[0].pos.end(), blades[1].pos.begin());
+        EXPECT_EQ(blades[1].pos.end(), blades[2].pos.begin());
+        EXPECT_EQ(blades[2].pos.end(), tower.pos.begin());
+
+        EXPECT_EQ(std::distance(grid.force.data(), blades[0].force.data()), 1);
+        EXPECT_EQ(std::distance(grid.force.data(), tower.force.data()), 16);
+        EXPECT_EQ(blades[0].force.end(), blades[1].force.begin());
+        EXPECT_EQ(blades[1].force.end(), blades[2].force.begin());
+        EXPECT_EQ(blades[2].force.end(), tower.force.begin());
+    }
+#else
+    GTEST_SKIP();
+#endif
+}
+
+TEST_F(ActTurbineFastTest, fast_turbine)
+{
+    initialize_mesh();
+    auto& vel = sim().repo().declare_field("velocity", 3, 3);
+    vel.setVal(10.0, 0, 1, 3);
+
+    {
+        amrex::ParmParse pp("Actuator");
+        amrex::Vector<std::string> actuators{"T1"};
+        pp.addarr("labels", actuators);
+    }
+
+    ActTurbPhyTest act(sim());
+    act.pre_init_actions();
+#ifdef AW_ENABLE_OPENFAST_UTEST
+    act.post_init_actions();
+#else
+    GTEST_SKIP();
+#endif
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
+++ b/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
@@ -80,7 +80,8 @@ TEST_F(ActTurbineFastTest, test_ops)
     act::utils::ActParser pp("Actuator.TurbineFastLine", "Actuator.T1");
     act::ActDataHolder<act::TurbineFast> data(sim(), "T1", 0);
     {
-        using ReadOp = act::ops::ReadInputsOp<act::TurbineFast, act::ActSrcLine>;
+        using ReadOp =
+            act::ops::ReadInputsOp<act::TurbineFast, act::ActSrcLine>;
         ReadOp op;
         op(data, pp);
     }
@@ -88,7 +89,7 @@ TEST_F(ActTurbineFastTest, test_ops)
     amrex::Vector<int> act_proc_count(::amrex::ParallelDescriptor::NProcs(), 0);
     act::ops::determine_root_proc<act::TurbineFast>(data, act_proc_count);
 
-#ifdef AW_ENABLE_OPENFAST_UTEST
+#if AW_ENABLE_OPENFAST_UTEST
     {
         using InitOp = act::ops::InitDataOp<act::TurbineFast, act::ActSrcLine>;
         InitOp op;
@@ -132,7 +133,7 @@ TEST_F(ActTurbineFastTest, fast_turbine)
 
     ActTurbPhyTest act(sim());
     act.pre_init_actions();
-#ifdef AW_ENABLE_OPENFAST_UTEST
+#if AW_ENABLE_OPENFAST_UTEST
     act.post_init_actions();
 #else
     GTEST_SKIP();


### PR DESCRIPTION
This commit introduces actuator models for wind turbines and OpenFAST
integration.

- Add an external solver interface to CFDSim to manage interfacing with solvers
  like OpenFAST

- Introduce OpenFAST interface and update CMake to allow linking to OpenFAST as
  an optional dependency

- Create OpenFAST turbine interface and implement actuator source models using
  OpenFAST data. Currently, initialization from scratch and "restart" using CFD
  velocities from a NetCDF file are supported. True restart using OpenFAST
  checkpoint files still to be implemented.

- Minor update to NetCDF interface to allow writing out floats instead of
  doubles. OpenFAST API requires data in float and not double.
