### PR TITLE
uniform disk reg test

### DIFF
--- a/test/test_files/uniform_ct_disk/uniform_ct_disk.i
+++ b/test/test_files/uniform_ct_disk/uniform_ct_disk.i
@@ -77,9 +77,3 @@ zlo.type =   "slip_wall"
 zhi.type =   "slip_wall"
 
 incflo.verbose          =   0          # incflo_level
-nodal_proj.verbose = 0
-
-nodal_proj.mg_rtol = 1.0e-6
-nodal_proj.mg_atol = 1.0e-12
-mac_proj.mg_rtol = 1.0e-6
-mac_proj.mg_atol = 1.0e-12


### PR DESCRIPTION
switched to default linear tolerances for uniform disk so we can pass GPU reg tests