### PR TITLE
Cleaning up warnings May 2021 round 1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,8 +67,8 @@ jobs:
           submodules: true
       - name: Dependencies
         run: |
-          sudo apt-get install -y clang-tidy-9
-          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 100
+          sudo apt-get install -y clang-tidy-10
+          sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10 100
       - name: Configure
         run: |
           echo "NPROCS=$(nproc)" >> $GITHUB_ENV
@@ -87,7 +87,7 @@ jobs:
         working-directory: build-clang-tidy
         run: |
           cmake --build . --parallel ${{env.NPROCS}} 2> clang-tidy-full-report.txt
-          cat clang-tidy-full-report.txt | grep "warning:" | grep -v "submods" | sort | uniq | sort -nr | \
+          cat clang-tidy-full-report.txt | grep "warning:" | grep -v "submods" | sort | uniq | \
             awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > clang-tidy-ci-report.txt
       - name: Full report
         working-directory: build-clang-tidy
@@ -97,3 +97,5 @@ jobs:
         run: |
           echo "::add-matcher::.github/problem-matchers/gcc.json"
           cat clang-tidy-ci-report.txt
+          export return=$(tail -n 1 clang-tidy-ci-report.txt | awk '{print $2}')
+          exit 0

--- a/amr-wind/core/Field.cpp
+++ b/amr-wind/core/Field.cpp
@@ -95,7 +95,7 @@ Field::~Field() = default;
 
 Field& Field::state(const FieldState fstate)
 {
-    auto& fstates = m_info->m_states;
+    const auto& fstates = m_info->m_states;
     const int fint = static_cast<int>(fstate);
     AMREX_ASSERT(fstates[fint] != nullptr);
     return *fstates[fint];
@@ -103,7 +103,7 @@ Field& Field::state(const FieldState fstate)
 
 const Field& Field::state(const FieldState fstate) const
 {
-    auto& fstates = m_info->m_states;
+    const auto& fstates = m_info->m_states;
     const int fint = static_cast<int>(fstate);
     AMREX_ASSERT(fstates[fint] != nullptr);
     return *fstates[fint];

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -372,7 +372,7 @@ protected:
     //! Allocate field data for a single level outside of regrid
     void allocate_field_data(
         int lev,
-        Field& field,
+        const Field& field,
         LevelDataHolder& fdata,
         const amrex::FabFactory<amrex::FArrayBox>& factory);
 
@@ -386,7 +386,7 @@ protected:
         LevelDataHolder& fdata,
         const amrex::FabFactory<amrex::FArrayBox>& factory);
 
-    void allocate_field_data(int lev, IntField& field, LevelDataHolder& fdata);
+    void allocate_field_data(int lev, const IntField& field, LevelDataHolder& fdata);
 
     void allocate_field_data(IntField& field);
 

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -388,7 +388,7 @@ protected:
 
     void allocate_field_data(int lev, const IntField& field, LevelDataHolder& fdata);
 
-    void allocate_field_data(IntField& field);
+    void allocate_field_data(const IntField& field);
 
     void allocate_field_data(
         const amrex::BoxArray& ba,

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -386,7 +386,8 @@ protected:
         LevelDataHolder& fdata,
         const amrex::FabFactory<amrex::FArrayBox>& factory);
 
-    void allocate_field_data(int lev, const IntField& field, LevelDataHolder& fdata);
+    void
+    allocate_field_data(int lev, const IntField& field, LevelDataHolder& fdata);
 
     void allocate_field_data(const IntField& field);
 

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -352,7 +352,7 @@ void FieldRepo::allocate_field_data(
         amrex::MFInfo(), *level_data.m_int_fact);
 }
 
