### PR TITLE
Enable inflow outflow capability with turbines

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
@@ -51,6 +51,11 @@ private:
     amrex::Real m_beta{0.0};
 
     int m_axis{2};
+
+    bool m_const_profile{false};
+
+    //! Read a temperature profile from a text file
+    void read_temperature_profile(std::string profile_file_name);
 };
 } // namespace icns
 

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -129,7 +129,7 @@ void ABLMeanBoussinesq::mean_temperature_update(const FieldPlaneAveraging& tavg)
 void ABLMeanBoussinesq::read_temperature_profile(std::string profile_file_name)
 {
 
-    m_axis = 2; //Fix to be z-direction for now
+    m_axis = 2; // Fix to be z-direction for now
     amrex::Vector<amrex::Real> theta_ht, theta_vals;
     std::ifstream infile;
     int n_hts;
@@ -139,19 +139,16 @@ void ABLMeanBoussinesq::read_temperature_profile(std::string profile_file_name)
     theta_vals.resize(n_hts);
     m_theta_ht.resize(n_hts);
     m_theta_vals.resize(n_hts);
-    for (int i = 0; i < n_hts; i++)
-        infile >> theta_ht[i] >> theta_vals[i];
+    for (int i = 0; i < n_hts; i++) infile >> theta_ht[i] >> theta_vals[i];
     infile.close();
 
-    //Now copy to GPU Device memory
+    // Now copy to GPU Device memory
     amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, theta_ht.begin(),
-        theta_ht.end(), m_theta_ht.begin());
+        amrex::Gpu::hostToDevice, theta_ht.begin(), theta_ht.end(),
+        m_theta_ht.begin());
     amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, theta_vals.begin(),
