### PR TITLE
Disallow assignment to rvalues in Vector/Tensor

### DIFF
--- a/amr-wind/core/vs/tensor.H
+++ b/amr-wind/core/vs/tensor.H
@@ -85,63 +85,90 @@ struct TensorT
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> cy() const noexcept;
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> cz() const noexcept;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xx() noexcept { return vv[0]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xy() noexcept { return vv[1]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xz() noexcept { return vv[2]; }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yx() noexcept { return vv[3]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yy() noexcept { return vv[4]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yz() noexcept { return vv[5]; }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zx() noexcept { return vv[6]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zy() noexcept { return vv[7]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zz() noexcept { return vv[8]; }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xx() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xx() & noexcept
     {
         return vv[0];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xy() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xy() & noexcept
     {
         return vv[1];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xz() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& xz() & noexcept
     {
         return vv[2];
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yx() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yx() & noexcept
     {
         return vv[3];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yy() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yy() & noexcept
     {
         return vv[4];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yz() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& yz() & noexcept
     {
         return vv[5];
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zx() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zx() & noexcept
     {
         return vv[6];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zy() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zy() & noexcept
     {
         return vv[7];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zz() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& zz() & noexcept
     {
         return vv[8];
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xx() const& noexcept
+    {
+        return vv[0];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xy() const& noexcept
+    {
+        return vv[1];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& xz() const& noexcept
+    {
+        return vv[2];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yx() const& noexcept
+    {
+        return vv[3];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yy() const& noexcept
+    {
+        return vv[4];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& yz() const& noexcept
+    {
+        return vv[5];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zx() const& noexcept
+    {
+        return vv[6];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zy() const& noexcept
+    {
+        return vv[7];
+    }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& zz() const& noexcept
+    {
+        return vv[8];
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos) &
     {
         return vv[pos];
     }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T&
-    operator[](size_type pos) const
+    operator[](size_type pos) const&
     {
         return vv[pos];
     }

--- a/amr-wind/core/vs/tensor.H
+++ b/amr-wind/core/vs/tensor.H
@@ -48,6 +48,14 @@ struct TensorT
         const VectorT<T>& z,
         const bool transpose = false);
 
+    ~TensorT() = default;
+    TensorT(const TensorT&) = default;
+    TensorT(TensorT&&) = default;
+    TensorT& operator=(const TensorT&) & = default;
+    TensorT& operator=(const TensorT&) && = delete;
+    TensorT& operator=(TensorT&&) & = default;
+    TensorT& operator=(TensorT&&) && = delete;
+
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr TensorT<T>
     zero() noexcept
     {

--- a/amr-wind/core/vs/vector.H
+++ b/amr-wind/core/vs/vector.H
@@ -36,6 +36,14 @@ struct VectorT
         : vv{x, y, z}
     {}
 
+    ~VectorT() = default;
+    VectorT(const VectorT&) = default;
+    VectorT(VectorT&&) = default;
+    VectorT& operator=(const VectorT&) & = default;
+    VectorT& operator=(const VectorT&) && = delete;
+    VectorT& operator=(VectorT&&) & = default;
+    VectorT& operator=(VectorT&&) && = delete;
+
     //! Zero vector
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr VectorT<T> zero()
     {

--- a/amr-wind/core/vs/vector.H
+++ b/amr-wind/core/vs/vector.H
@@ -94,18 +94,18 @@ struct VectorT
         return VectorT<T>(*this).normalize();
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& x() noexcept { return vv[0]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& y() noexcept { return vv[1]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& z() noexcept { return vv[2]; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& x() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& x() & noexcept { return vv[0]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& y() & noexcept { return vv[1]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& z() & noexcept { return vv[2]; }
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& x() const& noexcept
     {
         return vv[0];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& y() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& y() const& noexcept
     {
         return vv[1];
     }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& z() const noexcept
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T& z() const& noexcept
     {
         return vv[2];
     }
@@ -116,12 +116,12 @@ struct VectorT
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator/=(const T val);
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos) &
     {
         return vv[pos];
     }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE const T&
-    operator[](size_type pos) const
+    operator[](size_type pos) const&
     {
         return vv[pos];
     }

--- a/amr-wind/physics/SyntheticTurbulence.cpp
+++ b/amr-wind/physics/SyntheticTurbulence.cpp
@@ -457,7 +457,10 @@ SyntheticTurbulence::SyntheticTurbulence(const CFDSim& sim)
     m_turb_grid.tr_mat.zy() = 0.0;
     m_turb_grid.tr_mat.zz() = 1.0;
     // y = z .cross. x
-    m_turb_grid.tr_mat.y() = m_turb_grid.tr_mat.z() ^ m_turb_grid.tr_mat.x();
+    auto ydir = m_turb_grid.tr_mat.z() ^ m_turb_grid.tr_mat.x();
+    m_turb_grid.tr_mat.yx() = ydir.x();
+    m_turb_grid.tr_mat.yy() = ydir.y();
+    m_turb_grid.tr_mat.yz() = ydir.z();
 
     amrex::Print() << "Synthethic turbulence forcing initialized \n"
                    << "  Turbulence file = " << m_turb_filename << "\n"


### PR DESCRIPTION
See #399 for a description of the problem. Vector/Tensor classes allowed
assignment to rvalues which is a no-op and results in a bug. The
proposed changes will raise compile time error in future.

SyntheticTurbulence had to be changed to allow the code to compile.