-void FieldRepo::allocate_field_data(IntField& field)
+void FieldRepo::allocate_field_data(const IntField& field)
 {
     for (int lev = 0; lev <= m_mesh.finestLevel(); ++lev) {
         allocate_field_data(lev, field, *m_leveldata[lev]);

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -296,7 +296,7 @@ void FieldRepo::allocate_field_data(
 
 void FieldRepo::allocate_field_data(
     int lev,
-    Field& field,
+    const Field& field,
     LevelDataHolder& level_data,
     const amrex::FabFactory<amrex::FArrayBox>& factory)
 {
@@ -339,7 +339,7 @@ void FieldRepo::allocate_field_data(
 }
 
 void FieldRepo::allocate_field_data(
-    int lev, IntField& field, LevelDataHolder& level_data)
+    int lev, const IntField& field, LevelDataHolder& level_data)
 {
     auto& fab_vec = level_data.m_int_fabs;
     AMREX_ASSERT(fab_vec.size() == field.id());

--- a/amr-wind/equation_systems/DiffusionOps.cpp
+++ b/amr-wind/equation_systems/DiffusionOps.cpp
@@ -93,7 +93,7 @@ void DiffSolverIface<LinOp>::linsys_solve_impl()
     FieldState fstate = FieldState::New;
     auto& repo = this->m_pdefields.repo;
     auto& field = this->m_pdefields.field;
-    auto& density = m_density.state(fstate);
+    const auto& density = m_density.state(fstate);
     const int nlevels = repo.num_active_levels();
     const int ndim = field.num_comp();
     auto rhs_ptr = repo.create_scratch_field("rhs", field.num_comp(), 0);

--- a/amr-wind/equation_systems/icns/icns_advection.cpp
+++ b/amr-wind/equation_systems/icns/icns_advection.cpp
@@ -86,7 +86,7 @@ void MacProjOp::init_projector(const amrex::Real beta) noexcept
     m_options(*m_mac_proj);
 
     auto& pressure = m_repo.get_field("p");
-    auto& bctype = pressure.bc_type();
+    const auto& bctype = pressure.bc_type();
 
     m_mac_proj->setDomainBC(
         get_projection_bc(

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
@@ -16,7 +16,7 @@ class GravityForcing : public MomentumSource::Register<GravityForcing>
 public:
     static const std::string identifier() { return "GravityForcing"; }
 
-    GravityForcing(const CFDSim& sim);
+    explicit GravityForcing(const CFDSim& sim);
 
     virtual ~GravityForcing();
 

--- a/amr-wind/equation_systems/icns/source_terms/SynthTurbForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/SynthTurbForcing.H
@@ -15,7 +15,7 @@ class SynthTurbForcing : public MomentumSource::Register<SynthTurbForcing>
 public:
     static const std::string identifier() { return "SynthTurbForcing"; }
 
-    SynthTurbForcing(const CFDSim&);
+    explicit SynthTurbForcing(const CFDSim&);
 
     virtual ~SynthTurbForcing();
 

--- a/amr-wind/equation_systems/sdr/sdr_ops.H
+++ b/amr-wind/equation_systems/sdr/sdr_ops.H
@@ -48,7 +48,7 @@ struct PostSolveOp<SDR>
 template <typename Scheme>
 struct FieldRegOp<SDR, Scheme>
 {
-    FieldRegOp(CFDSim& sim_in) : sim(sim_in) {}
+    explicit FieldRegOp(CFDSim& sim_in) : sim(sim_in) {}
 
     PDEFields operator()(const SimTime& time, const int probtype)
     {

--- a/amr-wind/equation_systems/sdr/source_terms/SDRSrc.H
+++ b/amr-wind/equation_systems/sdr/source_terms/SDRSrc.H
@@ -17,7 +17,7 @@ class SDRSrc : public SDRSource::Register<SDRSrc>
 public:
     static const std::string identifier() { return "SDRSrc"; }
 
-    SDRSrc(const CFDSim&);
+    explicit SDRSrc(const CFDSim&);
 
     virtual ~SDRSrc();
 

--- a/amr-wind/equation_systems/tke/source_terms/KwSSTSrc.H
+++ b/amr-wind/equation_systems/tke/source_terms/KwSSTSrc.H
@@ -17,7 +17,7 @@ class KwSSTSrc : public TKESource::Register<KwSSTSrc>
 public:
     static const std::string identifier() { return "KwSSTSrc"; }
 
-    KwSSTSrc(const CFDSim&);
+    explicit KwSSTSrc(const CFDSim&);
 
     virtual ~KwSSTSrc();
 

--- a/amr-wind/equation_systems/tke/tke_ops.H
+++ b/amr-wind/equation_systems/tke/tke_ops.H
@@ -64,7 +64,7 @@ struct PostSolveOp<TKE>
 template <typename Scheme>
 struct FieldRegOp<TKE, Scheme>
 {
-    FieldRegOp(CFDSim& sim_in) : sim(sim_in) {}
+    explicit FieldRegOp(CFDSim& sim_in) : sim(sim_in) {}
 
     PDEFields operator()(const SimTime& time, const int probtype)
     {

--- a/amr-wind/equation_systems/vof/vof_advection.H
+++ b/amr-wind/equation_systems/vof/vof_advection.H
@@ -30,7 +30,7 @@ struct AdvectionOp<VOF, fvm::Godunov>
             VOF::ndim == 1, "Invalid number of components for scalar");
 
         auto& repo = fields.repo;
-        auto& geom = repo.mesh().Geom();
+        const auto& geom = repo.mesh().Geom();
 
         auto& dof_field = fields.field;
         //

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -199,10 +199,10 @@ void incflo::ApplyPredictor(bool incremental_projection)
         }
     }
 
-    // *************************************************************************************
-    // Compute explicit viscous term
-    // *************************************************************************************
     if (need_divtau()) {
+        // *************************************************************************************
+        // Compute explicit viscous term
+        // *************************************************************************************
         // Reuse existing buffer to avoid creating new multifabs
         amr_wind::field_ops::copy(
             velocity_new, velocity_old, 0, 0, velocity_new.num_comp(), 1);
@@ -218,12 +218,9 @@ void incflo::ApplyPredictor(bool incremental_projection)
             amr_wind::field_ops::add(
                 velocity_forces, divtau, 0, 0, AMREX_SPACEDIM, 0);
         }
-    }
-
-    // *************************************************************************************
-    // Compute explicit diffusive terms
-    // *************************************************************************************
-    if (need_divtau()) {
+        // *************************************************************************************
+        // Compute explicit diffusive terms
+        // *************************************************************************************
         for (auto& eqn : scalar_eqns()) {
             auto& field = eqn->fields().field;
             // Reuse existing buffer to avoid creating new multifabs

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -49,7 +49,7 @@ class TiogaInterface : public OversetManager::Register<TiogaInterface>
 public:
     static std::string identifier() { return "TIOGA"; }
 
-    TiogaInterface(CFDSim& sim);
+    explicit TiogaInterface(CFDSim& sim);
 
     /** Perform one-time initialization actions.
      *

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -20,7 +20,7 @@ namespace {
  *  \end{cases}
  *  \f}
  */
-void iblank_to_mask(const IntField& iblank, IntField& maskf)
+void iblank_to_mask(const IntField& iblank, const IntField& maskf)
 {
     const auto& nlevels = iblank.repo().mesh().finestLevel() + 1;
 
@@ -286,8 +286,8 @@ void TiogaInterface::amr_to_tioga_mesh()
 
     // Reset local patch counter
     ilp = 0;
-    auto& ibcell = m_sim.repo().get_int_field("iblank_cell");
-    auto& ibnode = m_sim.repo().get_int_field("iblank_node");
+    const auto& ibcell = m_sim.repo().get_int_field("iblank_cell");
+    const auto& ibnode = m_sim.repo().get_int_field("iblank_node");
     for (int lev = 0; lev < nlevels; ++lev) {
         auto& ad = *m_amr_data;
         auto& ibfab = ibcell(lev);

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -20,7 +20,7 @@ namespace {
  *  \end{cases}
  *  \f}
  */
-void iblank_to_mask(const IntField& iblank, const IntField& maskf)
+void iblank_to_mask(const IntField& iblank, IntField& maskf)
 {
     const auto& nlevels = iblank.repo().mesh().finestLevel() + 1;
 
@@ -286,8 +286,8 @@ void TiogaInterface::amr_to_tioga_mesh()
 
     // Reset local patch counter
     ilp = 0;
-    const auto& ibcell = m_sim.repo().get_int_field("iblank_cell");
-    const auto& ibnode = m_sim.repo().get_int_field("iblank_node");
+    auto& ibcell = m_sim.repo().get_int_field("iblank_cell");
+    auto& ibnode = m_sim.repo().get_int_field("iblank_node");
     for (int lev = 0; lev < nlevels; ++lev) {
         auto& ad = *m_amr_data;
         auto& ibfab = ibcell(lev);

--- a/amr-wind/physics/ChannelFlow.H
+++ b/amr-wind/physics/ChannelFlow.H
@@ -16,7 +16,7 @@ class ChannelFlow : public Physics::Register<ChannelFlow>
 public:
     static const std::string identifier() { return "ChannelFlow"; }
 
-    ChannelFlow(CFDSim& sim);
+    explicit ChannelFlow(CFDSim& sim);
 
     virtual ~ChannelFlow() = default;
 

--- a/amr-wind/physics/ConvectingTaylorVortex.H
+++ b/amr-wind/physics/ConvectingTaylorVortex.H
@@ -91,7 +91,7 @@ class ConvectingTaylorVortex : public Physics::Register<ConvectingTaylorVortex>
 public:
     static const std::string identifier() { return "ConvectingTaylorVortex"; }
 
-    ConvectingTaylorVortex(const CFDSim& sim);
+    explicit ConvectingTaylorVortex(const CFDSim& sim);
 
     virtual ~ConvectingTaylorVortex() = default;
 

--- a/amr-wind/physics/EkmanSpiral.H
+++ b/amr-wind/physics/EkmanSpiral.H
@@ -15,7 +15,7 @@ class EkmanSpiral : public Physics::Register<EkmanSpiral>
 public:
     static const std::string identifier() { return "EkmanSpiral"; }
 
-    EkmanSpiral(const CFDSim& sim);
+    explicit EkmanSpiral(const CFDSim& sim);
 
     virtual ~EkmanSpiral() = default;
 

--- a/amr-wind/physics/HybridRANSLESABL.H
+++ b/amr-wind/physics/HybridRANSLESABL.H
@@ -16,7 +16,7 @@ class HybridRANSLESABL : public Physics::Register<HybridRANSLESABL>
 public:
     static const std::string identifier() { return "HybridRANSLESABL"; }
 
-    HybridRANSLESABL(CFDSim& sim);
+    explicit HybridRANSLESABL(CFDSim& sim);
 
     virtual ~HybridRANSLESABL() = default;
 

--- a/amr-wind/physics/multiphase/ZalesakDisk.H
+++ b/amr-wind/physics/multiphase/ZalesakDisk.H
@@ -20,7 +20,7 @@ class ZalesakDisk : public Physics::Register<ZalesakDisk>
 public:
     static const std::string identifier() { return "ZalesakDisk"; }
 
-    ZalesakDisk(CFDSim& sim);
+    explicit ZalesakDisk(CFDSim& sim);
 
     virtual ~ZalesakDisk() = default;
 

--- a/amr-wind/transport_models/ConstTransport.H
+++ b/amr-wind/transport_models/ConstTransport.H
@@ -17,7 +17,7 @@ public:
 
     static const std::string identifier() { return "ConstTransport"; }
 
-    ConstTransport(CFDSim& sim) : m_repo(sim.repo())
+    explicit ConstTransport(CFDSim& sim) : m_repo(sim.repo())
     {
         amrex::ParmParse pp("transport");
         pp.query("viscosity", m_mu);

--- a/amr-wind/transport_models/TwoPhaseTransport.H
+++ b/amr-wind/transport_models/TwoPhaseTransport.H
@@ -18,9 +18,8 @@ public:
 
     static const std::string identifier() { return "TwoPhaseTransport"; }
 
-    TwoPhaseTransport(CFDSim& sim) : m_sim(sim), m_repo(sim.repo())
+    explicit TwoPhaseTransport(CFDSim& sim) : m_sim(sim), m_repo(sim.repo())
     {
-
         auto& physics_mgr = m_sim.physics_manager();
         if (!physics_mgr.contains("MultiPhase"))
             amrex::Abort("TwoPhaseTransport requires MultiPhase physics");

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -14,7 +14,7 @@ template <typename Transport>
 class OneEqKsgs : public TurbModelBase<Transport>
 {
 public:
-    OneEqKsgs(CFDSim& sim);
+    explicit OneEqKsgs(CFDSim& sim);
 
     virtual ~OneEqKsgs();
 
@@ -49,7 +49,7 @@ public:
         return "OneEqKsgsM84-" + Transport::identifier();
     }
 
-    OneEqKsgsM84(CFDSim& sim);
+    explicit OneEqKsgsM84(CFDSim& sim);
 
     virtual ~OneEqKsgsM84();
 

--- a/amr-wind/turbulence/LES/Smagorinsky.H
+++ b/amr-wind/turbulence/LES/Smagorinsky.H
@@ -20,7 +20,7 @@ public:
         return "Smagorinsky-" + Transport::identifier();
     }
 
-    Smagorinsky(CFDSim& sim);
+    explicit Smagorinsky(CFDSim& sim);
 
     //! Model name for debugging purposes
     virtual std::string model_name() const override { return "Smagorinsky"; }

--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -39,7 +39,7 @@ public:
         return "KOmegaSST-" + Transport::identifier();
     }
 
-    KOmegaSST(CFDSim& sim);
+    explicit KOmegaSST(CFDSim& sim);
 
     virtual ~KOmegaSST();
 

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
@@ -30,7 +30,7 @@ public:
         return "KOmegaSSTIDDES-" + Transport::identifier();
     }
 
-    KOmegaSSTIDDES(CFDSim& sim);
+    explicit KOmegaSSTIDDES(CFDSim& sim);
 
     virtual ~KOmegaSSTIDDES();
 

--- a/amr-wind/turbulence/TurbModelBase.H
+++ b/amr-wind/turbulence/TurbModelBase.H
@@ -96,7 +96,7 @@ template <typename Transport>
 class TurbModelBase : public TurbModel<Transport>
 {
 public:
-    TurbModelBase(CFDSim& sim)
+    explicit TurbModelBase(CFDSim& sim)
         : TurbModel<Transport>(sim)
         , m_mu_turb(sim.repo().declare_field("mu_turb", 1, 1, 1))
     {

--- a/amr-wind/utilities/tagging/CurvatureRefinement.H
+++ b/amr-wind/utilities/tagging/CurvatureRefinement.H
@@ -22,7 +22,7 @@ class CurvatureRefinement
 public:
     static std::string identifier() { return "CurvatureRefinement"; }
 
-    CurvatureRefinement(const CFDSim& sim);
+    explicit CurvatureRefinement(const CFDSim& sim);
 
     virtual ~CurvatureRefinement() = default;
 

--- a/amr-wind/utilities/tagging/FieldRefinement.H
+++ b/amr-wind/utilities/tagging/FieldRefinement.H
@@ -25,7 +25,7 @@ class FieldRefinement : public RefinementCriteria::Register<FieldRefinement>
 public:
     static std::string identifier() { return "FieldRefinement"; }
 
-    FieldRefinement(const CFDSim& sim);
+    explicit FieldRefinement(const CFDSim& sim);
 
     virtual ~FieldRefinement() = default;
 

--- a/amr-wind/utilities/tagging/GradientMagRefinement.H
+++ b/amr-wind/utilities/tagging/GradientMagRefinement.H
@@ -22,7 +22,7 @@ class GradientMagRefinement
 public:
     static std::string identifier() { return "GradientMagRefinement"; }
 
-    GradientMagRefinement(const CFDSim& sim);
+    explicit GradientMagRefinement(const CFDSim& sim);
 
     virtual ~GradientMagRefinement() = default;
 

--- a/amr-wind/utilities/tagging/OversetRefinement.H
+++ b/amr-wind/utilities/tagging/OversetRefinement.H
@@ -10,7 +10,7 @@ class OversetRefinement : public RefinementCriteria::Register<OversetRefinement>
 public:
     static std::string identifier() { return "OversetRefinement"; }
 
-    OversetRefinement(const CFDSim& sim);
+    explicit OversetRefinement(const CFDSim& sim);
 
     virtual ~OversetRefinement() = default;
 

--- a/amr-wind/utilities/tagging/QCriterionRefinement.H
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.H
@@ -23,7 +23,7 @@ class QCriterionRefinement
 public:
     static std::string identifier() { return "QCriterionRefinement"; }
 
-    QCriterionRefinement(const CFDSim& sim);
+    explicit QCriterionRefinement(const CFDSim& sim);
 
     virtual ~QCriterionRefinement() = default;
 

--- a/amr-wind/utilities/tagging/VorticityMagRefinement.H
+++ b/amr-wind/utilities/tagging/VorticityMagRefinement.H
@@ -23,7 +23,7 @@ class VorticityMagRefinement
 public:
     static std::string identifier() { return "VorticityMagRefinement"; }
 
-    VorticityMagRefinement(const CFDSim& sim);
+    explicit VorticityMagRefinement(const CFDSim& sim);
 
     virtual ~VorticityMagRefinement() = default;
 

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
@@ -22,7 +22,7 @@ class FastIface : public ::amr_wind::ExtSolver::Register<FastIface>
 public:
     static std::string identifier() { return "OpenFAST"; }
 
-    FastIface(const ::amr_wind::CFDSim& sim);
+    explicit FastIface(const ::amr_wind::CFDSim& sim);
 
     virtual ~FastIface();
 

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -144,7 +144,7 @@ private:
     int m_out_freq{10};
 
 public:
-    ProcessOutputsOp(typename ActTrait::DataType& data) : m_data(data) {}
+    explicit ProcessOutputsOp(typename ActTrait::DataType& data) : m_data(data) {}
 
     void read_io_options(const utils::ActParser& pp)
     {

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -144,7 +144,8 @@ private:
     int m_out_freq{10};
 
 public:
-    explicit ProcessOutputsOp(typename ActTrait::DataType& data) : m_data(data) {}
+    explicit ProcessOutputsOp(typename ActTrait::DataType& data) : m_data(data)
+    {}
 
     void read_io_options(const utils::ActParser& pp)
     {

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -95,7 +95,7 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" ${CMAKE_BINARY_DIR}/compile_commands.json > cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=danglingTemporaryLifetime --suppress=unreadVariable --suppress=internalAstError --suppress=unusedFunction --suppress=unmatchedSuppression --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=danglingTemporaryLifetime --suppress=unreadVariable --suppress=internalAstError --suppress=unusedFunction --suppress=unmatchedSuppression --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
           COMMENT "Run cppcheck on project compile_commands.json"
           BYPRODUCTS cppcheck-full-report.txt
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -95,7 +95,7 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck/cppcheck-wd
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" ${CMAKE_BINARY_DIR}/compile_commands.json > cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=internalAstError --suppress=unusedFunction --std=c++14 --language=c++ --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=danglingTemporaryLifetime --suppress=unreadVariable --suppress=internalAstError --suppress=unusedFunction --suppress=unmatchedSuppression --enable=all --project=cppcheck_compile_commands.json --cppcheck-build-dir=cppcheck-wd -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
           COMMENT "Run cppcheck on project compile_commands.json"
           BYPRODUCTS cppcheck-full-report.txt
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck

--- a/unit_tests/core/test_simtime.cpp
+++ b/unit_tests/core/test_simtime.cpp
@@ -57,7 +57,6 @@ TEST_F(SimTimeTest, init)
     // Check that the timestep growth is not greater than 10% of the last
     // timestep
     time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
-    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(time.deltaT(), 1.1 * first_dt, tol);
 }
 
@@ -85,7 +84,6 @@ TEST_F(SimTimeTest, time_loop)
     EXPECT_EQ(regrid_counter, 1);
 
     EXPECT_TRUE(time.write_last_checkpoint());
-    // cppcheck-suppress unreadVariable
     EXPECT_FALSE(time.write_last_plot_file());
 }
 
@@ -117,7 +115,6 @@ TEST_F(SimTimeTest, fixed_dt_loop)
     EXPECT_EQ(regrid_counter, 3);
 
     EXPECT_FALSE(time.write_last_checkpoint());
-    // cppcheck-suppress unreadVariable
     EXPECT_FALSE(time.write_last_plot_file());
 }
 

--- a/unit_tests/core/vs/test_vspace.cpp
+++ b/unit_tests/core/vs/test_vspace.cpp
@@ -156,7 +156,6 @@ TEST(VectorSpace, vector_create)
 
     EXPECT_NEAR(v1.x(), v6.x(), tol);
     EXPECT_NEAR(v1.y(), v6.y(), tol);
-    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(v1.z(), v6.z(), tol);
 
     test_vector_create_impl();
@@ -179,7 +178,6 @@ TEST(VectorSpace, vector_ops)
 
     EXPECT_NEAR((v1 & v2), 50.0 * v21, tol);
     EXPECT_NEAR((v1 & vs::Vector::khat()), 0.0, tol);
-    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(vs::mag_sqr((v1 + v2) - vs::Vector{11.0, 22.0, 0.0}), 0.0, tol);
 }
 

--- a/unit_tests/utilities/test_field_plane_averaging.cpp
+++ b/unit_tests/utilities/test_field_plane_averaging.cpp
@@ -71,7 +71,7 @@ void add_linear(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();
@@ -178,7 +178,7 @@ void add_periodic(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();

--- a/unit_tests/utilities/test_linear_interpolation.cpp
+++ b/unit_tests/utilities/test_linear_interpolation.cpp
@@ -30,7 +30,6 @@ TEST(LinearInterpolation, check_bounds)
         const amrex::Real xinp = 9.0 * amrex::Random();
         const auto idx = interp::check_bounds(start, end, xinp);
         EXPECT_EQ(idx.idx, 0);
-        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::VALID);
     }
 }
@@ -56,7 +55,6 @@ TEST(LinearInterpolation, bisection_search)
     {
         const auto idx = interp::bisection_search(start, end, 9.1);
         EXPECT_EQ(idx.idx, 9);
-        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::UPLIM);
     }
 }
@@ -87,7 +85,6 @@ TEST(LinearInterpolation, find_index)
     {
         const auto idx = interp::find_index(start, end, 9.1);
         EXPECT_EQ(idx.idx, 9);
-        // cppcheck-suppress unreadVariable
         EXPECT_EQ(idx.lim, interp::Limits::UPLIM);
     }
 }

--- a/unit_tests/utilities/test_plane_averaging.cpp
+++ b/unit_tests/utilities/test_plane_averaging.cpp
@@ -72,7 +72,7 @@ void add_linear(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();
@@ -182,7 +182,7 @@ void add_periodic(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();

--- a/unit_tests/utilities/test_second_moment.cpp
+++ b/unit_tests/utilities/test_second_moment.cpp
@@ -64,7 +64,7 @@ void add_linear(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();
@@ -170,7 +170,7 @@ void add_periodic(
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> a,
     const amrex::Geometry& geom,
     const amrex::Box& bx,
-    amrex::Array4<amrex::Real>& velocity)
+    const amrex::Array4<amrex::Real>& velocity)
 {
     auto xlo = geom.ProbLoArray();
     auto dx = geom.CellSizeArray();

--- a/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
@@ -178,7 +178,7 @@ namespace amr_wind_tests {
 class ActPhysicsTest : public ::amr_wind::actuator::Actuator
 {
 public:
-    ActPhysicsTest(::amr_wind::CFDSim& sim)
+    explicit ActPhysicsTest(::amr_wind::CFDSim& sim)
         : ::amr_wind::actuator::Actuator(sim)
     {}
 

--- a/unit_tests/wind_energy/actuator/test_actuator_sampling.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_sampling.cpp
@@ -55,7 +55,6 @@ TEST_F(ActuatorTest, act_container)
     const int nprocs = amrex::ParallelDescriptor::NProcs();
     if (nprocs > 2) {
         GTEST_SKIP();
-        return;
     }
 
     const int iproc = amrex::ParallelDescriptor::MyProc();

--- a/unit_tests/wind_energy/actuator/test_airfoil.cpp
+++ b/unit_tests/wind_energy/actuator/test_airfoil.cpp
@@ -60,7 +60,6 @@ TEST(Airfoil, read_txt_file)
     auto af = AirfoilLoader::load_text_file(ss);
     EXPECT_EQ(af->num_entries(), 6);
     EXPECT_NEAR(af->aoa().front(), -1.0 * ::amr_wind::utils::pi(), 1.0e-12);
-    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(af->aoa().back(), 1.0 * ::amr_wind::utils::pi(), 1.0e-12);
 }
 
@@ -72,7 +71,6 @@ TEST(Airfoil, read_openfast_file)
     auto af = AirfoilLoader::load_openfast_airfoil(ss);
     EXPECT_EQ(af->num_entries(), 6);
     EXPECT_NEAR(af->aoa().front(), -1.0 * ::amr_wind::utils::pi(), 1.0e-12);
-    // cppcheck-suppress unreadVariable
     EXPECT_NEAR(af->aoa().back(), ::amr_wind::utils::radians(-150.0), 1.0e-12);
 }
 


### PR DESCRIPTION
I'm working on cleaning up warnings again. This first round is mostly to add `explicit` to constructors with one argument, and adding some `const`, but there are a few other fixes as well.