-        theta_vals.end(), m_theta_vals.begin());
-
-
+        amrex::Gpu::hostToDevice, theta_vals.begin(), theta_vals.end(),
+        m_theta_vals.begin());
 }
 
 } // namespace icns

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -128,6 +128,8 @@ void ABLMeanBoussinesq::mean_temperature_update(const FieldPlaneAveraging& tavg)
 
 void ABLMeanBoussinesq::read_temperature_profile(std::string profile_file_name)
 {
+
+    m_axis = 2; //Fix to be z-direction for now
     amrex::Vector<amrex::Real> theta_ht, theta_vals;
     std::ifstream infile;
     int n_hts;
@@ -135,9 +137,10 @@ void ABLMeanBoussinesq::read_temperature_profile(std::string profile_file_name)
     infile >> n_hts;
     theta_ht.resize(n_hts);
     theta_vals.resize(n_hts);
-    for (int i = 0; i < n_hts; i++) {
+    m_theta_ht.resize(n_hts);
+    m_theta_vals.resize(n_hts);
+    for (int i = 0; i < n_hts; i++)
         infile >> theta_ht[i] >> theta_vals[i];
-    }
     infile.close();
 
     //Now copy to GPU Device memory

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -36,10 +36,6 @@ public:
     void
     update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
 
-    void computeplanar();
-
-    void computeusingheatflux();
-
 private:
     const CFDSim& m_sim;
 

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -57,6 +57,11 @@ private:
     amrex::Real m_surf_temp_rate{0.0};
     amrex::Real m_surf_temp_rate_tstart{0.0};
     amrex::Real m_surf_temp_init{300.0};
+
+    bool m_inflow_outflow{false};
+    amrex::Real m_wf_vmag{0.0};
+    amrex::Array<amrex::Real, 2> m_wf_vel{{0.0, 0.0}};
+    amrex::Real m_wf_theta{300.0};
 };
 
 /** Applies a shear-stress value at the domain boundary

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -124,7 +124,6 @@ void ABLWallFunction::update_umean(
     }
 
     m_mo.update_fluxes();
-
 }
 
 ABLVelWallFunc::ABLVelWallFunc(Field&, const ABLWallFunction& wall_func)

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -111,19 +111,16 @@ void ABLWallFunction::update_umean(
                 3600.0;
     }
 
-#if 1
     if (m_inflow_outflow) {
         m_mo.vel_mean[0] = m_wf_vel[0];
         m_mo.vel_mean[1] = m_wf_vel[1];
         m_mo.vmag_mean = m_wf_vmag;
         m_mo.theta_mean = m_wf_theta;
     } else {
-        {
-            m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
-            m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
-            m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
-            m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
-        }
+        m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
+        m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
+        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
+        m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
     }
 
     m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
@@ -133,12 +130,6 @@ void ABLWallFunction::update_umean(
 
     m_mo.update_fluxes();
 
-#else
-
-    computeplanar();
-    computeusingheatflux();
-
-#endif
 }
 
 ABLVelWallFunc::ABLVelWallFunc(Field&, const ABLWallFunction& wall_func)

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -108,17 +108,21 @@ void ABLWallFunction::update_umean(
             m_surf_temp_rate *
                 amrex::max(time.current_time() - m_surf_temp_rate_tstart, 0.0) /
                 3600.0;
+    }
 
+#if 1
     if (m_inflow_outflow) {
         m_mo.vel_mean[0] = m_wf_vel[0];
         m_mo.vel_mean[1] = m_wf_vel[1];
         m_mo.vmag_mean = m_wf_vmag;
         m_mo.theta_mean = m_wf_theta;
     } else {
+        {
         m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
         m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
         m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
         m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
+        }
     }
 
     m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
@@ -127,6 +131,14 @@ void ABLWallFunction::update_umean(
     m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
 
     m_mo.update_fluxes();
+    
+#else
+    
+    computeplanar();
+    computeusingheatflux();
+    
+#endif
+    
 }
 
 ABLVelWallFunc::ABLVelWallFunc(Field&, const ABLWallFunction& wall_func)

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -71,6 +71,18 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
                        << std::endl;
     }
 
+    if (pp.contains("inflow_outflow_mode")) {
+        pp.query("inflow_outflow_mode", m_inflow_outflow);
+        if (m_inflow_outflow) {
+            pp.query("wf_velocity", m_wf_vel);
+            pp.query("wf_vmag", m_wf_vmag);
+            pp.query("wf_theta", m_wf_theta);
+            amrex::Print() << "ABLWallFunction: Inflow/Outflow mode is turned "
+                "on. Please make sure wall shear stress type is set to local."
+                           << std::endl;
+        }
+    }
+
     m_mo.alg_type =
         m_tempflux ? MOData::HEAT_FLUX : MOData::SURFACE_TEMPERATURE;
     m_mo.gravity = utils::vec_mag(m_gravity.data());
@@ -96,6 +108,17 @@ void ABLWallFunction::update_umean(
             m_surf_temp_rate *
                 amrex::max(time.current_time() - m_surf_temp_rate_tstart, 0.0) /
                 3600.0;
+
+    if (m_inflow_outflow) {
+        m_mo.vel_mean[0] = m_wf_vel[0];
+        m_mo.vel_mean[1] = m_wf_vel[1];
+        m_mo.vmag_mean = m_wf_vmag;
+        m_mo.theta_mean = m_wf_theta;
+    } else {
+        m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
+        m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
+        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
+        m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
     }
 
     m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -78,7 +78,8 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
             pp.query("wf_vmag", m_wf_vmag);
             pp.query("wf_theta", m_wf_theta);
             amrex::Print() << "ABLWallFunction: Inflow/Outflow mode is turned "
-                "on. Please make sure wall shear stress type is set to local."
+                              "on. Please make sure wall shear stress type is "
+                              "set to local."
                            << std::endl;
         }
     }
@@ -118,10 +119,10 @@ void ABLWallFunction::update_umean(
         m_mo.theta_mean = m_wf_theta;
     } else {
         {
-        m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
-        m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
-        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
-        m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
+            m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
+            m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
+            m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
+            m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
         }
     }
 
@@ -131,14 +132,13 @@ void ABLWallFunction::update_umean(
     m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
 
     m_mo.update_fluxes();
-    
+
 #else
-    
+
     computeplanar();
     computeusingheatflux();
-    
+
 #endif
-    
 }
 
 ABLVelWallFunc::ABLVelWallFunc(Field&, const ABLWallFunction& wall_func)

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -123,11 +123,6 @@ void ABLWallFunction::update_umean(
         m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
     }
 
-    m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
-    m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
-    m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
-    m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
-
     m_mo.update_fluxes();
 
 }


### PR DESCRIPTION
This pull request adds the capability to specify the QOI's for the wall function and the ABLMeanBoussinesq term for inflow/outflow simulations of the ABL. These features are only turned on through user request in the input file.

The QOI's for the wall function can be specified as follows

```
ABL.inflow_outflow_mode = true
ABL.wf_velocity = 5.17589773617045 0.038579676516582534
ABL.wf_vmag = 5.207002998349855
ABL.wf_theta = 288.59182752619785
```

A fixed temperature profile to calculate the ABLMeanBoussinesq term can be applied as follows 

```
BoussinesqBuoyancy.read_temperature_profile = true
BoussinesqBuoyancy.tprofile_filename = avg_theta.dat
```

The file with the temperature profile should look as follows:

```
160
6.0 288.5918275261976
18.0 288.5106096878474
30.0 288.47096492218867
42.0 288.45397024022895
.
.
.
1914.0 296.89388984542086
```