### PR TITLE
Update FindNetCDF.cmake for newer MacOS 

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -17,17 +17,24 @@ if (netCDF_FOUND)
   set(NetCDF_LIBRARIES "${netCDF_LIBRARIES}")
   set(NetCDF_VERSION "${NetCDFVersion}")
   if (NOT TARGET NetCDF::NetCDF)
+    
     add_library(NetCDF::NetCDF INTERFACE IMPORTED)
     if (TARGET "netCDF::netcdf")
       # 4.7.3
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netCDF::netcdf")
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_INCLUDE_DIRS}")
     elseif (TARGET "netcdf")
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netcdf")
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_INCLUDE_DIRS}")
     else ()
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "${netCDF_LIBRARIES}")
+      set_target_properties(NetCDF::NetCDF PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${NetCDF_INCLUDE_DIRS}")
     endif ()
   endif ()
   # Skip the rest of the logic in this file.


### PR DESCRIPTION
Modified FindNetCDF.cmake with the help from Shreyas to allow for NetCDF linking during compilation on the latest apple intel macs. Checked the compilation on eagle using GCC and Intel to make sure these changes work on eagle as well. 
@sayerhs 
@jrood-nrel 