### PR TITLE
Refactor ABLStats implementation for non-precursor type runs

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -35,7 +35,7 @@ ABLMeanBoussinesq::ABLMeanBoussinesq(const CFDSim& sim) : m_mesh(sim.mesh())
     amrex::ParmParse pp_incflo("incflo");
     pp_incflo.queryarr("gravity", m_gravity);
 
-    mean_temperature_init(abl.abl_statistics().temperature_plane_stats());
+    mean_temperature_init(abl.abl_statistics().theta_profile());
 }
 
 ABLMeanBoussinesq::~ABLMeanBoussinesq() = default;

--- a/amr-wind/wind_energy/ABL.H
+++ b/amr-wind/wind_energy/ABL.H
@@ -9,7 +9,7 @@
 #include "amr-wind/wind_energy/ABLBoundaryPlane.H"
 #include "amr-wind/core/SimTime.H"
 #include "amr-wind/utilities/FieldPlaneAveraging.H"
-#include "amr-wind/wind_energy/ABLStats.H"
+#include "amr-wind/wind_energy/ABLStatsBase.H"
 /**
  *  \defgroup wind Wind energy modeling
  *  Wind energy modeling
@@ -84,7 +84,7 @@ public:
     const ABLBoundaryPlane& bndry_plane() const { return *m_bndry_plane; }
 
     //! Return the ABL statistics calculator
-    const ABLStats& abl_statistics() const { return *m_stats; }
+    const ABLStatsBase& abl_statistics() const { return *m_stats; }
 
 private:
     const CFDSim& m_sim;
@@ -107,7 +107,7 @@ private:
     mutable pde::icns::ABLForcing* m_abl_forcing{nullptr};
 
     //! ABL integrated statistics object
-    std::unique_ptr<ABLStats> m_stats;
+    std::unique_ptr<ABLStatsBase> m_stats;
 
     mutable pde::icns::ABLMeanBoussinesq* m_abl_mean_bous{nullptr};
 };

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -80,14 +80,9 @@ void ABL::post_init_actions()
 
     // Register ABL wall function for velocity
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
-    if (m_bndry_plane->is_initialized()) {
-        m_bndry_plane->post_init_actions();
-        m_bndry_plane->write_header();
-        m_bndry_plane->write_file();
-        m_bndry_plane->read_header();
-        m_bndry_plane->read_file();
-    }
     (*m_temperature).register_custom_bc<ABLTempWallFunc>(m_abl_wall_func);
+
+    m_bndry_plane->post_init_actions();
 }
 
 /** Perform tasks at the beginning of a new timestep
@@ -119,9 +114,7 @@ void ABL::pre_advance_work()
         m_abl_mean_bous->mean_temperature_update(
             m_stats->temperature_plane_stats());
 
-    if (m_bndry_plane->is_initialized()) {
-        m_bndry_plane->read_file();
-    }
+    m_bndry_plane->pre_advance_work();
 }
 
 /** Perform tasks at the end of a new timestep
@@ -132,10 +125,7 @@ void ABL::pre_advance_work()
 void ABL::post_advance_work()
 {
     m_stats->post_advance_work();
-
-    if (m_bndry_plane->is_initialized()) {
-        m_bndry_plane->write_file();
-    }
+    m_bndry_plane->post_advance_work();
 }
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -62,8 +62,6 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
             temp.array(mfi));
     }
 
-    m_stats->initialize();
-
     if (m_sim.repo().field_exists("tke")) {
         m_tke = &(m_sim.repo().get_field("tke"));
         auto& tke = (*m_tke)(level);
@@ -73,9 +71,9 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
 
 void ABL::post_init_actions()
 {
-    m_abl_wall_func.init_log_law_height();
+    m_stats->post_init_actions();
 
-    m_stats->calc_averages();
+    m_abl_wall_func.init_log_law_height();
 
     m_abl_wall_func.update_umean(
         m_stats->vel_plane_averaging(), m_stats->temperature_plane_stats());
@@ -133,7 +131,6 @@ void ABL::pre_advance_work()
  */
 void ABL::post_advance_work()
 {
-    m_stats->calc_averages();
     m_stats->post_advance_work();
 
     if (m_bndry_plane->is_initialized()) {

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -96,7 +96,14 @@ class ABLBoundaryPlane
 public:
     explicit ABLBoundaryPlane(CFDSim&);
 
+    //! Execute initialization actions after mesh has been fully generated
     void post_init_actions();
+
+    void pre_advance_work();
+
+    void post_advance_work();
+
+    void initialize_data();
 
     void write_header();
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -110,9 +110,9 @@ void InletData::read_data(
     const size_t n0 = bx.length(perp[0]);
     const size_t n1 = bx.length(perp[1]);
 
-    amrex::Vector<size_t> start{
-        static_cast<size_t>(idx), static_cast<size_t>(lo[perp[0]]),
-        static_cast<size_t>(lo[perp[1]]), 0};
+    amrex::Vector<size_t> start{static_cast<size_t>(idx),
+                                static_cast<size_t>(lo[perp[0]]),
+                                static_cast<size_t>(lo[perp[1]]), 0};
     amrex::Vector<size_t> count{1, n0, n1, nc};
     amrex::Vector<amrex::Real> buffer(n0 * n1 * nc);
     grp.var(fld->name()).get(buffer.data(), start, count);
@@ -205,6 +205,28 @@ ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
 }
 
 void ABLBoundaryPlane::post_init_actions()
+{
+    if (!m_is_initialized) return;
+    initialize_data();
+    write_header();
+    write_file();
+    read_header();
+    read_file();
+}
+
+void ABLBoundaryPlane::pre_advance_work()
+{
+    if (!m_is_initialized) return;
+    read_file();
+}
+
+void ABLBoundaryPlane::post_advance_work()
+{
+    if (!m_is_initialized) return;
+    write_file();
+}
+
+void ABLBoundaryPlane::initialize_data()
 {
 #ifdef AMR_WIND_USE_NETCDF
     for (const auto& plane : m_planes) {
@@ -655,9 +677,8 @@ void ABLBoundaryPlane::write_data(
                 lbx, n1, nc, perp, v_offset, fld_arr, buffer.data);
             amrex::Gpu::streamSynchronize();
 
-            buffer.start = {
-                m_out_counter, static_cast<size_t>(lo[perp[0]]),
-                static_cast<size_t>(lo[perp[1]]), 0};
+            buffer.start = {m_out_counter, static_cast<size_t>(lo[perp[0]]),
+                            static_cast<size_t>(lo[perp[1]]), 0};
             buffer.count = {1, n0, n1, nc};
         }
     }

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -110,9 +110,9 @@ void InletData::read_data(
     const size_t n0 = bx.length(perp[0]);
     const size_t n1 = bx.length(perp[1]);
 
-    amrex::Vector<size_t> start{static_cast<size_t>(idx),
-                                static_cast<size_t>(lo[perp[0]]),
-                                static_cast<size_t>(lo[perp[1]]), 0};
+    amrex::Vector<size_t> start{
+        static_cast<size_t>(idx), static_cast<size_t>(lo[perp[0]]),
+        static_cast<size_t>(lo[perp[1]]), 0};
     amrex::Vector<size_t> count{1, n0, n1, nc};
     amrex::Vector<amrex::Real> buffer(n0 * n1 * nc);
     grp.var(fld->name()).get(buffer.data(), start, count);
@@ -677,8 +677,9 @@ void ABLBoundaryPlane::write_data(
                 lbx, n1, nc, perp, v_offset, fld_arr, buffer.data);
             amrex::Gpu::streamSynchronize();
 
-            buffer.start = {m_out_counter, static_cast<size_t>(lo[perp[0]]),
-                            static_cast<size_t>(lo[perp[1]]), 0};
+            buffer.start = {
+                m_out_counter, static_cast<size_t>(lo[perp[0]]),
+                static_cast<size_t>(lo[perp[1]]), 0};
             buffer.count = {1, n0, n1, nc};
         }
     }

--- a/amr-wind/wind_energy/ABLStats.H
+++ b/amr-wind/wind_energy/ABLStats.H
@@ -37,6 +37,9 @@ public:
 
     virtual ~ABLStats();
 
+    // Perform initialization actions after the mesh has been created
+    void post_init_actions();
+
     //! Read user inputs and create the necessary files
     void initialize();
 

--- a/amr-wind/wind_energy/ABLStats.H
+++ b/amr-wind/wind_energy/ABLStats.H
@@ -1,8 +1,7 @@
 #ifndef ABLISTATS_H
 #define ABLISTATS_H
 
-#include <memory>
-
+#include "amr-wind/wind_energy/ABLStatsBase.H"
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/utilities/FieldPlaneAveraging.H"
 #include "amr-wind/utilities/SecondMomentAveraging.H"
@@ -28,41 +27,40 @@ class ABLForcing;
  *
  * \ingroup we_abl
  */
-class ABLStats
+class ABLStats : public ABLStatsBase::Register<ABLStats>
 {
 public:
-    static const std::string identifier() { return "ABLStats"; }
+    static const std::string identifier() { return "precursor"; }
 
-    ABLStats(CFDSim&, const ABLWallFunction&);
+    ABLStats(CFDSim&, const ABLWallFunction&, const int dir);
 
     virtual ~ABLStats();
 
+    ABLStatsMode abl_mode() const override { return ABLStatsMode::computed; }
+
     // Perform initialization actions after the mesh has been created
-    void post_init_actions();
+    void post_init_actions() override;
 
-    //! Read user inputs and create the necessary files
-    void initialize();
-
-    //! Calculate plane average profiles
-    void calc_averages();
+    //! Perform actions before a new timestep
+    void pre_advance_work() override {}
 
     //! Process fields given timestep and output to disk
-    void post_advance_work();
+    void post_advance_work() override;
 
     //! Compute height of capping inversion
     template <typename h1_dir, typename h2_dir>
     void compute_zi(const h1_dir& h1Sel, const h2_dir& h2Sel);
 
     //! Return vel plane averaging instance
-    const VelPlaneAveraging& vel_plane_averaging() { return m_pa_vel; };
+    const VelPlaneAveraging& vel_profile() const override { return m_pa_vel; };
 
     //! Return instance that handles temperature statistics
-    const FieldPlaneAveraging& temperature_plane_stats() const
+    const FieldPlaneAveraging& theta_profile() const override
     {
         return m_pa_temp;
     }
 
-    void register_forcing_term(pde::icns::ABLForcing* forcing) const
+    void register_forcing_term(pde::icns::ABLForcing* forcing) const override
     {
         m_abl_forcing = forcing;
     }
@@ -72,6 +70,12 @@ public:
     calc_sfs_stress_avgs(ScratchField& sfs_stress, ScratchField& t_sfs_stress);
 
 protected:
+    //! Read user inputs and create the necessary files
+    void initialize();
+
+    //! Calculate plane average profiles
+    void calc_averages();
+
     //! Output data based on user-defined format
     virtual void process_output();
 

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -480,8 +480,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'theta'_r", "v'theta'_r",
-                                                 "w'theta'_r"};
+            amrex::Vector<std::string> var_names{
+                "u'theta'_r", "v'theta'_r", "w'theta'_r"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 m_pa_tu.line_moment(i, l_vec);
                 auto var = grp.var(var_names[i]);
@@ -501,8 +501,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'u'u'_r", "v'v'v'_r",
-                                                 "w'w'w'_r"};
+            amrex::Vector<std::string> var_names{
+                "u'u'u'_r", "v'v'v'_r", "w'w'w'_r"};
             amrex::Vector<int> var_comp{0, 13, 26};
             for (int i = 0; i < var_comp.size(); i++) {
                 m_pa_uuu.line_moment(var_comp[i], l_vec);
@@ -512,8 +512,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'v'_sfs", "u'w'_sfs",
-                                                 "v'w'_sfs"};
+            amrex::Vector<std::string> var_names{
+                "u'v'_sfs", "u'w'_sfs", "v'w'_sfs"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 pa_sfs.line_average(i, l_vec);
                 auto var = grp.var(var_names[i]);
@@ -522,8 +522,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{"u'theta'_sfs", "v'theta'_sfs",
-                                                 "w'theta'_sfs"};
+            amrex::Vector<std::string> var_names{
+                "u'theta'_sfs", "v'theta'_sfs", "w'theta'_sfs"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 pa_tsfs.line_average(i, l_vec);
                 auto var = grp.var(var_names[i]);

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -35,6 +35,12 @@ ABLStats::ABLStats(CFDSim& sim, const ABLWallFunction& abl_wall_func)
 
 ABLStats::~ABLStats() = default;
 
+void ABLStats::post_init_actions()
+{
+    initialize();
+    calc_averages();
+}
+
 void ABLStats::initialize()
 {
     BL_PROFILE("amr-wind::ABLStats::initialize");
@@ -135,8 +141,12 @@ void ABLStats::calc_sfs_stress_avgs(
 
 void ABLStats::post_advance_work()
 {
-#ifndef AMREX_USE_DPCPP
     BL_PROFILE("amr-wind::ABLStats::post_advance_work");
+
+    // Always compute mean velocity/temperature profiles
+    calc_averages();
+
+#ifndef AMREX_USE_DPCPP
     const auto& time = m_sim.time();
     const int tidx = time.time_index();
     // Skip processing if it is not an output timestep
@@ -469,8 +479,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{
-                "u'theta'_r", "v'theta'_r", "w'theta'_r"};
+            amrex::Vector<std::string> var_names{"u'theta'_r", "v'theta'_r",
+                                                 "w'theta'_r"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 m_pa_tu.line_moment(i, l_vec);
                 auto var = grp.var(var_names[i]);
@@ -490,8 +500,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{
-                "u'u'u'_r", "v'v'v'_r", "w'w'w'_r"};
+            amrex::Vector<std::string> var_names{"u'u'u'_r", "v'v'v'_r",
+                                                 "w'w'w'_r"};
             amrex::Vector<int> var_comp{0, 13, 26};
             for (int i = 0; i < var_comp.size(); i++) {
                 m_pa_uuu.line_moment(var_comp[i], l_vec);
@@ -501,8 +511,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{
-                "u'v'_sfs", "u'w'_sfs", "v'w'_sfs"};
+            amrex::Vector<std::string> var_names{"u'v'_sfs", "u'w'_sfs",
+                                                 "v'w'_sfs"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 pa_sfs.line_average(i, l_vec);
                 auto var = grp.var(var_names[i]);
@@ -511,8 +521,8 @@ void ABLStats::write_netcdf()
         }
 
         {
-            amrex::Vector<std::string> var_names{
-                "u'theta'_sfs", "v'theta'_sfs", "w'theta'_sfs"};
+            amrex::Vector<std::string> var_names{"u'theta'_sfs", "v'theta'_sfs",
+                                                 "w'theta'_sfs"};
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
                 pa_tsfs.line_average(i, l_vec);
                 auto var = grp.var(var_names[i]);

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -20,14 +20,15 @@ struct TemperatureGradient
 };
 } // namespace
 
-ABLStats::ABLStats(CFDSim& sim, const ABLWallFunction& abl_wall_func)
+ABLStats::ABLStats(
+    CFDSim& sim, const ABLWallFunction& abl_wall_func, const int dir)
     : m_sim(sim)
     , m_abl_wall_func(abl_wall_func)
     , m_temperature(sim.repo().get_field("temperature"))
     , m_mueff(sim.pde_manager().icns().fields().mueff)
-    , m_pa_vel(sim, 2)
-    , m_pa_temp(m_temperature, sim.time(), 2)
-    , m_pa_mueff(m_mueff, sim.time(), 2)
+    , m_pa_vel(sim, dir)
+    , m_pa_temp(m_temperature, sim.time(), dir)
+    , m_pa_mueff(m_mueff, sim.time(), dir)
     , m_pa_tu(m_pa_vel, m_pa_temp)
     , m_pa_uu(m_pa_vel, m_pa_vel)
     , m_pa_uuu(m_pa_vel, m_pa_vel, m_pa_vel)

--- a/amr-wind/wind_energy/ABLStatsBase.H
+++ b/amr-wind/wind_energy/ABLStatsBase.H
@@ -12,8 +12,7 @@ class ABLForcing;
 } // namespace icns
 } // namespace pde
 
-enum class ABLStatsMode : int
-{
+enum class ABLStatsMode : int {
     computed = 0, ///! Computed using planar averages
     prescribed    ///! Prescribed as user inputs
 };
@@ -46,7 +45,8 @@ public:
     //! Perform actions at the end of a timestep
     virtual void post_advance_work() = 0;
 
-    virtual void register_forcing_term(pde::icns::ABLForcing* forcing) const = 0;
+    virtual void
+    register_forcing_term(pde::icns::ABLForcing* forcing) const = 0;
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLStatsBase.H
+++ b/amr-wind/wind_energy/ABLStatsBase.H
@@ -1,0 +1,54 @@
+#ifndef ABLSTATSBASE_H
+#define ABLSTATSBASE_H
+
+#include "amr-wind/core/Factory.H"
+#include "amr-wind/CFDSim.H"
+#include "amr-wind/wind_energy/ABLWallFunction.H"
+
+namespace amr_wind {
+namespace pde {
+namespace icns {
+class ABLForcing;
+} // namespace icns
+} // namespace pde
+
+enum class ABLStatsMode : int
+{
+    computed = 0, ///! Computed using planar averages
+    prescribed    ///! Prescribed as user inputs
+};
+
+class ABLStatsBase
+    : public Factory<ABLStatsBase, CFDSim&, ABLWallFunction&, int>
+{
+public:
+    static std::string base_identifier() { return "ABLStatsBase"; }
+
+    ABLStatsBase() = default;
+
+    virtual ~ABLStatsBase() = default;
+
+    //! Flag indicating ABL simulation mode
+    virtual ABLStatsMode abl_mode() const = 0;
+
+    //! Interpolating object for vertical velocity profile
+    virtual const VelPlaneAveraging& vel_profile() const = 0;
+
+    //! Interpolating object for vertical temperature profile
+    virtual const FieldPlaneAveraging& theta_profile() const = 0;
+
+    //! Perform initialization actions after the mesh has been created
+    virtual void post_init_actions() = 0;
+
+    //! Perform actions at the beginning of a timestep
+    virtual void pre_advance_work() = 0;
+
+    //! Perform actions at the end of a timestep
+    virtual void post_advance_work() = 0;
+
+    virtual void register_forcing_term(pde::icns::ABLForcing* forcing) const = 0;
+};
+
+} // namespace amr_wind
+
+#endif /* ABLSTATSBASE_H */


### PR DESCRIPTION
This PR is the first step in refactoring out ABL statistics class so that we can disable this for non-periodic runs and instead use prescribed profiles for forcing, heat-flux, and wall shear stress, etc. 