### PR TITLE
fix time indices for output and checkpoint file 

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -169,12 +169,14 @@ bool SimTime::do_regrid()
 
 bool SimTime::write_plot_file()
 {
-    return ((m_plt_interval > 0) && (m_time_index % m_plt_interval == 0));
+    return ((m_plt_interval > 0) &&
+            ((m_time_index - m_start_time_index) % m_plt_interval == 0));
 }
 
 bool SimTime::write_checkpoint()
 {
-    return ((m_chkpt_interval > 0) && (m_time_index % m_chkpt_interval == 0));
+    return ((m_chkpt_interval > 0) &&
+            ((m_time_index - m_start_time_index) % m_chkpt_interval == 0));
 }
 
 bool SimTime::write_last_plot_file()


### PR DESCRIPTION
When restarting, currently the time step indices do not take into account the time index of the restart file. As a result the checkpoint and output files are plotted at intervals inconsistent with the requested interval.