### PR TITLE
Nacelle epsilon min value fix

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -237,9 +237,9 @@ struct InitDataOp<TurbineFast, SrcTrait>
                 std::sqrt(2.0 / ::amr_wind::utils::pi() * cd * area);
 
             auto& nac_eps = data.grid().epsilon[0];
-            nac_eps.x() = amrex::max(eps, 1.0);
-            nac_eps.y() = amrex::max(eps, 1.0);
-            nac_eps.z() = amrex::max(eps, 1.0);
+            nac_eps.x() = amrex::max(eps, tdata.eps_min.x());
+            nac_eps.y() = amrex::max(eps, tdata.eps_min.y());
+            nac_eps.z() = amrex::max(eps, tdata.eps_min.z());
         }
 
         for (int ib = 0; ib < tdata.num_blades; ++ib) {


### PR DESCRIPTION
This fix sets the nacelle epsilon to be the maximum between the value computed and the minimum value specified in the input file.

