### PR TITLE
Add `beta_h` ABL MO param

### DIFF
--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -22,6 +22,7 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
     pp.query("mo_gamma_m", m_mo.gamma_m);
     pp.query("mo_gamma_h", m_mo.gamma_h);
     pp.query("mo_beta_m", m_mo.beta_m);
+    pp.query("mo_beta_h", m_mo.beta_h);
     pp.query("surface_roughness_z0", m_mo.z0);
     pp.query("normal_direction", m_direction);
     pp.queryarr("gravity", m_gravity);

--- a/amr-wind/wind_energy/MOData.H
+++ b/amr-wind/wind_energy/MOData.H
@@ -42,6 +42,7 @@ struct MOData
     amrex::Real gamma_m{5.0};
     amrex::Real gamma_h{5.0};
     amrex::Real beta_m{16.0};
+    amrex::Real beta_h{16.0};
 
     ThetaCalcType alg_type{HEAT_FLUX};
 

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -30,7 +30,7 @@ amrex::Real MOData::calc_psi_h(amrex::Real zeta) const
     if (zeta > 0) {
         return -gamma_h * zeta;
     } else {
-        amrex::Real x = std::sqrt(1 - beta_m * zeta);
+        amrex::Real x = std::sqrt(1 - beta_h * zeta);
         return 2.0 * std::log(0.5 * (1 + x));
     }
 }


### PR DESCRIPTION
`MOData::calc_psi_h()` currently assumes that the empirical constant `beta_h`==`beta_m` (e.g., gamma_1==gamma_2 https://atmos.washington.edu/~breth/classes/AS547/lect/lect6.pdf). 

https://github.com/Exawind/amr-wind/blob/512d60f2efcace44fef198d091ca2300341d3a13/amr-wind/wind_energy/MOData.cpp#L28-L36

For generality, I've added `beta_h` as an additional (optional) input.