### PR TITLE
Standardize nested namespace parsing

### DIFF
--- a/amr-wind/utilities/averaging/TimeAveraging.cpp
+++ b/amr-wind/utilities/averaging/TimeAveraging.cpp
@@ -29,7 +29,7 @@ void TimeAveraging::pre_init_actions()
         //! Fields to be averaged
         amrex::Vector<std::string> fnames;
         std::string avg_type;
-        const std::string pp_key = m_label + "/" + lbl;
+        const std::string pp_key = m_label + "." + lbl;
 
         amrex::ParmParse pp1(pp_key);
         pp1.getarr("fields", fnames);

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -51,7 +51,7 @@ void Sampling::initialize()
     int idx = 0;
     m_total_particles = 0;
     for (auto& lbl : labels) {
-        const std::string key = m_label + "/" + lbl;
+        const std::string key = m_label + "." + lbl;
         amrex::ParmParse pp1(key);
         std::string stype = "LineSampler";
 

--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -22,7 +22,7 @@ void GeometryRefinement::initialize(const std::string& key)
     }
 
     for (const auto& geom : shapes) {
-        const std::string& gkey = key + "/" + geom;
+        const std::string& gkey = key + "." + geom;
         amrex::ParmParse pp(gkey);
         std::string gtype;
         pp.get("type", gtype);

--- a/amr-wind/utilities/tagging/RefinementCriteria.cpp
+++ b/amr-wind/utilities/tagging/RefinementCriteria.cpp
@@ -18,7 +18,7 @@ void RefineCriteriaManager::initialize()
     }
 
     for (auto& lbl : labels) {
-        const std::string key = "tagging/" + lbl;
+        const std::string key = "tagging." + lbl;
         amrex::ParmParse pp(key);
         std::string stype;
         pp.get("type", stype);

--- a/docs/sphinx/user/amr_wind_inputs.txt
+++ b/docs/sphinx/user/amr_wind_inputs.txt
@@ -117,16 +117,16 @@ sampling.labels = l_v11 p_h
 sampling.fields = velocity temperature
 
 # sampling along a line
-sampling/l_v11.type = LineSampler
-sampling/l_v11.num_points = 192
-sampling/l_v11.start = 500.0 500.0 5.0
-sampling/l_v11.end = 500.0 500.0 1995.0
+sampling.l_v11.type = LineSampler
+sampling.l_v11.num_points = 192
+sampling.l_v11.start = 500.0 500.0 5.0
+sampling.l_v11.end = 500.0 500.0 1995.0
 
 # Sampling on a plane
-sampling/p_h.type = PlaneSampler
-sampling/p_h.axis1 = 5210.0 0.0 0.0
-sampling/p_h.axis2 = 0.0 5210.0 0.0
-sampling/p_h.origin = 0.0 0.0 50.0
-sampling/p_h.num_points = 288 288
-sampling/p_h.normal = 0.0 0.0 1.0
-sampling/p_h.offsets = 0.0 50.0 150.0
+sampling.p_h.type = PlaneSampler
+sampling.p_h.axis1 = 5210.0 0.0 0.0
+sampling.p_h.axis2 = 0.0 5210.0 0.0
+sampling.p_h.origin = 0.0 0.0 50.0
+sampling.p_h.num_points = 288 288
+sampling.p_h.normal = 0.0 0.0 1.0
+sampling.p_h.offsets = 0.0 50.0 150.0

--- a/docs/sphinx/user/inputs.rst
+++ b/docs/sphinx/user/inputs.rst
@@ -363,14 +363,14 @@ as initial conditions and discretization options.
      sampling.output_frequency  = 5
      sampling.labels            = line1 line2
      sampling.fields            = velocity
-     sampling/line1.type        = LineSampler
-     sampling/line1.num_points  = 21
-     sampling/line1.start       = 250.0 250.0 10.0
-     sampling/line1.end         = 250.0 250.0 210.0
-     sampling/line2.type        = LineSampler
-     sampling/line2.num_points  = 21
-     sampling/line2.start       = 500.0 500.0 10.0
-     sampling/line2.end         = 500.0 500.0 210.0
+     sampling.line1.type        = LineSampler
+     sampling.line1.num_points  = 21
+     sampling.line1.start       = 250.0 250.0 10.0
+     sampling.line1.end         = 250.0 250.0 210.0
+     sampling.line2.type        = LineSampler
+     sampling.line2.num_points  = 21
+     sampling.line2.start       = 500.0 500.0 10.0
+     sampling.line2.end         = 500.0 500.0 210.0
 
    In the above example, the code will read the parameters with keyword
    ``sampling`` to initialize user-defined probes.
@@ -856,27 +856,27 @@ of tagging logic. Note that this section is only active if
 Example::
 
   tagging.labels = s1 f1 g1
-  tagging/s1.type = CartBoxRefinement
-  tagging/s1.static_refinement_def = static_box.txt
+  tagging.s1.type = CartBoxRefinement
+  tagging.s1.static_refinement_def = static_box.txt
 
-  tagging/f1.type = FieldRefinement
-  tagging/f1.field_name = density
-  tagging/f1.grad_error = 0.1. 0.1 0.1
+  tagging.f1.type = FieldRefinement
+  tagging.f1.field_name = density
+  tagging.f1.grad_error = 0.1. 0.1 0.1
 
-  tagging/g1.type = GeometryRefinement
-  tagging/g1.shapes = c1 b1
+  tagging.g1.type = GeometryRefinement
+  tagging.g1.shapes = c1 b1
 
-  tagging/g1/c1.type = cylinder
-  tagging/g1/c1.start = 500.0 500.0 250.0
-  tagging/g1/c1.end = 500.0 500.0 750.0
-  tagging/g1/c1.outer_radius = 300.0
-  tagging/g1/c1.inner_radius = 275.0
+  tagging.g1.c1.type = cylinder
+  tagging.g1.c1.start = 500.0 500.0 250.0
+  tagging.g1.c1.end = 500.0 500.0 750.0
+  tagging.g1.c1.outer_radius = 300.0
+  tagging.g1.c1.inner_radius = 275.0
 
-  tagging/g1/b1.type = box
-  tagging/g1/b1.origin = 300.0 150.0 250.0
-  tagging/g1/b1.xaxis =  450.0 600.0 0.0
-  tagging/g1/b1.yaxis =  -150.0 100.0 0.0
-  tagging/g1/b1.zaxis = 0.0 0.0 500.0
+  tagging.g1.b1.type = box
+  tagging.g1.b1.origin = 300.0 150.0 250.0
+  tagging.g1.b1.xaxis =  450.0 600.0 0.0
+  tagging.g1.b1.yaxis =  -150.0 100.0 0.0
+  tagging.g1.b1.zaxis = 0.0 0.0 500.0
 
 Each section must contain the keyword ``type`` that is one of the refinement types:
 
@@ -906,8 +906,8 @@ Refinement using Cartesian boxes
 Example::
 
    tagging.labels = static
-   tagging/static.type = CartBoxRefinement
-   tagging/static.static_refinement_def = static_box.txt
+   tagging.static.type = CartBoxRefinement
+   tagging.static.static_refinement_def = static_box.txt
 
 .. input_param:: tagging.CartBoxRefinement.static_refinement_def
 
@@ -921,9 +921,9 @@ Refinement using field error criteria
 
 Example::
 
-  tagging/f1.type = FieldRefinement
-  tagging/f1.field_name = density
-  tagging/f1.grad_error = 0.1. 0.1 0.1
+  tagging.f1.type = FieldRefinement
+  tagging.f1.field_name = density
+  tagging.f1.grad_error = 0.1. 0.1 0.1
 
 .. input_param:: tagging.FieldRefinement.field_name
 
@@ -986,28 +986,28 @@ where refinement regions are active.
 
 Example::
 
-  tagging/g1.type = GeometryRefinement
-  tagging/g1.shapes = b1 b2
-  tagging/g1.level = 0
-  tagging/g1/b1.type = box
-  tagging/g1/b1.origin = 300.0 150.0 250.0
-  tagging/g1/b1.xaxis =  450.0 600.0 0.0
-  tagging/g1/b1.yaxis =  -150.0 100.0 0.0
-  tagging/g1/b1.zaxis = 0.0 0.0 500.0
-  tagging/g1/b2.type = box
-  tagging/g1/b2.origin = 600.0 350.0 250.0
-  tagging/g1/b2.xaxis =  50.0 30.0 0.0
-  tagging/g1/b2.yaxis =  -50.0 60.0 0.0
-  tagging/g1/b2.zaxis = 0.0 0.0 500.0
+  tagging.g1.type = GeometryRefinement
+  tagging.g1.shapes = b1 b2
+  tagging.g1.level = 0
+  tagging.g1.b1.type = box
+  tagging.g1.b1.origin = 300.0 150.0 250.0
+  tagging.g1.b1.xaxis =  450.0 600.0 0.0
+  tagging.g1.b1.yaxis =  -150.0 100.0 0.0
+  tagging.g1.b1.zaxis = 0.0 0.0 500.0
+  tagging.g1.b2.type = box
+  tagging.g1.b2.origin = 600.0 350.0 250.0
+  tagging.g1.b2.xaxis =  50.0 30.0 0.0
+  tagging.g1.b2.yaxis =  -50.0 60.0 0.0
+  tagging.g1.b2.zaxis = 0.0 0.0 500.0
 
-  tagging/g2.type = GeometryRefinement
-  tagging/g2.shapes = c1
-  tagging/g2.level = 1
-  tagging/g2/c1.type = cylinder
-  tagging/g2/c1.start = 500.0 500.0 250.0
-  tagging/g2/c1.end = 500.0 500.0 750.0
-  tagging/g2/c1.outer_radius = 300.0
-  tagging/g2/c1.inner_radius = 275.0
+  tagging.g2.type = GeometryRefinement
+  tagging.g2.shapes = c1
+  tagging.g2.level = 1
+  tagging.g2.c1.type = cylinder
+  tagging.g2.c1.start = 500.0 500.0 250.0
+  tagging.g2.c1.end = 500.0 500.0 750.0
+  tagging.g2.c1.outer_radius = 300.0
+  tagging.g2.c1.inner_radius = 275.0
 
 
 This example defines two different refinement definitions acting on level 0 and
@@ -1045,9 +1045,9 @@ Refinement using Q-Criterion
 
 Example::
 
-  tagging/qc1.type = QCriterionRefinement
-  tagging/qc1.nondim = false
-  tagging/qc1.values = 10.0 20.0 20.0
+  tagging.qc1.type = QCriterionRefinement
+  tagging.qc1.nondim = false
+  tagging.qc1.values = 10.0 20.0 20.0
 
 .. input_param:: tagging.QCriterionRefinement.nondim
 
@@ -1115,8 +1115,8 @@ actual keyword is determined by the labels provided to
 
       sampling.labels = line1 plane1 probe1
 
-   Then the code expects to read ``sampling/line1, sampling/plane1,
-   sampling/probe1`` sections to determine the specific sampling probe information.
+   Then the code expects to read ``sampling.line1, sampling.plane1,
+   sampling.probe1`` sections to determine the specific sampling probe information.
 
 .. input_param:: sampling.fields
 
@@ -1135,10 +1135,10 @@ nodes.
 
 Example::
 
-  sampling/line1.type       = LineSampler
-  sampling/line1.num_points = 21
-  sampling/line1.start      = 250.0 250.0 10.0
-  sampling/line1.end        = 250.0 250.0 210.0
+  sampling.line1.type       = LineSampler
+  sampling.line1.num_points = 21
+  sampling.line1.start      = 250.0 250.0 10.0
+  sampling.line1.end        = 250.0 250.0 210.0
 
 Sampling on one or more planes
 ```````````````````````````````
@@ -1152,13 +1152,13 @@ offset for as many planes as there are entries in the ``offset`` array.
 
 Example::
 
-  sampling/plane1.type        = PlaneSampler
-  sampling/plane1.axis1       = 0.0 1.0 0.0
-  sampling/plane1.axis2       = 0.0 0.0 1.0
-  sampling/plane1.origin      = 0.0 0.0 0.0
-  sampling/plane1.num_points  = 10 10
-  sampling/plane1.normal      = 1.0 0.0 0.0
-  sampling/plane1.offsets     = -10.0 0.0 10.0
+  sampling.plane1.type        = PlaneSampler
+  sampling.plane1.axis1       = 0.0 1.0 0.0
+  sampling.plane1.axis2       = 0.0 0.0 1.0
+  sampling.plane1.origin      = 0.0 0.0 0.0
+  sampling.plane1.num_points  = 10 10
+  sampling.plane1.normal      = 1.0 0.0 0.0
+  sampling.plane1.offsets     = -10.0 0.0 10.0
 
 Sampling at arbitrary locations
 ````````````````````````````````
@@ -1168,8 +1168,8 @@ locations read from a text file (default: ``probe_locations.txt``).
 
 Example::
 
-  sampling/probe1.type = ProbeSampler
-  sampling/probe1.probe_location_file = "probe_locations.txt"
+  sampling.probe1.type = ProbeSampler
+  sampling.probe1.probe_location_file = "probe_locations.txt"
 
 The first line of the file contains the total number of probes for this set.
 This is followed by the coordinates (three real numbers), one line per probe.

--- a/test/test_files/abl_godunov_static_refinement/abl_godunov_static_refinement.i
+++ b/test/test_files/abl_godunov_static_refinement/abl_godunov_static_refinement.i
@@ -5,8 +5,8 @@ time.stop_time               =   22000.0     # Max (simulated) time to evolve
 time.max_step                =   10          # Max number of time steps
 
 tagging.labels = static
-tagging/static.type = CartBoxRefinement
-tagging/static.static_refinement_def = static_box.txt
+tagging.static.type = CartBoxRefinement
+tagging.static.static_refinement_def = static_box.txt
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #
 #.......................................#

--- a/test/test_files/abl_stable/abl_stable.i
+++ b/test/test_files/abl_stable/abl_stable.i
@@ -59,7 +59,6 @@ ABL.stats_output_frequency = 100
 #.......................................#
 amr.n_cell              = 48 48 48 # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
-tagging.static_refinement = false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#

--- a/test/test_files/abl_unstable/abl_unstable.i
+++ b/test/test_files/abl_unstable/abl_unstable.i
@@ -57,7 +57,6 @@ ABL.stats_output_frequency = 100
 amr.n_cell              = 36 36 24    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
 amr.blocking_factor     = 4
-tagging.static_refinement = false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#

--- a/test/test_files/abl_unstable_constant_wall_model/abl_unstable_constant_wall_model.i
+++ b/test/test_files/abl_unstable_constant_wall_model/abl_unstable_constant_wall_model.i
@@ -57,7 +57,6 @@ ABL.wall_shear_stress_type = constant
 amr.n_cell              = 36 36 24    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
 amr.blocking_factor     = 4
-tagging.static_refinement = false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#

--- a/test/test_files/abl_unstable_local_wall_model/abl_unstable_local_wall_model.i
+++ b/test/test_files/abl_unstable_local_wall_model/abl_unstable_local_wall_model.i
@@ -57,7 +57,6 @@ ABL.wall_shear_stress_type = local
 amr.n_cell              = 36 36 24    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
 amr.blocking_factor     = 4
-tagging.static_refinement = false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#

--- a/test/test_files/abl_unstable_schumann_wall_model/abl_unstable_schumann_wall_model.i
+++ b/test/test_files/abl_unstable_schumann_wall_model/abl_unstable_schumann_wall_model.i
@@ -57,7 +57,6 @@ ABL.wall_shear_stress_type = Schumann
 amr.n_cell              = 36 36 24    # Grid cells at coarsest AMRlevel
 amr.max_level           = 0           # Max AMR level in hierarchy
 amr.blocking_factor     = 4
-tagging.static_refinement = false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              GEOMETRY                 #
 #.......................................#

--- a/test/test_files/boussinesq_bubble_godunov/boussinesq_bubble_godunov.i
+++ b/test/test_files/boussinesq_bubble_godunov/boussinesq_bubble_godunov.i
@@ -38,9 +38,9 @@ zlo.temperature_type = "fixed_gradient"
 zhi.temperature_type = "fixed_gradient"
 
 tagging.labels = density
-tagging/density.type = FieldRefinement
-tagging/density.field_name = density
-tagging/density.grad_error = 0.1 0.1 0.1 0.1
+tagging.density.type = FieldRefinement
+tagging.density.field_name = density
+tagging.density.grad_error = 0.1 0.1 0.1 0.1
 
 incflo.diffusion_type   = 2             # 0 = Explicit, 1 = Crank-Nicolson, 2 = Implicit
 

--- a/test/test_files/boussinesq_bubble_mol/boussinesq_bubble_mol.i
+++ b/test/test_files/boussinesq_bubble_mol/boussinesq_bubble_mol.i
@@ -37,9 +37,9 @@ zlo.temperature_type = "fixed_gradient"
 zhi.temperature_type = "fixed_gradient"
 
 tagging.labels = density
-tagging/density.type = FieldRefinement
-tagging/density.field_name = density
-tagging/density.grad_error = 0.1 0.1 0.1 0.1
+tagging.density.type = FieldRefinement
+tagging.density.field_name = density
+tagging.density.grad_error = 0.1 0.1 0.1 0.1
 
 incflo.diffusion_type   = 2             # 0 = Explicit, 1 = Crank-Nicolson, 2 = Implicit
 

--- a/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
+++ b/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.i
@@ -36,9 +36,9 @@ RayleighTaylor.rho_hi = 2.0
 incflo.gravity          = 0. 0. -0.3
 
 tagging.labels = density
-tagging/density.type = FieldRefinement
-tagging/density.field_name = density
-tagging/density.grad_error = 0.1 0.1 0.1 0.1
+tagging.density.type = FieldRefinement
+tagging.density.field_name = density
+tagging.density.grad_error = 0.1 0.1 0.1 0.1
 
 incflo.use_godunov      = true
 incflo.constant_density = false

--- a/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.i
+++ b/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.i
@@ -35,9 +35,9 @@ RayleighTaylor.rho_hi = 2.0
 incflo.gravity          = 0. 0. -0.3
 
 tagging.labels = density
-tagging/density.type = FieldRefinement
-tagging/density.field_name = density
-tagging/density.grad_error = 0.1 0.1 0.1 0.1
+tagging.density.type = FieldRefinement
+tagging.density.field_name = density
+tagging.density.grad_error = 0.1 0.1 0.1 0.1
 
 incflo.use_godunov      = false
 incflo.constant_density = false

--- a/test/test_files/sloshing_tank/sloshing_tank.i
+++ b/test/test_files/sloshing_tank/sloshing_tank.i
@@ -39,9 +39,9 @@ ICNS.source_terms = GravityForcing
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#
 amr.n_cell              = 128 16 96    # Grid cells at coarsest AMRlevel
-tagging.labels = sr                                                                                                                                                             
-tagging/sr.type = CartBoxRefinement                                                                                                                                             
-tagging/sr.static_refinement_def = static_box.refine                                                                                                                               
+tagging.labels = sr
+tagging.sr.type = CartBoxRefinement
+tagging.sr.static_refinement_def = static_box.refine
 amr.max_level = 1 
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/unit_tests/utilities/test_sampling.cpp
+++ b/unit_tests/utilities/test_sampling.cpp
@@ -203,7 +203,7 @@ TEST_F(SamplingTest, sampling)
             amrex::Vector<std::string>{"density", "pressure", "velocity"});
     }
     {
-        amrex::ParmParse pp("sampling/line1");
+        amrex::ParmParse pp("sampling.line1");
         pp.add("type", std::string("LineSampler"));
         pp.add("num_points", 16);
         pp.addarr("start", amrex::Vector<amrex::Real>{66.0, 66.0, 1.0});


### PR DESCRIPTION
This PR standardizes the parsing of nested groups of input parameters in the AMR-Wind input file to always use period as the separator similar to what is done in core AMReX and other AMReX applications. 

```diff
-  sampling/plane1.type        = PlaneSampler
-  sampling/plane1.axis1       = 0.0 1.0 0.0
-  sampling/plane1.axis2       = 0.0 0.0 1.0
-  sampling/plane1.origin      = 0.0 0.0 0.0
-  sampling/plane1.num_points  = 10 10
-  sampling/plane1.normal      = 1.0 0.0 0.0
-  sampling/plane1.offsets     = -10.0 0.0 10.0
+  sampling.plane1.type        = PlaneSampler
+  sampling.plane1.axis1       = 0.0 1.0 0.0
+  sampling.plane1.axis2       = 0.0 0.0 1.0
+  sampling.plane1.origin      = 0.0 0.0 0.0
+  sampling.plane1.num_points  = 10 10
+  sampling.plane1.normal      = 1.0 0.0 0.0
+  sampling.plane1.offsets     = -10.0 0.0 10.0
```