### PR TITLE
Avoid explicitly defining libraries to be shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ set(aw_api_lib "amrwind_api")
 
 #Create main target executable
 add_library(${amr_wind_lib_name} OBJECT)
-add_library(${aw_api_lib} SHARED)
+add_library(${aw_api_lib})
 add_executable(${amr_wind_exe_name})
 
 init_code_checks()

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -22,6 +22,7 @@ function(set_cuda_build_properties target)
     list(FILTER _tgt_src INCLUDE REGEX "\\.cpp")
     set_source_files_properties(${_tgt_src} PROPERTIES LANGUAGE CUDA)
     set_target_properties(${target} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+    set_target_properties(${target} PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   endif()
 endfunction(set_cuda_build_properties)
 


### PR DESCRIPTION
This allows us to use `BUILD_SHARED_LIBS` CMake option to either build all libraries as static or shared from the command line. Static AMR-Wind libraries with CUDA enabled have allowed me to succeed in building the exawind driver.