### PR TITLE
Fixed GeometryRefinement `level` specification

### DIFF
--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -36,7 +36,7 @@ void GeometryRefinement::operator()(
 {
     // If the user has requested a particular level then check for it and exit
     // early
-    if ((m_set_level > 1) && (level != m_set_level)) return;
+    if ((m_set_level > -1) && (level != m_set_level)) return;
 
     // If the user has specified a range of levels, check and return early
     if ((level < m_min_level) || (level > m_max_level)) return;


### PR DESCRIPTION
Fixes issue raised in [issue 423](https://github.com/Exawind/amr-wind/issues/423).  Changed the `m_set_level` comparison to be
```cpp
 if ((m_set_level > -1) && (level != m_set_level)) return; 
```
Tested and it should work for refinements at level 0 and 1 now.

Lawrence