### PR TITLE
replicate feature

### DIFF
--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -51,7 +51,8 @@ public:
     void read_checkpoint_fields(
         const std::string& restart_file,
         const amrex::Vector<amrex::BoxArray>& ba_chk,
-        const amrex::Vector<amrex::DistributionMapping>& dm_chk);
+        const amrex::Vector<amrex::DistributionMapping>& dm_chk,
+        const amrex::IntVect& rep);
 
     //! Register a variable for output
     void register_output_var(const std::string& fname)

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -182,6 +182,10 @@ void IOManager::read_checkpoint_fields(
     std::set<std::string> missing;
     const std::string level_prefix = "Level_";
     const int nlevels = m_sim.mesh().finestLevel() + 1;
+
+    // always use the level 0 domain
+    amrex::Box orig_domain(ba_chk[0].minimalBox());
+
     for (int lev = 0; lev < nlevels; ++lev) {
         for (auto* fld : m_chk_fields) {
             auto& field = *fld;
@@ -210,9 +214,6 @@ void IOManager::read_checkpoint_fields(
                 amrex::VisMF::Read(
                     tmp, amrex::MultiFabFileFullPrefix(
                              lev, restart_file, level_prefix, field.name()));
-
-                // always use the level 0 domain
-                amrex::Box orig_domain(ba_chk[0].minimalBox());
 
                 for (int k = 0; k < rep[2]; k++) {
                     for (int j = 0; j < rep[1]; j++) {

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -217,17 +217,18 @@ void IOManager::read_checkpoint_fields(
                 for (int k = 0; k < rep[2]; k++) {
                     for (int j = 0; j < rep[1]; j++) {
                         for (int i = 0; i < rep[0]; i++) {
+
                             amrex::IntVect shift_vec(
                                 i * orig_domain.length(0),
                                 j * orig_domain.length(1),
                                 k * orig_domain.length(2));
 
-                            tmp.shift(shift_vec * (1 << lev));
+                            // equivalent to 2^lev
+                            shift_vec *= (1 << lev);
 
-                            mfab.ParallelCopy(tmp);
-
-                            shift_vec *= -1;
                             tmp.shift(shift_vec);
+                            mfab.ParallelCopy(tmp);
+                            tmp.shift(-shift_vec);
                         }
                     }
                 }

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -211,7 +211,8 @@ void IOManager::read_checkpoint_fields(
                     tmp, amrex::MultiFabFileFullPrefix(
                              lev, restart_file, level_prefix, field.name()));
 
-                amrex::Box orig_domain(ba_chk[lev].minimalBox());
+                // always use the level 0 domain
+                amrex::Box orig_domain(ba_chk[0].minimalBox());
 
                 for (int k = 0; k < rep[2]; k++) {
                     for (int j = 0; j < rep[1]; j++) {
@@ -221,7 +222,7 @@ void IOManager::read_checkpoint_fields(
                                 j * orig_domain.length(1),
                                 k * orig_domain.length(2));
 
-                            tmp.shift(shift_vec);
+                            tmp.shift(shift_vec * (1 << lev));
 
                             mfab.ParallelCopy(tmp);
 

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -21,13 +21,6 @@ void incflo::ReadCheckpointFile()
 {
     BL_PROFILE("amr-wind::incflo::ReadCheckpointFile()");
 
-    //    amrex::ParmParse pp("io");
-    //    amrex::Vector<int> repvec{{1, 1, 1}};
-    //    pp.queryarr("replicate", repvec);
-    //    IntVect rep(repvec[0], repvec[1], repvec[2]);
-    //    IntVect rep(1,1,1);
-    //    bool replicate = (rep == IntVect::TheUnitVector()) ? false : true;
-
     const std::string& restart_file = m_sim.io_manager().restart_file();
     amrex::Print() << "Restarting from checkpoint " << restart_file
                    << std::endl;

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -115,8 +115,20 @@ void incflo::ReadCheckpointFile()
     IntVect rep(1, 1, 1);
     for (int d = 0; d < AMREX_SPACEDIM; d++) {
         AMREX_ALWAYS_ASSERT(prob_hi[d] - prob_lo[d] > 0.0);
-        rep[d] = static_cast<int>(
-            (prob_hi_input[d] - prob_lo_input[d]) / (prob_hi[d] - prob_lo[d]));
+
+        const amrex::Real domain_ratio =
+            (prob_hi_input[d] - prob_lo_input[d]) / (prob_hi[d] - prob_lo[d]);
+
+        rep[d] = static_cast<int>(domain_ratio);
+
+        constexpr amrex::Real domain_eps = 1.0e-6;
+        if (amrex::Math::abs(static_cast<amrex::Real>(rep[d]) - domain_ratio) >
+            domain_eps) {
+            amrex::Abort(
+                "Domain size changed which indicates replication but there is "
+                "either some precision issues or a non integer domain size "
+                "change was input");
+        }
     }
 
     bool replicate = (rep == IntVect::TheUnitVector()) ? false : true;

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -154,16 +154,19 @@ void incflo::ReadCheckpointFile()
         // read in level 'lev' BoxArray from Header
         ba_inp[lev].readFrom(is);
         GotoNextLine(is);
+    }
 
-        // always use level 0 to check domain size
-        Box orig_domain(ba_inp[0].minimalBox());
+    // always use level 0 to check domain size
+    constexpr int lev0{0};
+    Box orig_domain(ba_inp[lev0].minimalBox());
 
-        if (replicate && lev == 0) {
-            amrex::Print() << " OLD BA had " << ba_inp[lev].size() << " GRIDS "
-                           << std::endl;
-            amrex::Print() << " OLD Domain" << orig_domain << std::endl;
-        }
+    if (replicate) {
+        amrex::Print() << " OLD BA had " << ba_inp[lev0].size() << " GRIDS "
+                       << std::endl;
+        amrex::Print() << " OLD Domain" << orig_domain << std::endl;
+    }
 
+    for (int lev = 0; lev <= finest_level; ++lev) {
         BoxList bl;
         for (int nb = 0; nb < ba_inp[lev].size(); nb++) {
             for (int k = 0; k < rep[2]; k++) {

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -21,8 +21,10 @@ void incflo::ReadCheckpointFile()
 {
     BL_PROFILE("amr-wind::incflo::ReadCheckpointFile()");
 
-    // make me an input
-    IntVect Nrep(2, 3, 1);
+    amrex::ParmParse pp("amr");
+    amrex::Vector<int> rep{{1, 1, 1}};
+    pp.queryarr("replicate", rep);
+    IntVect Nrep(rep[0], rep[1], rep[2]);
 
     bool replicate = (Nrep == IntVect::TheUnitVector()) ? false : true;
 

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -174,7 +174,11 @@ void incflo::ReadCheckpointFile()
                             i * orig_domain.length(0),
                             j * orig_domain.length(1),
                             k * orig_domain.length(2));
-                        b.shift(shift_vec * (1 << lev));
+
+                        // equivalent to 2^lev
+                        shift_vec *= (1 << lev);
+
+                        b.shift(shift_vec);
                         bl.push_back(b);
                     }
                 }


### PR DESCRIPTION
- useful for weak scaling studies
- can be used to initialize a larger ABL run from a smaller restart file

if `amr.n_cell = 48 48 48` and `geometry.prob_hi=1000 1000 1000` to replicate in the x direction use a restart file and set
`amr.n_cell = 96 48 48` and `geometry.prob_hi=2000 1000 1000`


can also shift the domain at the same time:

original inputs:
`amr.n_cell = 48 48 48
geometry.prob_lo = 0 0 0
geometry.prob_hi = 1000 1000 1000`

new inputs:
`amr.n_cell = 96 144 48
geometry.prob_lo = -1000 0 0
geometry.prob_hi = 1000 3000 1000`

This replicated twice in x-dir and three times in y-dir, also translated domain in x by -1000.0