### PR TITLE
Failing CDash tests: remove y-component output for GPU tests

### DIFF
--- a/test/test_files/dam_break_godunov/dam_break_godunov.i
+++ b/test/test_files/dam_break_godunov/dam_break_godunov.i
@@ -7,6 +7,10 @@ time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 
+io.output_default_variables = 0
+io.outputs = density p vof
+io.derived_outputs = "components(velocity,0,2)" "components(gp,0,2)"
+
 incflo.use_godunov = 1
 incflo.godunov_type = "weno"
 transport.model = TwoPhaseTransport

--- a/test/test_files/sloshing_tank/sloshing_tank.i
+++ b/test/test_files/sloshing_tank/sloshing_tank.i
@@ -8,7 +8,7 @@ time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  10       # Steps between checkpoint files
 
 io.output_default_variables = 0
-io.outputs = density p
+io.outputs = density p vof
 io.derived_outputs = "components(velocity,0,2)" "components(gp,0,2)"
 
 incflo.use_godunov = 1


### PR DESCRIPTION
Adjust `sloshing_tank` and `dam_break_godunov` to skip the `y-component` of
velocity and `grad(p)` terms in nightly regression tests.
