### PR TITLE
Add component view for hub

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp.H
@@ -63,6 +63,7 @@ void ActSrcOp<
 {
     const auto& meta = m_data.meta();
     std::vector<ComponentView> tower_vec(1, meta.tower);
+    std::vector<ComponentView> hub_vec(1, meta.hub);
 
     amrex::Gpu::copy(
         amrex::Gpu::hostToDevice, meta.blades.begin(), meta.blades.end(),
@@ -70,6 +71,9 @@ void ActSrcOp<
     amrex::Gpu::copy(
         amrex::Gpu::hostToDevice, tower_vec.begin(), tower_vec.end(),
         m_tower.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, hub_vec.begin(), hub_vec.end(),
+        m_hub.begin());
 }
 
 template <typename ActTrait>
@@ -168,7 +172,6 @@ operator()(const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom)
                 const auto dist_local = tmat[0] & dist;
                 const auto gauss_fac = utils::gaussian3d(dist_local, eps[0]);
                 const auto& pforce = force[0];
-
                 src_force[0] += gauss_fac * pforce.x();
                 src_force[1] += gauss_fac * pforce.y();
                 src_force[2] += gauss_fac * pforce.z();

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -218,6 +218,14 @@ struct InitDataOp<TurbineFast, SrcTrait>
             cv.chord = ::amr_wind::utils::slice(
                 tdata.chord, ntwr_start, num_pts_tower);
         }
+        {
+            auto& cv = tdata.hub;
+            cv.pos = ::amr_wind::utils::slice(grid.pos, 0, 1);
+            cv.force = ::amr_wind::utils::slice(grid.force, 0, 1);
+            cv.epsilon = ::amr_wind::utils::slice(grid.epsilon, 0, 1);
+            cv.orientation = ::amr_wind::utils::slice(grid.orientation, 0, 1);
+            cv.chord = ::amr_wind::utils::slice(tdata.chord, 0, 1);
+        }
     }
 
     void init_epsilon(typename TurbineFast::DataType& data)

--- a/amr-wind/wind_energy/actuator/turbine/turbine_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_types.H
@@ -80,6 +80,7 @@ struct TurbineBaseData
 
     std::vector<ComponentView> blades;
     ComponentView tower;
+    ComponentView hub;
 };
 
 struct TurbineType : public ActuatorType


### PR DESCRIPTION
This fixes a memory leak because I forgot to deal with all the hub stuff and added it hastily at the end of #413.

I've added a component view for this rather than just using index 0.  This will allow for turbine data structures beyond openfast in the future and keeps the framework the same for hub when compared with the blades and tower.