### PR TITLE
Enable OpenFAST restart from checkpoint files

### DIFF
--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -121,6 +121,9 @@ public:
     AMREX_FORCE_INLINE
     int stop_time_index() const { return m_stop_time_index; }
 
+    AMREX_FORCE_INLINE
+    int chkpt_interval() const { return m_chkpt_interval; }
+
     //! Read user defined options from input file
     void parse_parameters();
 

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -159,6 +159,12 @@ void FastIface::advance_turbine(const int local_id)
     for (int i = 0; i < fi.num_substeps; ++i, ++fi.time_index) {
         fast_func(FAST_OpFM_Step, &fi.tid_local);
     }
+
+    if ( ( fi.time_index / fi.num_substeps) % fi.chkpt_interval == 0) {
+        char rst_file[fast_strlen()];
+        copy_filename(" ", rst_file);
+        fast_func(FAST_CreateCheckpoint, &fi.tid_local, rst_file);
+    }
 }
 
 void FastIface::init_turbine(const int local_id)
@@ -282,9 +288,54 @@ void FastIface::fast_replay_turbine(FastTurbine& fi)
 #endif
 }
 
-void FastIface::fast_restart_turbine(FastTurbine&)
+void FastIface::fast_restart_turbine(FastTurbine& fi)
 {
     BL_PROFILE("amr-wind::FastIface::restart_turbine");
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        amrex::FileSystem::Exists(fi.checkpoint_file + ".chkp"),
+        "FastIface: Cannot find OpenFAST checkpoint file: "
+        + fi.checkpoint_file);
+
+    int abort_lev;
+    char chkpt_file[fast_strlen()];
+    copy_filename(fi.checkpoint_file, chkpt_file);
+
+    fast_func(
+        FAST_OpFM_Restart, &fi.tid_local, chkpt_file, &abort_lev,
+        &fi.dt_fast, &fi.num_blades, &fi.num_blade_elem, &fi.time_index,
+        &fi.to_cfd, &fi.from_cfd, &fi.to_sc, &fi.from_sc);
+
+    {
+#ifdef AMR_WIND_USE_OPENFAST
+        // Check if OpenFAST has tower and reset tower nodes appropriately
+        const int npts = fi.to_cfd.fx_Len;
+        const int nrotor_pts = fi.num_blades * fi.num_pts_blade + 1;
+        if (nrotor_pts == npts) {
+            amrex::OutStream()
+                << "OpenFAST model does not include tower for turbine: "
+                << fi.tlabel << " Turning off tower actuator points"
+                << std::endl;
+            fi.num_pts_tower = 0;
+        }
+        AMREX_ALWAYS_ASSERT(npts == (nrotor_pts + fi.num_pts_tower));
+#endif
+    }
+
+    // Determine the number of substeps for FAST per CFD timestep
+    fi.num_substeps = static_cast<int>(std::floor(fi.dt_cfd / fi.dt_fast));
+
+    AMREX_ALWAYS_ASSERT(fi.num_substeps > 0);
+    // Check that the time step sizes are consistent and FAST advances at an
+    // integral multiple of CFD timestep
+    double dt_err =
+        fi.dt_cfd / (static_cast<double>(fi.num_substeps) * fi.dt_fast) - 1.0;
+    if (dt_err > 1.0e-4) {
+        amrex::Abort(
+            "FastIFace: OpenFAST timestep is not an integral "
+            "multiple of CFD timestep");
+    }
+    
 }
 
 #ifdef AMR_WIND_USE_OPENFAST

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
@@ -72,6 +72,9 @@ struct FastTurbine
     //! Does FAST need solution0
     bool is_solution0{true};
 
+    //! Checkpoint interval for FAST
+    int chkpt_interval;
+
     // Data structures that are used to exchange between fast/cfd
 
     exw_fast::OpFM_InputType to_cfd;

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
@@ -36,6 +36,7 @@ inline void FAST_AllocateTurbines(int*, int*, char*) {}
 inline void FAST_DeallocateTurbines(int*, char*) {}
 inline void FAST_OpFM_Solution0(int*, int*, char*) {}
 inline void FAST_OpFM_Step(int*, int*, char*) {}
+inline void FAST_CreateCheckpoint(int *, char, int *, char *) {}
 
 // clang-format off
 inline void FAST_OpFM_Init(

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -36,7 +36,6 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         tf.num_pts_tower = tdata.num_pts_tower;
         tf.dt_cfd = data.sim().time().deltaT();
 
-        pp.get("openfast_input_file", tf.input_file);
         pp.get("openfast_start_time", tf.start_time);
         pp.get("openfast_stop_time", tf.stop_time);
 
@@ -57,7 +56,12 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         // the path to the checkpoint file.
         if (tf.sim_mode == ::exw_fast::SimMode::restart) {
             pp.get("openfast_restart_file", tf.checkpoint_file);
+        } else {
+            pp.get("openfast_input_file", tf.input_file);
         }
+
+        const auto& time = data.sim().time();
+        tf.chkpt_interval = time.chkpt_interval();
 
         perform_checks(data);
     }


### PR DESCRIPTION
Not sure if this pull request is ready to merge. But this enables both writing of OpenFAST checkpoint files consistent with amr-wind's checkpoint files, as well as the ability to read OpenFAST checkpoint files without the need for replay capability.