### PR TITLE
Address failing tests

### DIFF
--- a/test/CTestList.cmake
+++ b/test/CTestList.cmake
@@ -174,9 +174,12 @@ if(AMR_WIND_ENABLE_MASA)
   add_test_re(mms_mol)
 endif()
 
+# TODO: Enable hypre capability on GPUs
+if (NOT AMR_WIND_ENABLE_CUDA)
 if (AMR_WIND_ENABLE_HYPRE)
   add_test_re(abl_godunov_hypre)
   add_test_re(channel_kwsst_hypre)
+endif()
 endif()
 
 #=============================================================================

--- a/test/test_files/sloshing_tank/sloshing_tank.i
+++ b/test/test_files/sloshing_tank/sloshing_tank.i
@@ -7,6 +7,10 @@ time.initial_dt =0.001
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  10       # Steps between checkpoint files
 
+io.output_default_variables = 0
+io.outputs = density p
+io.derived_outputs = "components(velocity,0,2)" "components(gp,0,2)"
+
 incflo.use_godunov = 1
 incflo.godunov_type="weno"
 transport.model = TwoPhaseTransport


### PR DESCRIPTION
- Disable hypre tests on CUDA builds temporarily (see #391)
- Modify `sloshing_tank` test to only output x/y components (similar to CTV)
