### PR TITLE
fixing favre_filtering

### DIFF
--- a/amr-wind/core/Physics.H
+++ b/amr-wind/core/Physics.H
@@ -82,9 +82,6 @@ public:
     //! Perform tasks necessary after advancing timestep
     virtual void post_advance_work() = 0;
 
-    //! Perform tasks necessary before mac projection
-    virtual void pre_mac_projection_work() {}
-
     //! Perform tasks necessary before applying the pressure correction
     virtual void pre_pressure_correction_work() {}
 

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -255,8 +255,6 @@ void incflo::ApplyPredictor(bool incremental_projection)
     // if (!m_use_godunov) Compute the explicit advective terms
     //                     R_u^n      , R_s^n       and R_t^n
     // *************************************************************************************
-    for (auto& pp : m_sim.physics()) pp->pre_mac_projection_work();
-
     icns().compute_advection_term(amr_wind::FieldState::Old);
     for (auto& seqn : scalar_eqns()) {
         seqn->compute_advection_term(amr_wind::FieldState::Old);

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -36,8 +36,6 @@ public:
 
     void pre_advance_work() override {}
 
-    void pre_mac_projection_work() override;
-
     void post_advance_work() override;
 
     void set_density_via_levelset();

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -76,6 +76,7 @@ void MultiPhase::post_advance_work()
     switch (m_interface_capturing_method) {
     case InterfaceCapturingMethod::VOF:
         set_density_via_vof();
+        if (m_interface_smoothing) favre_filtering();
         // Compute the print the total volume fraction
         if (m_verbose > 0) {
             m_total_volfrac = volume_fraction_sum();
@@ -93,11 +94,6 @@ void MultiPhase::post_advance_work()
         set_density_via_levelset();
         break;
     };
-}
-
-void MultiPhase::pre_mac_projection_work()
-{
-    if (m_interface_smoothing) favre_filtering();
 }
 
 amrex::Real MultiPhase::volume_fraction_sum()
@@ -228,7 +224,7 @@ void MultiPhase::favre_filtering()
         auto& density = m_density(lev);
 
         for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {
-            const auto& bx = mfi.validbox();
+            const auto& bx = mfi.growntilebox(1);
             const amrex::Array4<amrex::Real>& vel = velocity.array(mfi);
             const amrex::Array4<amrex::Real>& rho = density.array(mfi);
             const amrex::Array4<amrex::Real>& rhou = mom.array(mfi);


### PR DESCRIPTION
- Small fix for favre_filter. Using a growntilebox to compute momentum before applying the filtering operator.
- Also removing pre_mac_projection from the physics class (not needed anymore)