### PR TITLE
Adjust MAC/Nodal projection settings for channel flow in GPU builds

### DIFF
--- a/amr-wind/core/MLMGOptions.cpp
+++ b/amr-wind/core/MLMGOptions.cpp
@@ -21,9 +21,9 @@ void MLMGOptions::parse_options(const std::string& prefix)
 
     // LPInfo options
     pp.query("do_agglomeration", m_lpinfo.do_agglomeration);
-    pp.query("do_consolidation", m_lpinfo.do_agglomeration);
-    pp.query("do_semicoarsening", m_lpinfo.do_agglomeration);
-    pp.query("agg_grid_size", m_lpinfo.do_agglomeration);
+    pp.query("do_consolidation", m_lpinfo.do_consolidation);
+    pp.query("do_semicoarsening", m_lpinfo.do_semicoarsening);
+    pp.query("agg_grid_size", m_lpinfo.agg_grid_size);
     pp.query("con_grid_size", m_lpinfo.con_grid_size);
     pp.query("max_coarsening_level", m_lpinfo.max_coarsening_level);
     pp.query("max_semicoarsening_level", m_lpinfo.max_semicoarsening_level);

--- a/test/test_files/channel_kwsst/channel_kwsst.i
+++ b/test/test_files/channel_kwsst/channel_kwsst.i
@@ -11,7 +11,7 @@ time.cfl              =   0.25       # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#
-io.KE_int = 1
+io.KE_int = 0
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
@@ -21,6 +21,8 @@ incflo.density        =  1.0             # Reference density
 incflo.use_godunov = 1
 transport.viscosity = 1.0e-3
 turbulence.model = KOmegaSST
+
+ICNS.source_terms = BodyForce
 BodyForce.magnitude = 1.0 0 0
 TKE.source_terms = KwSSTSrc
 SDR.source_terms = SDRSrc

--- a/test/test_files/channel_kwsst/channel_kwsst.i
+++ b/test/test_files/channel_kwsst/channel_kwsst.i
@@ -58,3 +58,5 @@ incflo.verbose  = 0
 
 mac_proj.mg_rtol = 1.0e-11
 mac_proj.mg_atol = 1.0e-11
+mac_proj.do_semicoarsening = true
+nodal_proj.mg_atol = 1.0e-11

--- a/test/test_files/channel_kwsstiddes/channel_kwsstiddes.i
+++ b/test/test_files/channel_kwsstiddes/channel_kwsstiddes.i
@@ -11,7 +11,7 @@ time.cfl              =   0.25       # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#
-io.KE_int = 1
+io.KE_int = 0
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
@@ -21,6 +21,8 @@ incflo.density        =  1.0             # Reference density
 incflo.use_godunov = 1
 transport.viscosity = 1.0e-3
 turbulence.model = KOmegaSSTIDDES
+
+ICNS.source_terms = BodyForce
 BodyForce.magnitude = 1.0 0 0
 TKE.source_terms = KwSSTSrc
 SDR.source_terms = SDRSrc

--- a/test/test_files/channel_kwsstiddes/channel_kwsstiddes.i
+++ b/test/test_files/channel_kwsstiddes/channel_kwsstiddes.i
@@ -58,3 +58,5 @@ incflo.verbose  = 0
 
 mac_proj.mg_rtol = 1.0e-11
 mac_proj.mg_atol = 1.0e-11
+mac_proj.do_semicoarsening = true
+nodal_proj.mg_atol = 1.0e-11


### PR DESCRIPTION
Relax the absolute tolerance for elliptic solves so that MLMG does not fail on GPU runs. Also enable semicoarsening for MAC solves.

Requires #358