### PR TITLE
Regrid on restart

### DIFF
--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -65,6 +65,9 @@ void incflo::init_mesh()
     } else {
         // Read starting configuration from chk file.
         ReadCheckpointFile();
+        for (int lev = finestLevel(); lev <= maxLevel(); ++lev) {
+            regrid(lev, m_time.current_time());
+        }
         if (ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "Grid summary: " << std::endl;
             printGridSummary(amrex::OutStream(), 0, finest_level);


### PR DESCRIPTION
Add ability to refine the AMR-Wind mesh upon restart to a user-specified number
of levels. The use-case is performing a turbine simulation from a restart file
containing the ABL precursor solution. In this case, typically the user wants to
only perform regrid once at the beginning of the restarted simulation and then
maintain the nested grids for the duration of the turbine run. The usual process
of restart will not work in this case, as AMReX only adds one level of
refinement for each `regrid` call.

In the proposed implementation, we check if the user has requested more levels
than the finest level available in the restart solution. If true, then we call
regrid for all the new levels after reading the checkpoint file.

The current implementation assumes that if the user has set `max_level` to a
value greater than the number of levels in the checkpoint file, refinement is
intended during initialization. It might be necessary to provide
`SimTime::regrid_on_restart()` flag to control this behavior.
