### PR TITLE
Inflow BC for nodal projection

### DIFF
--- a/amr-wind/boundary_conditions/incflo_set_velocity_bcs.cpp
+++ b/amr-wind/boundary_conditions/incflo_set_velocity_bcs.cpp
@@ -7,7 +7,7 @@ void incflo::set_inflow_velocity(
     int lev, amrex::Real time, MultiFab& vel, int nghost)
 {
     auto& velocity = icns().fields().field;
-    velocity.fillphysbc(lev, time, vel, nghost);
+    velocity.set_inflow(lev, time, vel, nghost);
 #if 0
     auto& bctype = velocity.bc_type();
     Geometry const& gm = Geom(lev);

--- a/amr-wind/core/Field.H
+++ b/amr-wind/core/Field.H
@@ -324,6 +324,12 @@ public:
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost) noexcept;
 
+    void set_inflow(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost) noexcept;
+
     inline void fillpatch(
         int lev,
         amrex::Real time,
@@ -343,6 +349,12 @@ public:
         int lev, amrex::Real time, amrex::MultiFab& mfab, int nghost) noexcept
     {
         fillphysbc(lev, time, mfab, amrex::IntVect(nghost));
+    }
+
+    inline void set_inflow(
+        int lev, amrex::Real time, amrex::MultiFab& mfab, int nghost) noexcept
+    {
+        set_inflow(lev, time, mfab, amrex::IntVect(nghost));
     }
 
 protected:

--- a/amr-wind/core/Field.cpp
+++ b/amr-wind/core/Field.cpp
@@ -227,6 +227,19 @@ void Field::apply_bc_funcs(const FieldState rho_state) noexcept
     for (auto& func : m_info->m_bc_func) (*func)(*this, rho_state);
 }
 
+void Field::set_inflow(
+    int lev,
+    amrex::Real time,
+    amrex::MultiFab& mfab,
+    const amrex::IntVect& ng) noexcept
+{
+    BL_PROFILE("amr-wind::Field::set_inflow");
+    BL_ASSERT(m_info->m_fillpatch_op);
+    BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
+    auto& fop = *(m_info->m_fillpatch_op);
+    fop.set_inflow(lev, time, mfab, ng, field_state());
+}
+
 void Field::advance_states() noexcept
 {
     BL_PROFILE("amr-wind::Field::advance_states");

--- a/amr-wind/core/FieldBCOps.H
+++ b/amr-wind/core/FieldBCOps.H
@@ -63,6 +63,16 @@ struct FieldBCNoOp
         const int /* bcomp */,
         const int /* orig_comp */) const
     {}
+
+    AMREX_GPU_DEVICE
+    inline void set_inflow(
+        const amrex::IntVect&,
+        amrex::Array4<amrex::Real> const&,
+        amrex::GeometryData const&,
+        const amrex::Real,
+        amrex::Orientation,
+        const int) const
+    {}
 };
 
 struct ConstDirichlet
@@ -200,6 +210,18 @@ struct DirichletOp
             }
 #endif
         }
+    }
+
+    AMREX_GPU_DEVICE
+    inline void set_inflow(
+        const amrex::IntVect& iv,
+        amrex::Array4<amrex::Real> const& field,
+        amrex::GeometryData const& geom,
+        const amrex::Real time,
+        amrex::Orientation ori,
+        const int comp) const
+    {
+        m_inflow_op(iv, field, geom, time, ori, comp);
     }
 };
 

--- a/amr-wind/core/FieldFillPatchOps.H
+++ b/amr-wind/core/FieldFillPatchOps.H
@@ -65,6 +65,13 @@ public:
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
         const FieldState fstate = FieldState::New) = 0;
+
+    virtual void set_inflow(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        const FieldState fstate = FieldState::New) = 0;
 };
 
 /** Implementation that just fills a constant value on newly created grids
@@ -104,6 +111,16 @@ public:
         const FieldState) override
     {
         mfab.setVal(m_fill_val);
+    }
+
+    void set_inflow(
+        int,
+        amrex::Real,
+        amrex::MultiFab&,
+        const amrex::IntVect&,
+        const FieldState) override
+    {
+        amrex::Abort("FieldFillConstScalar::set_inflow is not implemented");
     }
 
 private:
@@ -279,6 +296,47 @@ public:
         amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> physbc(
             m_mesh.Geom(lev), m_field.bcrec(), bc_functor());
         physbc.FillBoundary(mfab, 0, m_field.num_comp(), nghost, time, 0);
+    }
+
+    void set_inflow(
+        int lev,
+        amrex::Real time,
+        amrex::MultiFab& mfab,
+        const amrex::IntVect& nghost,
+        const FieldState) override
+    {
+        const int ng = nghost[0];
+        const auto& bctype = m_field.bc_type();
+        const auto& geom = m_mesh.Geom(lev);
+        const auto& gdata = geom.data();
+        const auto& domain = geom.growPeriodicDomain(ng);
+        const auto& bcfunc = bc_functor();
+        const auto& ncomp = m_field.num_comp();
+
+        for (amrex::OrientationIter oit; oit; ++oit) {
+            auto ori = oit();
+            if (bctype[ori] != BC::mass_inflow) continue;
+
+            const int idir = ori.coordDir();
+            const auto& dbx =
+                ori.isLow() ? amrex::adjCellLo(domain, idir, nghost[idir])
+                            : amrex::adjCellHi(domain, idir, nghost[idir]);
+
+            for (amrex::MFIter mfi(mfab); mfi.isValid(); ++mfi) {
+                const auto& gbx = amrex::grow(mfi.validbox(), nghost);
+                const auto& bx = gbx & dbx;
+                if (!bx.ok()) continue;
+
+                const auto& marr = mfab[mfi].array();
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(
+                            const int i, const int j, const int k) noexcept {
+                        for (int n = 0; n < ncomp; ++n)
+                            bcfunc.set_inflow(
+                                {i, j, k}, marr, gdata, time, ori, n);
+                    });
+            }
+        }
     }
 
 protected:


### PR DESCRIPTION
Recent refactor to generalize inflow BCs (#262) replaced the logic for setting inflow BC in nodal-proj with `fillphysbc`. This PR addresses the issue and reverts back to only setting inflow when doing nodal projection. 