### PR TITLE
Changed KE and enstrophy sampling formatting

### DIFF
--- a/amr-wind/utilities/sampling/Enstrophy.H
+++ b/amr-wind/utilities/sampling/Enstrophy.H
@@ -69,7 +69,7 @@ private:
     int m_out_freq{10};
 
     //! width in ASCII output
-    int m_width{18};
+    int m_width{22};
 
     //! precision in ASCII output
     int m_precision{12};

--- a/amr-wind/utilities/sampling/Enstrophy.cpp
+++ b/amr-wind/utilities/sampling/Enstrophy.cpp
@@ -125,7 +125,7 @@ void Enstrophy::write_ascii()
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream f(m_out_fname.c_str(), std::ios_base::app);
-        f << m_sim.time().time_index() << std::fixed
+        f << m_sim.time().time_index() << std::scientific
           << std::setprecision(m_precision) << std::setw(m_width)
           << m_sim.time().new_time();
         f << std::setw(m_width) << m_total_enstrophy;

--- a/amr-wind/utilities/sampling/KineticEnergy.H
+++ b/amr-wind/utilities/sampling/KineticEnergy.H
@@ -69,7 +69,7 @@ private:
     int m_out_freq{10};
 
     //! width in ASCII output
-    int m_width{18};
+    int m_width{22};
 
     //! precision in ASCII output
     int m_precision{12};

--- a/amr-wind/utilities/sampling/KineticEnergy.cpp
+++ b/amr-wind/utilities/sampling/KineticEnergy.cpp
@@ -124,7 +124,7 @@ void KineticEnergy::write_ascii()
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream f(m_out_fname.c_str(), std::ios_base::app);
-        f << m_sim.time().time_index() << std::fixed
+        f << m_sim.time().time_index() << std::scientific
           << std::setprecision(m_precision) << std::setw(m_width)
           << m_sim.time().new_time();
         f << std::setw(m_width) << m_total_kinetic_energy;


### PR DESCRIPTION
Changed formatting from std::fixed to std::scientific and increased printed column widths by four characters to accommodate for 'e+xx' part.