### PR TITLE
Corrected S2 and W2 definitions for Q criterion

### DIFF
--- a/amr-wind/fvm/qcriterion.H
+++ b/amr-wind/fvm/qcriterion.H
@@ -77,9 +77,9 @@ struct Qcriterion
                      idx[2];
 
                 const amrex::Real S2 =
-                    std::pow(ux, 2) + std::pow(vy, 2) +
-                    std::pow(wz, 2) + 0.5 * std::pow(uy + vx, 2) +
-                    0.5 * std::pow(vz + wy, 2) + 0.5 * std::pow(wx + uz, 2);
+                    std::pow(ux, 2) + std::pow(vy, 2) + std::pow(wz, 2) +
+                    0.5 * std::pow(uy + vx, 2) + 0.5 * std::pow(vz + wy, 2) +
+                    0.5 * std::pow(wx + uz, 2);
 
                 const amrex::Real W2 = 0.5 * std::pow(uy - vx, 2) +
                                        0.5 * std::pow(vz - wy, 2) +

--- a/amr-wind/fvm/qcriterion.H
+++ b/amr-wind/fvm/qcriterion.H
@@ -77,13 +77,13 @@ struct Qcriterion
                      idx[2];
 
                 const amrex::Real S2 =
-                    2.0 * std::pow(ux, 2) + 2.0 * std::pow(vy, 2) +
-                    2.0 * std::pow(wz, 2) + std::pow(uy + vx, 2) +
-                    std::pow(vz + wy, 2) + std::pow(wx + uz, 2);
+                    std::pow(ux, 2) + std::pow(vy, 2) +
+                    std::pow(wz, 2) + 0.5 * std::pow(uy + vx, 2) +
+                    0.5 * std::pow(vz + wy, 2) + 0.5 * std::pow(wx + uz, 2);
 
