### PR TITLE
Print location of NetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,12 @@ include(set_compile_flags)
 
 if (AMR_WIND_ENABLE_NETCDF)
   set(CMAKE_PREFIX_PATH ${NETCDF_DIR} ${CMAKE_PREFIX_PATH})
-  find_package(NetCDF REQUIRED)
+  find_package(NetCDF QUIET REQUIRED)
+  if(NetCDF_FOUND)
+    message(STATUS "Found NetCDF = ${NETCDF_DIR}")
+  endif()
+  target_compile_definitions(${amr_wind_lib_name} PUBLIC AMR_WIND_USE_NETCDF)
+  target_link_libraries_system(${amr_wind_lib_name} PUBLIC NetCDF::NetCDF)
 endif()
 
 if(AMR_WIND_ENABLE_MASA)

--- a/amr-wind/CMakeLists.txt
+++ b/amr-wind/CMakeLists.txt
@@ -39,10 +39,6 @@ include(AMReXBuildInfo)
 generate_buildinfo(${amr_wind_lib_name} ${CMAKE_SOURCE_DIR})
 
 target_link_libraries_system(${amr_wind_lib_name} PUBLIC AMReX::amrex)
-if (AMR_WIND_ENABLE_NETCDF)
-  target_compile_definitions(${amr_wind_lib_name} PUBLIC AMR_WIND_USE_NETCDF)
-  target_link_libraries_system(${amr_wind_lib_name} PUBLIC NetCDF::NetCDF)
-endif()
 target_link_libraries(${amr_wind_exe_name} PRIVATE ${amr_wind_lib_name})
 target_link_libraries(${aw_api_lib} PUBLIC ${amr_wind_lib_name})
 


### PR DESCRIPTION
It's helpful for me to see the location of libraries found during testing. I also think it's better to consolidate the library actions to a single location when possible.