### PR TITLE
Fix FPE arising from ssq == Rsq

### DIFF
--- a/amr-wind/physics/VortexRing.cpp
+++ b/amr-wind/physics/VortexRing.cpp
@@ -235,7 +235,9 @@ void VortexRing::initialize_velocity(const VortexRingType& vorticity_theta)
     const amrex::Real rel_tol = 1.0e-13;
     const amrex::Real abs_tol = 1.0e-13;
 
-    (*vectorpotential)(0).setVal(0.0, 0, AMREX_SPACEDIM, 1);
+    for (int level = 0; level <= m_repo.mesh().finestLevel(); ++level) {
+        (*vectorpotential)(level).setVal(0.0, 0, AMREX_SPACEDIM, 1);
+    }
 
     // might be able to skip z-dir since vorticity is 0.0
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {

--- a/amr-wind/physics/VortexRing.cpp
+++ b/amr-wind/physics/VortexRing.cpp
@@ -25,7 +25,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real FatCore::operator()(
 {
     amrex::Real Rsq = std::pow(R, 2);
     const amrex::Real ssq = std::pow(z, 2) + std::pow(r - R, 2);
-    if (ssq <= Rsq) {
+    if (ssq < Rsq) {
         return 0.54857674 * Gamma / Rsq * std::exp(-4 * ssq / (Rsq - ssq));
     }
     return 0.0;


### PR DESCRIPTION
`fat_cored_vortex_ring` currently fails with an FPE.

The first reason for this: when `ssq == Rsq` then the denominator of the `exp` is non-determinate. The first commit of this PR fixes that.

However, this isn't the end of the story. After fixing this, I am hitting another FPE in the MLMG solve:
```
(lldb) bt
* thread #1, name = 'amr_wind', stop reason = signal SIGFPE: invalid floating point operation
  * frame #0: 0x000000000138cf34 amr_wind`amrex::MLNodeLaplacian::Fapply(int, int, amrex::MultiFab&, amrex::MultiFab const&) const::$_1::operator()(int, int, int) const at AMReX_MLNodeLap_3D_K.H:924:31
    frame #1: 0x000000000138caa1 amr_wind`amrex::MLNodeLaplacian::Fapply(this=0x00007fffffff31a8, i=17, j=17, k=17) const::$_1::operator()(int, int, int) const at AMReX_MLNodeLaplacian_misc.cpp:284
    frame #2: 0x0000000001351972 amr_wind`void amrex::LoopConcurrentOnCpu<amrex::MLNodeLaplacian::Fapply(int, int, amrex::MultiFab&, amrex::MultiFab const&) const::$_1>(bx=0x00007fffffff3318, f=0x00007fffffff31a8) const::$_1&&) at AMReX_Loop.H:196:9
    frame #3: 0x0000000001350ae4 amr_wind`amrex::MLNodeLaplacian::Fapply(this=0x00007fffffff4dd0, amrlev=1, mglev=0, out=0x0000000002dffcd0, in=0x0000000002e184c0) const at AMReX_MLNodeLaplacian_misc.cpp:282:17
    frame #4: 0x000000000110b1a6 amr_wind`amrex::MLNodeLinOp::apply(this=0x00007fffffff4dd0, amrlev=1, mglev=0, out=0x0000000002dffcd0, in=0x0000000002e184c0, bc_mode=Inhomogeneous, s_mode=Solution, (null)=0x0000000000000000) const at AMReX_MLNodeLinOp.cpp:139:5
    frame #5: 0x000000000110a56a amr_wind`amrex::MLNodeLinOp::solutionResidual(this=0x00007fffffff4dd0, amrlev=1, resid=0x0000000002dffcd0, x=0x0000000002e184c0, b=0x0000000002e18d30, (null)=0x0000000002e18350) at AMReX_MLNodeLinOp.cpp:102:5
    frame #6: 0x000000000108c73e amr_wind`amrex::MLMG::computeMLResidual(this=0x00007fffffff4b58, amrlevmax=1) at AMReX_MLMG.cpp:305:15
    frame #7: 0x00000000010886c6 amr_wind`amrex::MLMG::solve(this=0x00007fffffff4b58, a_sol=0x00007fffffff4ad8, a_rhs=0x00007fffffff4ac0, a_tol_rel=1.0E-13, a_tol_abs=1.0E-13, checkpoint_file=0x0000000000000000) at AMReX_MLMG.cpp:85:5
    frame #8: 0x0000000000c2ba8a amr_wind`void amr_wind::VortexRing::initialize_velocity<amr_wind::FatCore>(this=0x000000000176b6e0, vorticity_theta=0x00007fffffff5708) at VortexRing.cpp:244:14
    frame #9: 0x0000000000c2ae87 amr_wind`amr_wind::VortexRing::post_init_actions(this=0x000000000176b6e0) at VortexRing.cpp:116:9
    frame #10: 0x0000000000416646 amr_wind`incflo::init_amr_wind_modules(this=0x00007fffffff5c60) at incflo.cpp:102:13
    frame #11: 0x0000000000416885 amr_wind`incflo::InitData(this=0x00007fffffff5c60) at incflo.cpp:158:5
    frame #12: 0x000000000040e05d amr_wind`main(argc=6, argv=0x00007fffffff62a8) at main.cpp:69:19
    frame #13: 0x00007ffff72f9555 libc.so.6`__libc_start_main + 245
    frame #14: 0x000000000040dbb4 amr_wind`_start + 41
```

Investigation ongoing... 