### PR TITLE
Fix typo in type value for AMR tagging docs

### DIFF
--- a/docs/sphinx/user/inputs_AMR_Tagging.rst
+++ b/docs/sphinx/user/inputs_AMR_Tagging.rst
@@ -42,7 +42,7 @@ Each section must contain the keyword ``type`` that is one of the refinement typ
 ``OversetRefinement``    Refinement around fringe/field interface
 ``GeometryRefinement``   Refinement using geometric shapes
 ``QCriterionRefinement`` Refinement using Q-Criterion
-``VorticityRefinement``  Refinement using vorticity
+``VorticityMagRefinement``  Refinement using vorticity
 ======================== ===================================================================
 
 .. input_param:: tagging.labels


### PR DESCRIPTION
Docs said to use the value `VorticityRefinement` instead of `VorticityMagRefinement` for AMR tagging type.