### PR TITLE
Update GoogleTest submodule and suppress remaining unread value warnings

### DIFF
--- a/amr-wind/convection/incflo_godunov_advection.cpp
+++ b/amr-wind/convection/incflo_godunov_advection.cpp
@@ -74,7 +74,6 @@ void godunov::compute_advection(
     Array4<Real> xyzlo = makeArray4(p, bxg1, ncomp);
     p += xyzlo.size();
     Array4<Real> xyzhi = makeArray4(p, bxg1, ncomp);
-    p += xyzhi.size(); // NOLINT: Value not read warning
 
     // Use PPM to generate Im and Ip */
     switch (godunov_scheme) {

--- a/amr-wind/convection/incflo_godunov_advection.cpp
+++ b/amr-wind/convection/incflo_godunov_advection.cpp
@@ -74,7 +74,7 @@ void godunov::compute_advection(
     Array4<Real> xyzlo = makeArray4(p, bxg1, ncomp);
     p += xyzlo.size();
     Array4<Real> xyzhi = makeArray4(p, bxg1, ncomp);
-    p += xyzhi.size();
+    p += xyzhi.size(); // NOLINT: Value not read warning
 
     // Use PPM to generate Im and Ip */
     switch (godunov_scheme) {

--- a/amr-wind/convection/incflo_godunov_predict.cpp
+++ b/amr-wind/convection/incflo_godunov_predict.cpp
@@ -171,7 +171,7 @@ void godunov::predict_godunov(
     Array4<Real> zlo = makeArray4(p, zebox, ncomp);
     p += zlo.size();
     Array4<Real> zhi = makeArray4(p, zebox, ncomp);
-    p += zhi.size();
+    p += zhi.size(); // NOLINT: Value not read warning
 
     amrex::ParallelFor(
         xebox, ncomp,

--- a/amr-wind/core/field_ops.H
+++ b/amr-wind/core/field_ops.H
@@ -336,7 +336,7 @@ inline amrex::Real global_max_magnitude(FType& field)
     const auto& repo = field.repo();
     const auto ncomp = field.num_comp();
 
-    amrex::Real maxglobal;
+    amrex::Real maxglobal = 0.0;
     const int nlevels = repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
         amrex::Real maxglobal_lev = 0.0;

--- a/amr-wind/equation_systems/vof/SplitAdvection.cpp
+++ b/amr-wind/equation_systems/vof/SplitAdvection.cpp
@@ -38,7 +38,7 @@ void multiphase::split_advection(
     Array4<Real> fluxC = makeArray4(p, bxg1, 1);
     p += fluxC.size();
     Array4<Real> fluxR = makeArray4(p, bxg1, 1);
-    p += fluxR.size();
+    p += fluxR.size(); // NOLINT: Value not read warning
 
     if (isweep % 3 == 0) {
         amrex::ParallelFor(

--- a/unit_tests/utilities/test_linear_interpolation.cpp
+++ b/unit_tests/utilities/test_linear_interpolation.cpp
@@ -30,6 +30,7 @@ TEST(LinearInterpolation, check_bounds)
         const amrex::Real xinp = 9.0 * amrex::Random();
         const auto idx = interp::check_bounds(start, end, xinp);
         EXPECT_EQ(idx.idx, 0);
+        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::VALID);
     }
 }
@@ -55,6 +56,7 @@ TEST(LinearInterpolation, bisection_search)
     {
         const auto idx = interp::bisection_search(start, end, 9.1);
         EXPECT_EQ(idx.idx, 9);
+        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::UPLIM);
     }
 }
@@ -85,6 +87,7 @@ TEST(LinearInterpolation, find_index)
     {
         const auto idx = interp::find_index(start, end, 9.1);
         EXPECT_EQ(idx.idx, 9);
+        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::UPLIM);
     }
 }

--- a/unit_tests/wind_energy/actuator/test_airfoil.cpp
+++ b/unit_tests/wind_energy/actuator/test_airfoil.cpp
@@ -60,6 +60,7 @@ TEST(Airfoil, read_txt_file)
     auto af = AirfoilLoader::load_text_file(ss);
     EXPECT_EQ(af->num_entries(), 6);
     EXPECT_NEAR(af->aoa().front(), -1.0 * ::amr_wind::utils::pi(), 1.0e-12);
+    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(af->aoa().back(), 1.0 * ::amr_wind::utils::pi(), 1.0e-12);
 }
 
@@ -71,6 +72,7 @@ TEST(Airfoil, read_openfast_file)
     auto af = AirfoilLoader::load_openfast_airfoil(ss);
     EXPECT_EQ(af->num_entries(), 6);
     EXPECT_NEAR(af->aoa().front(), -1.0 * ::amr_wind::utils::pi(), 1.0e-12);
+    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(af->aoa().back(), ::amr_wind::utils::radians(-150.0), 1.0e-12);
 }
 


### PR DESCRIPTION
I think the unread value warnings are false positives. Updating GoogleTest avoids the CMake deprecation warning about CMake compatibility < 2.18.2 being removed in future releases.