### PR TITLE
ABLBoundaryPlane: defer init actions until after mesh is generated

### DIFF
--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -83,6 +83,7 @@ void ABL::post_init_actions()
     // Register ABL wall function for velocity
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
     if (m_bndry_plane->is_initialized()) {
+        m_bndry_plane->post_init_actions();
         m_bndry_plane->write_header();
         m_bndry_plane->write_file();
         m_bndry_plane->read_header();

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -96,6 +96,8 @@ class ABLBoundaryPlane
 public:
     explicit ABLBoundaryPlane(CFDSim&);
 
+    void post_init_actions();
+
     void write_header();
 
     void write_file();

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -194,15 +194,19 @@ ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
         amrex::Abort(
             "ABLBoundaryPlane capability with IO mode requires NetCDF");
     }
-#endif
-
-#ifdef AMR_WIND_USE_NETCDF
+#else
     pp.query("bndry_write_frequency", m_write_frequency);
     pp.queryarr("bndry_planes", m_planes);
     pp.query("bndry_output_start_time", m_out_start_time);
     pp.queryarr("bndry_var_names", m_var_names);
     pp.get("bndry_file", m_filename);
 
+#endif
+}
+
+void ABLBoundaryPlane::post_init_actions()
+{
+#ifdef AMR_WIND_USE_NETCDF
     for (const auto& plane : m_planes) {
         amrex::Vector<std::string> valid_planes{"xlo", "ylo"};
 
@@ -223,8 +227,8 @@ ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
             }
             m_fields.emplace_back(&fld);
         } else {
-            amrex::Print() << "  Invalid variable requested: " << fname
-                           << std::endl;
+            amrex::Abort(
+                "ABLBoundaryPlane: invalid variable requested: " + fname);
         }
     }
 #endif


### PR DESCRIPTION
ABLBoundaryPlane did a lot of initialization work in the constructor. This was
an issue when the fields to be output/input were created after physics modules
were initialized. For example, TKE which was created by turbulence model.
