### PR TITLE
Allow AMR-Wind to change max_grid_size on restarts

### DIFF
--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -6,6 +6,8 @@
 #include <set>
 
 #include "AMReX_Vector.H"
+#include "AMReX_BoxArray.H"
+#include "AMReX_DistributionMapping.H"
 
 namespace amr_wind {
 
@@ -46,7 +48,10 @@ public:
     void write_checkpoint_file();
 
     //! Read all necessary fields for a restart
-    void read_checkpoint_fields(const std::string& restart_file);
+    void read_checkpoint_fields(
+        const std::string& restart_file,
+        const amrex::Vector<amrex::BoxArray>& ba_chk,
+        const amrex::Vector<amrex::DistributionMapping>& dm_chk);
 
     //! Register a variable for output
     void register_output_var(const std::string& fname)

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -180,7 +180,8 @@ void IOManager::read_checkpoint_fields(
         for (auto* fld : m_chk_fields) {
             auto& field = *fld;
             auto& mfab = field(lev);
-            if (mfab.boxArray() == ba_chk[lev] &&
+            const auto& ba_fab = amrex::convert(ba_chk[lev], mfab.ixType());
+            if (mfab.boxArray() == ba_fab &&
                 mfab.DistributionMap() == dm_chk[lev]) {
                 amrex::VisMF::Read(
                     field(lev),
@@ -188,7 +189,7 @@ void IOManager::read_checkpoint_fields(
                         lev, restart_file, level_prefix, field.name()));
             } else {
                 amrex::MultiFab tmp(
-                    ba_chk[lev], dm_chk[lev], mfab.nComp(), mfab.nGrowVect());
+                    ba_fab, dm_chk[lev], mfab.nComp(), mfab.nGrowVect());
                 amrex::VisMF::Read(
                     tmp, amrex::MultiFabFileFullPrefix(
                              lev, restart_file, level_prefix, field.name()));

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -168,7 +168,10 @@ void IOManager::write_checkpoint_file()
     }
 }
 
-void IOManager::read_checkpoint_fields(const std::string& restart_file)
+void IOManager::read_checkpoint_fields(
+    const std::string& restart_file,
+    const amrex::Vector<amrex::BoxArray>& ba_chk,
+    const amrex::Vector<amrex::DistributionMapping>& dm_chk)
 {
     BL_PROFILE("amr-wind::IOManager::read_checkpoint_fields");
     const std::string level_prefix = "Level_";
@@ -176,9 +179,22 @@ void IOManager::read_checkpoint_fields(const std::string& restart_file)
     for (int lev = 0; lev < nlevels; ++lev) {
         for (auto* fld : m_chk_fields) {
             auto& field = *fld;
-            amrex::VisMF::Read(
-                field(lev), amrex::MultiFabFileFullPrefix(
-                                lev, restart_file, level_prefix, field.name()));
+            auto& mfab = field(lev);
+            if (mfab.boxArray() == ba_chk[lev] &&
+                mfab.DistributionMap() == dm_chk[lev]) {
+                amrex::VisMF::Read(
+                    field(lev),
+                    amrex::MultiFabFileFullPrefix(
+                        lev, restart_file, level_prefix, field.name()));
+            } else {
+                amrex::MultiFab tmp(
+                    ba_chk[lev], dm_chk[lev], mfab.nComp(), mfab.nGrowVect());
+                amrex::VisMF::Read(
+                    tmp, amrex::MultiFabFileFullPrefix(
+                             lev, restart_file, level_prefix, field.name()));
+                mfab.setBndry(0.0);
+                mfab.ParallelCopy(tmp);
+            }
         }
     }
 }

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -106,17 +106,27 @@ void incflo::ReadCheckpointFile()
                      Geom(lev).isPeriodic()));
     }
 
+    amrex::Vector<amrex::BoxArray> ba_inp(finest_level + 1);
+    amrex::Vector<amrex::DistributionMapping> dm_inp(finest_level + 1);
     for (int lev = 0; lev <= finest_level; ++lev) {
         // read in level 'lev' BoxArray from Header
-        BoxArray ba;
-        ba.readFrom(is);
+        ba_inp[lev].readFrom(is);
         GotoNextLine(is);
 
         // Create distribution mapping
-        DistributionMapping dm{ba, ParallelDescriptor::NProcs()};
+        dm_inp[lev].define(ba_inp[lev], ParallelDescriptor::NProcs());
+        DistributionMapping dm = dm_inp[lev];
+
+        BoxArray ba(ba_inp[lev].simplified());
+        ba.maxSize(maxGridSize(lev));
+        if (ba == ba_inp[lev]) {
+            ba = ba_inp[lev];
+        } else {
+            dm = DistributionMapping{ba, ParallelDescriptor::NProcs()};
+        }
 
         MakeNewLevelFromScratch(lev, m_time.current_time(), ba, dm);
     }
 
-    m_sim.io_manager().read_checkpoint_fields(restart_file);
+    m_sim.io_manager().read_checkpoint_fields(restart_file, ba_inp, dm_inp);
 }

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -122,6 +122,8 @@ void incflo::ReadCheckpointFile()
         if (ba == ba_inp[lev]) {
             ba = ba_inp[lev];
         } else {
+            if ((lev == 0) || refine_grid_layout)
+                ChopGrids(lev, ba, ParallelDescriptor::NProcs());
             dm = DistributionMapping{ba, ParallelDescriptor::NProcs()};
         }
 


### PR DESCRIPTION
Modify checkpoint file read behavior to allow the user to change
``max_grid_size`` on restart. The use-case is to restart from a checkpoint file
that was run on CPUs (``max_grid_size = 32``) on GPUs where we want 128.
