### PR TITLE
Fix Ct table linear interpolation

### DIFF
--- a/amr-wind/utilities/linear_interpolation.H
+++ b/amr-wind/utilities/linear_interpolation.H
@@ -25,7 +25,7 @@ check_bounds(const It begin, const It end, const T& x)
     const int sz = static_cast<int>(end - begin);
 
     if (sz < 2) {
-        return Index{0, Limits::VALID};
+        return Index{0, Limits::LOWLIM};
     } else if (x < *begin) {
         return Index{0, Limits::LOWLIM};
     } else if (x > *(begin + (sz - 1))) {

--- a/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
@@ -141,7 +141,7 @@ struct ComputeForceOp<UniformCt, ActSrcDisk>
             (ddata.reference_velocity * ddata.reference_velocity) & normal;
 
         ddata.current_ct = ::amr_wind::interp::linear(
-            ddata.thrust_coeff, ddata.table_velocity,
+            ddata.table_velocity, ddata.thrust_coeff, 
             std::sqrt(std::abs(uInfSqr)));
 
         const int npts = ddata.num_force_pts;

--- a/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
@@ -141,7 +141,7 @@ struct ComputeForceOp<UniformCt, ActSrcDisk>
             (ddata.reference_velocity * ddata.reference_velocity) & normal;
 
         ddata.current_ct = ::amr_wind::interp::linear(
-            ddata.table_velocity, ddata.thrust_coeff, 
+            ddata.table_velocity, ddata.thrust_coeff,
             std::sqrt(std::abs(uInfSqr)));
 
         const int npts = ddata.num_force_pts;


### PR DESCRIPTION
I was getting some strange thrust coefficient values when testing out the Ct vs wind speed table lookup for the `uniformCtDisk` model.  I think the arguments to `interp::linear` need to be swapped:
```c++
        ddata.current_ct = ::amr_wind::interp::linear(
            ddata.thrust_coeff, ddata.table_velocity,
            std::sqrt(std::abs(uInfSqr)));
```
My understanding is that the arguments should be `::amr_wind::interp::linear(xdata, ydata, xpoint)`, so `ddata.table_velocity` should be first.

Also, when testing out the Ct table behavior when only 1 value is provided, I got some Ct's that were very slightly off.  Should `check_bounds()` return either `Limits::LOWLIM` or `Limits::UPLIM` when only 1 value is provided?  Otherwise, if it returns `Limits::VALID`, it will try to proceed with the linear interpolation and some undefined behavior could happen.

Lawrence

