### PR TITLE
Fix FPE when CFLs are zero

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -95,7 +95,9 @@ void SimTime::set_current_cfl(
     const amrex::Real cd_cfl = conv_cfl + diff_cfl;
     const amrex::Real cfl_unit_time =
         cd_cfl + std::sqrt(cd_cfl * cd_cfl + 4.0 * src_cfl);
-    amrex::Real dt_new = 2.0 * m_max_cfl / cfl_unit_time;
+    amrex::Real dt_new =
+        2.0 * m_max_cfl /
+        amrex::max(cfl_unit_time, std::numeric_limits<amrex::Real>::epsilon());
 
     // Restrict timestep during initialization phase
     if (m_is_init) {

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -95,6 +95,12 @@ void SimTime::set_current_cfl(
     const amrex::Real cd_cfl = conv_cfl + diff_cfl;
     const amrex::Real cfl_unit_time =
         cd_cfl + std::sqrt(cd_cfl * cd_cfl + 4.0 * src_cfl);
+    if ((m_adaptive) &&
+        (cfl_unit_time < std::numeric_limits<amrex::Real>::epsilon())) {
+        amrex::Abort(
+            "CFL is below machine epsilon and the time step is adaptive. "
+            "Please use a fixed time step or fix the case setup");
+    }
     amrex::Real dt_new =
         2.0 * m_max_cfl /
         amrex::max(cfl_unit_time, std::numeric_limits<amrex::Real>::epsilon());


### PR DESCRIPTION
It is possible to have CFLs computed to be zero, which leads to an FPE when computing `dt_new`. This fixes that potential FPE.

This FPE arose in several test cases, including BoussinesqBubble. The flow is initialized to zero and all CFLs are computed to be zero. This throws an FPE. 

Tests that throw an FPE and are resolved with this PR:
```
	  4 - boussinesq_bubble_godunov (Failed)
	 24 - boussinesq_bubble_mol (Failed)
	 30 - rayleigh_taylor_godunov (Failed)
	 31 - rayleigh_taylor_mol (Failed)
	 36 - dam_break_godunov (Failed)
```