### PR TITLE
fixing memory leak in ascent intergration

### DIFF
--- a/amr-wind/utilities/ascent/ascent.cpp
+++ b/amr-wind/utilities/ascent/ascent.cpp
@@ -106,6 +106,8 @@ void AscentPostProcess::post_advance_work()
     ascent.publish(bp_mesh);
 
     ascent.execute(actions);
+
+    ascent.close();
 }
 
 void AscentPostProcess::post_regrid_actions()


### PR DESCRIPTION
`ascent.close()` cleans up memory within ascent - adding this line