### PR TITLE
Enable blade-resolved sims in ABL with 1-eq k-sgs

### DIFF
--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -1,9 +1,9 @@
-
 #include "amr-wind/incflo.H"
 
 #include "amr-wind/wind_energy/ABL.H"
 #include "amr-wind/utilities/tagging/RefinementCriteria.H"
 #include "amr-wind/equation_systems/PDEBase.H"
+#include "amr-wind/turbulence/TurbulenceModel.H"
 #include "amr-wind/utilities/IOManager.H"
 #include "amr-wind/utilities/PostProcessing.H"
 #include "amr-wind/overset/OversetManager.H"
@@ -201,6 +201,9 @@ bool incflo::regrid_and_update()
 void incflo::post_advance_work()
 {
     BL_PROFILE("amr-wind::incflo::post_advance_work");
+
+    m_sim.turbulence_model().post_advance_work();
+
     for (auto& pp : m_sim.physics()) pp->post_advance_work();
 
     m_sim.post_manager().post_advance_work();

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -31,7 +31,6 @@ protected:
     //! Turbulence constant
     amrex::Real m_Ce{0.1};
     amrex::Real m_Ceps{0.93};
-
 };
 
 /** 1-equation subgrid scale TKE turbulence model

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -31,6 +31,7 @@ protected:
     //! Turbulence constant
     amrex::Real m_Ce{0.1};
     amrex::Real m_Ceps{0.93};
+
 };
 
 /** 1-equation subgrid scale TKE turbulence model
@@ -58,6 +59,9 @@ public:
     //! Update the turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
+    //! Do any post advance work
+    virtual void post_advance_work() override;
+
     //! Update the effective thermal diffusivity field
     virtual void update_alphaeff(Field& alphaeff) override;
 
@@ -76,6 +80,10 @@ private:
 
     //! Reference temperature (Kelvin)
     amrex::Real m_ref_theta{300.0};
+
+    //! Hybrid RANS-LES with Nalu-wind
+    bool m_hybrid_rl{false};
+    Field* m_sdr;
 };
 
 /** 1-equation subgrid scale TKE turbulence model
@@ -102,6 +110,9 @@ public:
 
     //! Update the turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
+
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
 
     //! Update the effective scalar diffusivity field
     virtual void

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -52,8 +52,8 @@ OneEqKsgsM84<Transport>::OneEqKsgsM84(CFDSim& sim)
     }
 
     if (m_hybrid_rl)
-        m_sdr =
-            &(sim.repo().declare_field("sdr", 1, this->m_tke.num_grow()[0], 1));
+        m_sdr = &(sim.repo().declare_field(
+            "sdr", 1, (*this->m_tke).num_grow()[0], 1));
 
     {
         amrex::ParmParse pp("incflo");

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -48,7 +48,11 @@ OneEqKsgsM84<Transport>::OneEqKsgsM84(CFDSim& sim)
     {
         amrex::ParmParse pp("ABL");
         pp.get("reference_temperature", m_ref_theta);
+        pp.query("enable_hybrid_rl_mode", m_hybrid_rl);
     }
+
+    if (m_hybrid_rl)
+        m_sdr = &(sim.repo().declare_field("sdr", 1, 1, 1));
 
     {
         amrex::ParmParse pp("incflo");
@@ -205,6 +209,47 @@ void OneEqKsgsM84<Transport>::update_scalar_diff(
             name);
     }
 }
+
+template <typename Transport>
+void OneEqKsgsM84<Transport>::post_advance_work() {
+
+    BL_PROFILE("amr-wind::" + this->identifier() + "::post_advance_work");
+
+    if ( m_hybrid_rl )   {
+        // Update sdr field based on sfs ke
+
+        auto& tke = *(this->m_tke);
+        auto& sdr = *(this->m_sdr);
+        const amrex::Real Ce = this->m_Ce;
+
+        auto& repo = tke.repo();
+        auto& geom_vec = repo.mesh().Geom();
+        const int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            const auto& geom = geom_vec[lev];
+
+            const amrex::Real dx = geom.CellSize()[0];
+            const amrex::Real dy = geom.CellSize()[1];
+            const amrex::Real dz = geom.CellSize()[2];
+            const amrex::Real ds = std::cbrt(dx * dy * dz);
+
+            for (amrex::MFIter mfi(tke(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& tke_arr = tke(lev).array(mfi);
+                const auto& sdr_arr = sdr(lev).array(mfi);
+
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        sdr_arr(i, j, k) = std::sqrt(tke_arr(i,j,k))/(Ce * ds);
+                    });
+            }
+        }
+
+        sdr.fillpatch(this->m_sim.time().current_time());
+
+    }
+}
+
 
 template <typename Transport>
 OneEqKsgsS94<Transport>::OneEqKsgsS94(CFDSim& sim) : OneEqKsgs<Transport>(sim)

--- a/amr-wind/turbulence/LES/Smagorinsky.H
+++ b/amr-wind/turbulence/LES/Smagorinsky.H
@@ -28,6 +28,9 @@ public:
     //! Update the turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
+
     //! Return model coefficients dictionary
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 

--- a/amr-wind/turbulence/LaminarModel.H
+++ b/amr-wind/turbulence/LaminarModel.H
@@ -30,6 +30,9 @@ public:
     //! Update the effective/turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
+
     //! Return the turbulent viscosity field (just the same as the effective
     //! field)
     virtual Field& mu_turb() override { return this->mueff(); }

--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -48,6 +48,9 @@ public:
     //! Update the turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
+
     //! Update the effective scalar diffusivity field
     virtual void
     update_scalar_diff(Field& deff, const std::string& name) override;

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
@@ -39,6 +39,9 @@ public:
     //! Update the turbulent viscosity field
     virtual void update_turbulent_viscosity(const FieldState fstate) override;
 
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
+
     //! Return turbulence model coefficients
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 

--- a/amr-wind/turbulence/TurbulenceModel.H
+++ b/amr-wind/turbulence/TurbulenceModel.H
@@ -49,6 +49,9 @@ public:
      */
     virtual void update_turbulent_viscosity(const FieldState fstate) = 0;
 
+    //! Do any post advance actions for the turbulence model
+    virtual void post_advance_work() = 0;
+
     //! Register the effective viscosity (for momentum field)
     virtual void register_mueff_field(Field& mueff) = 0;
 


### PR DESCRIPTION
Calculate `sdr` based on `k_sgs` for 1-eq K-sgs model in AMR-wind. This will enable blade-resolved simulations in the ABL using the hybrid solver.