### PR TITLE
Fix install errors with ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(AMR_WIND_ENABLE_CUDA)
   enable_language(CUDA)
   # Fix issues with GPU builds
-  enable_language(Fortran)
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "10.0")
     message(FATAL_ERROR "Your nvcc version is ${CMAKE_CUDA_COMPILER_VERSION} which is unsupported."
       "Please use CUDA toolkit version 10.0 or newer.")
@@ -66,9 +65,6 @@ if(AMR_WIND_TEST_WITH_FCOMPARE)
   set(AMR_WIND_ENABLE_FCOMPARE ON)
 endif()
 
-if (AMR_WIND_ENABLE_OPENFAST)
-  enable_language(Fortran)
-endif()
 
 ########################### AMReX #####################################
 init_amrex()


### PR DESCRIPTION
amr-wind fails to install correctly when using `ninja` as the build generator.  This is because `ninja` is looking for fortran files to install. Since we don't actually build with fortran we should not enable it as a compiler language.