### PR TITLE
OneAPI: Workaround for device reductions in plane averaging code

### DIFF
--- a/amr-wind/utilities/FieldPlaneAveraging.cpp
+++ b/amr-wind/utilities/FieldPlaneAveraging.cpp
@@ -286,9 +286,16 @@ void FPlaneAveraging<FType>::compute_averages(
                             const int ind = idxOp(i, j, k);
 
                             for (int n = 0; n < ncomp; ++n) {
+#ifndef AMREX_USE_DPCPP
                                 amrex::Gpu::deviceReduceSum(
                                     &line_avg[ncomp * ind + n],
                                     fab_arr(i, j, k, n) * denom, handler);
+#else
+                                amrex::ignore_unused(handler);
+                                amrex::HostDevice::Atomic::Add(
+                                    &line_avg[ncomp * ind + n],
+                                    fab_arr(i, j, k, n) * denom);
+#endif
                             }
                         }
                     }
@@ -392,8 +399,14 @@ void VelPlaneAveraging::compute_hvelmag_averages(
                                     fab_arr(i, j, k, h1_idx) +
                                 fab_arr(i, j, k, h2_idx) *
                                     fab_arr(i, j, k, h2_idx));
+#ifndef AMREX_USE_DPCPP
                             amrex::Gpu::deviceReduceSum(
                                 &line_avg[ind], hvelmag * denom, handler);
+#else
+                            amrex::ignore_unused(handler);
+                            amrex::HostDevice::Atomic::Add(
+                                &line_avg[ind], hvelmag * denom);
+#endif
                         }
                     }
                 }

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -135,6 +135,7 @@ void ABLStats::calc_sfs_stress_avgs(
 
 void ABLStats::post_advance_work()
 {
+#ifndef AMREX_USE_DPCPP
     BL_PROFILE("amr-wind::ABLStats::post_advance_work");
     const auto& time = m_sim.time();
     const int tidx = time.time_index();
@@ -158,6 +159,9 @@ void ABLStats::post_advance_work()
     m_pa_uuu();
 
     process_output();
+#else
+    return;
+#endif
 }
 
 template <typename h1_dir, typename h2_dir>


### PR DESCRIPTION
Recent switch to optimized deviceReduceSum for plane averaging does not seem to
work on Intel OneAPI builds. This workaround temporarily reverts back to the old
Atomic::Add approach until a proper fix is determined for this issue.