-                const amrex::Real W2 = std::pow(uy - vx, 2) +
-                                       std::pow(vz - wy, 2) +
-                                       std::pow(wx - uz, 2);
+                const amrex::Real W2 = 0.5 * std::pow(uy - vx, 2) +
+                                       0.5 * std::pow(vz - wy, 2) +
+                                       0.5 * std::pow(wx - uz, 2);
                 if (nondim) {
                     qcritphi(i, j, k) = 0.5 * (W2 / S2 - 1.0);
                 } else {

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -88,11 +88,12 @@ void QCriterionRefinement::operator()(
                 const auto wz =
                     0.5 * (vel(i, j, k + 1, 2) - vel(i, j, k - 1, 2)) * idx[2];
 
-                const auto S2 = ux * ux + vy * vy + wz * wz +
-                                0.5 * std::pow(uy + vx, 2) + 0.5 * std::pow(vz + wy, 2) +
-                                0.5 * std::pow(wx + uz, 2);
+                const auto S2 = 
+                    ux * ux + vy * vy + wz * wz + 0.5 * std::pow(uy + vx, 2) + 
+                    0.5 * std::pow(vz + wy, 2) + 0.5 * std::pow(wx + uz, 2);
 
-                const auto W2 = 0.5 * std::pow(uy - vx, 2) + 0.5 * std::pow(vz - wy, 2) +
+                const auto W2 = 0.5 * std::pow(uy - vx, 2) + 
+                                0.5 * std::pow(vz - wy, 2) +
                                 0.5 * std::pow(wx - uz, 2);
 
                 const auto qc = 0.5 * (W2 - S2);

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -89,7 +89,7 @@ void QCriterionRefinement::operator()(
                     0.5 * (vel(i, j, k + 1, 2) - vel(i, j, k - 1, 2)) * idx[2];
 
                 const auto S2 =
-                    ux * ux + vy * vy + wz * wz + 0.5 * std::pow(uy + vx, 2) + 
+                    ux * ux + vy * vy + wz * wz + 0.5 * std::pow(uy + vx, 2) +
                     0.5 * std::pow(vz + wy, 2) + 0.5 * std::pow(wx + uz, 2);
 
                 const auto W2 = 0.5 * std::pow(uy - vx, 2) +

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -88,12 +88,12 @@ void QCriterionRefinement::operator()(
                 const auto wz =
                     0.5 * (vel(i, j, k + 1, 2) - vel(i, j, k - 1, 2)) * idx[2];
 
-                const auto S2 = 2.0 * ux * ux + 2.0 * vy * vy + 2.0 * wz * wz +
-                                std::pow(uy + vx, 2) + std::pow(vz + wy, 2) +
-                                std::pow(wx + uz, 2);
+                const auto S2 = ux * ux + vy * vy + wz * wz +
+                                0.5 * std::pow(uy + vx, 2) + 0.5 * std::pow(vz + wy, 2) +
+                                0.5 * std::pow(wx + uz, 2);
 
-                const auto W2 = std::pow(uy - vx, 2) + std::pow(vz - wy, 2) +
-                                std::pow(wx - uz, 2);
+                const auto W2 = 0.5 * std::pow(uy - vx, 2) + 0.5 * std::pow(vz - wy, 2) +
+                                0.5 * std::pow(wx - uz, 2);
 
                 const auto qc = 0.5 * (W2 - S2);
                 const auto qc_nondim =

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -88,11 +88,11 @@ void QCriterionRefinement::operator()(
                 const auto wz =
                     0.5 * (vel(i, j, k + 1, 2) - vel(i, j, k - 1, 2)) * idx[2];
 
-                const auto S2 = 
+                const auto S2 =
                     ux * ux + vy * vy + wz * wz + 0.5 * std::pow(uy + vx, 2) + 
                     0.5 * std::pow(vz + wy, 2) + 0.5 * std::pow(wx + uz, 2);
 
-                const auto W2 = 0.5 * std::pow(uy - vx, 2) + 
+                const auto W2 = 0.5 * std::pow(uy - vx, 2) +
                                 0.5 * std::pow(vz - wy, 2) +
                                 0.5 * std::pow(wx - uz, 2);
 

--- a/unit_tests/fvm/AnalyticalFunction.H
+++ b/unit_tests/fvm/AnalyticalFunction.H
@@ -345,7 +345,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real q_criterion(
     const amrex::Real W2 =
         (uy - vx) * (uy - vx) + (vz - wy) * (vz - wy) + (wx - uz) * (wx - uz);
 
-    return 0.5 * (W2 - S2);
+    return 0.25 * (W2 - S2);
 }
 
 } // namespace analytical_function


### PR DESCRIPTION
[Hussain, F. (1995) On the identification of a vortex. JFM 285, 69-94](https://www.researchgate.net/publication/231865270_Hussain_F_On_the_identification_of_a_vortex_JFM_285_69-94), [Haller, G. (2005). An objective definition of a vortex. Journal of Fluid Mechanics, 525, 1-26](http://www.georgehaller.com/reprints/vortex.pdf), and others use the following definition for the Q-criterion:

<img src="https://render.githubusercontent.com/render/math?math=Q%20%3D%20%5Cfrac%7B1%7D%7B2%7D%20(%20%7C%7C%5COmega%7C%7C%5E2%20-%20%7C%7CS%7C%7C%5E2)">

with <img src="https://render.githubusercontent.com/render/math?math=S"> and <img src="https://render.githubusercontent.com/render/math?math=%5COmega"> the symmetric and anti-symmetric parts, respectively, of the gradient of velocity tensor.

With these definitions, the tensors are

<img src="https://render.githubusercontent.com/render/math?math=S%20%3D%20%5Cfrac%7B1%7D%7B2%7D(%5Cnabla%20u%20%2B%20(%5Cnabla%20u)%5ET)%20%3D%20%5Cfrac%7B1%7D%7B2%7D%20%5Cbegin%7Bbmatrix%7D%202%20%5Cpartial_x%20u%20%26%20%5Cpartial_y%20u%20%2B%20%5Cpartial_x%20v%20%26%20%5Cpartial_z%20u%20%2B%20%5Cpartial_x%20w%20%5C%5C%20%5Cpartial_x%20v%20%2B%20%5Cpartial_y%20u%20%26%202%20%5Cpartial_y%20v%20%26%20%5Cpartial_z%20v%20%2B%20%5Cpartial_y%20w%5C%5C%20%5Cpartial_x%20w%20%2B%20%5Cpartial_z%20u%20%26%20%5Cpartial_yw%20%2B%20%5Cpartial_z%20v%20%26%202%20%5Cpartial_z%20w%20%5Cend%7Bbmatrix%7D">

and

<img src="https://render.githubusercontent.com/render/math?math=%5COmega%20%3D%20%5Cfrac%7B1%7D%7B2%7D(%5Cnabla%20u%20-%20(%5Cnabla%20u)%5ET)%20%3D%20%5Cfrac%7B1%7D%7B2%7D%20%5Cbegin%7Bbmatrix%7D%200%20%26%20%5Cpartial_y%20u%20-%20%5Cpartial_x%20v%20%26%20%5Cpartial_z%20u%20-%20%5Cpartial_x%20w%20%5C%5C%20%5Cpartial_x%20v%20-%20%5Cpartial_y%20u%20%26%200%20%26%20%5Cpartial_z%20v%20-%20%5Cpartial_y%20w%5C%5C%20%5Cpartial_x%20w%20-%20%5Cpartial_z%20u%20%26%20%5Cpartial_yw%20-%20%5Cpartial_z%20v%20%26%200%20%5Cend%7Bbmatrix%7D">.

Therefore, the square of their Frobenius norm are

<img src="https://render.githubusercontent.com/render/math?math=%7C%7CS%7C%7C%5E2%20%3D%20%5Csum_%7Bi%2Cj%7DS_%7Bi%2Cj%7D%5E2%20%3D%20(%5Cpartial_x%20u)%5E2%20%2B%20(%5Cpartial_y%20v)%5E2%20%2B%20(%5Cpartial_z%20w)%5E2%20%2B%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_x%20v%20%2B%20%5Cpartial_y%20u)%5E2%20%2B%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_x%20w%20%2B%20%5Cpartial_z%20u)%5E2%20%2B%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_y%20w%20%2B%20%5Cpartial_z%20v)%5E2">

and

<img src="https://render.githubusercontent.com/render/math?math=%7C%7C%5COmega%7C%7C%5E2%20%3D%20%5Csum_%7Bi%2Cj%7D%5COmega_%7Bi%2Cj%7D%5E2%20%3D%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_x%20v%20-%20%5Cpartial_y%20u)%5E2%20%2B%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_x%20w%20-%20%5Cpartial_z%20u)%5E2%20%2B%20%5Cfrac%7B1%7D%7B2%7D(%5Cpartial_y%20w%20-%20%5Cpartial_z%20v)%5E2">.

