### PR TITLE
Move virtual function call outside of constructor

### DIFF
--- a/amr-wind/CFDSim.cpp
+++ b/amr-wind/CFDSim.cpp
@@ -35,6 +35,7 @@ void CFDSim::create_turbulence_model()
 
     const std::string identifier = turbulence_model + "-" + transport_model;
     m_turbulence = turbulence::TurbulenceModel::create(identifier, *this);
+    m_turbulence->parse_model_coeffs();
 }
 
 void CFDSim::init_physics()

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -68,6 +68,9 @@ public:
     virtual void
     update_scalar_diff(Field& deff, const std::string& name) override;
 
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() override;
+
     //! Return turbulence model coefficients
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 
@@ -116,6 +119,9 @@ public:
     //! Update the effective scalar diffusivity field
     virtual void
     update_scalar_diff(Field& deff, const std::string& name) override;
+
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() override;
 
     //! Return turbulence model coefficients
     TurbulenceModel::CoeffsDictType model_coeffs() const override;

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -41,13 +41,6 @@ OneEqKsgsM84<Transport>::OneEqKsgsM84(CFDSim& sim)
     }
 
     {
-        const std::string coeffs_dict = this->model_name() + "_coeffs";
-        amrex::ParmParse pp(coeffs_dict);
-        pp.query("Ceps", this->m_Ceps);
-        pp.query("Ce", this->m_Ce);
-    }
-
-    {
         amrex::ParmParse pp("ABL");
         pp.get("reference_temperature", m_ref_theta);
         pp.query("enable_hybrid_rl_mode", m_hybrid_rl);
@@ -72,6 +65,15 @@ OneEqKsgsM84<Transport>::OneEqKsgsM84(CFDSim& sim)
 
 template <typename Transport>
 OneEqKsgsM84<Transport>::~OneEqKsgsM84() = default;
+
+template <typename Transport>
+void OneEqKsgsM84<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("Ceps", this->m_Ceps);
+    pp.query("Ce", this->m_Ce);
+}
 
 template <typename Transport>
 TurbulenceModel::CoeffsDictType OneEqKsgsM84<Transport>::model_coeffs() const
@@ -261,10 +263,6 @@ void OneEqKsgsM84<Transport>::post_advance_work()
 template <typename Transport>
 OneEqKsgsS94<Transport>::OneEqKsgsS94(CFDSim& sim) : OneEqKsgs<Transport>(sim)
 {
-    const std::string coeffs_dict = this->model_name() + "_coeffs";
-    amrex::ParmParse pp(coeffs_dict);
-    pp.query("Ceps", this->m_Ceps);
-
     // TKE source term to be added to PDE
     turb_utils::inject_turbulence_src_terms(
         pde::TKE::pde_name(), {"KsgsS94Src"});
@@ -272,6 +270,14 @@ OneEqKsgsS94<Transport>::OneEqKsgsS94(CFDSim& sim) : OneEqKsgs<Transport>(sim)
 
 template <typename Transport>
 OneEqKsgsS94<Transport>::~OneEqKsgsS94() = default;
+
+template <typename Transport>
+void OneEqKsgsS94<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("Ceps", this->m_Ceps);
+}
 
 template <typename Transport>
 TurbulenceModel::CoeffsDictType OneEqKsgsS94<Transport>::model_coeffs() const

--- a/amr-wind/turbulence/LES/Smagorinsky.H
+++ b/amr-wind/turbulence/LES/Smagorinsky.H
@@ -31,6 +31,9 @@ public:
     //! No post advance work for this model
     virtual void post_advance_work() override {}
 
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() override;
+
     //! Return model coefficients dictionary
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 

--- a/amr-wind/turbulence/LES/Smagorinsky.cpp
+++ b/amr-wind/turbulence/LES/Smagorinsky.cpp
@@ -16,11 +16,7 @@ Smagorinsky<Transport>::Smagorinsky(CFDSim& sim)
     : TurbModelBase<Transport>(sim)
     , m_vel(sim.repo().get_field("velocity"))
     , m_rho(sim.repo().get_field("density"))
-{
-    const std::string coeffs_dict = this->model_name() + "_coeffs";
-    amrex::ParmParse pp(coeffs_dict);
-    pp.query("Cs", m_Cs);
-}
+{}
 
 template <typename Transport>
 void Smagorinsky<Transport>::update_turbulent_viscosity(const FieldState fstate)
@@ -64,6 +60,14 @@ void Smagorinsky<Transport>::update_turbulent_viscosity(const FieldState fstate)
     }
 
     mu_turb.fillpatch(this->m_sim.time().current_time());
+}
+
+template <typename Transport>
+void Smagorinsky<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("Cs", this->m_Cs);
 }
 
 template <typename Transport>

--- a/amr-wind/turbulence/LaminarModel.H
+++ b/amr-wind/turbulence/LaminarModel.H
@@ -33,6 +33,9 @@ public:
     //! No post advance work for this model
     virtual void post_advance_work() override {}
 
+    //! No model specific coefficient for this model
+    virtual void parse_model_coeffs() override {}
+
     //! Return the turbulent viscosity field (just the same as the effective
     //! field)
     virtual Field& mu_turb() override { return this->mueff(); }

--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -55,6 +55,9 @@ public:
     virtual void
     update_scalar_diff(Field& deff, const std::string& name) override;
 
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() override;
+
     //! Return turbulence model coefficients
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 

--- a/amr-wind/turbulence/RANS/KOmegaSST.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSST.cpp
@@ -14,6 +14,22 @@ namespace amr_wind {
 namespace turbulence {
 
 template <typename Transport>
+void KOmegaSST<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("beta_star", this->m_beta_star);
+    pp.query("alpha1", this->m_alpha1);
+    pp.query("alpha2", this->m_alpha2);
+    pp.query("beta1", this->m_beta1);
+    pp.query("beta2", this->m_beta2);
+    pp.query("sigma_k1", this->m_sigma_k1);
+    pp.query("sigma_k2", this->m_sigma_k2);
+    pp.query("sigma_omega1", this->m_sigma_omega1);
+    pp.query("sigma_omega2", this->m_sigma_omega2);
+}
+
+template <typename Transport>
 TurbulenceModel::CoeffsDictType KOmegaSST<Transport>::model_coeffs() const
 {
     return TurbulenceModel::CoeffsDictType{

--- a/amr-wind/turbulence/RANS/KOmegaSSTI.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTI.H
@@ -1,3 +1,6 @@
+#ifndef KOMEGASSTI_H
+#define KOMEGASSTI_H
+
 #include "amr-wind/turbulence/RANS/KOmegaSST.H"
 #include "amr-wind/equation_systems/PDEBase.H"
 #include "amr-wind/turbulence/TurbModelDefs.H"
@@ -40,21 +43,7 @@ KOmegaSST<Transport>::KOmegaSST(CFDSim& sim)
 template <typename Transport>
 KOmegaSST<Transport>::~KOmegaSST() = default;
 
-template <typename Transport>
-void KOmegaSST<Transport>::parse_model_coeffs()
-{
-    const std::string coeffs_dict = this->model_name() + "_coeffs";
-    amrex::ParmParse pp(coeffs_dict);
-    pp.query("beta_star", this->m_beta_star);
-    pp.query("alpha1", this->m_alpha1);
-    pp.query("alpha2", this->m_alpha2);
-    pp.query("beta1", this->m_beta1);
-    pp.query("beta2", this->m_beta2);
-    pp.query("sigma_k1", this->m_sigma_k1);
-    pp.query("sigma_k2", this->m_sigma_k2);
-    pp.query("sigma_omega1", this->m_sigma_omega1);
-    pp.query("sigma_omega2", this->m_sigma_omega2);
-}
-
 } // namespace turbulence
 } // namespace amr_wind
+
+#endif /* KOMEGASSTI_H */

--- a/amr-wind/turbulence/RANS/KOmegaSSTI.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTI.H
@@ -32,19 +32,6 @@ KOmegaSST<Transport>::KOmegaSST(CFDSim& sim)
     auto& sdr_eqn =
         sim.pde_manager().register_transport_pde(pde::SDR::pde_name());
     m_sdr = &(sdr_eqn.fields().field);
-    {
-        const std::string coeffs_dict = this->model_name() + "_coeffs";
-        amrex::ParmParse pp(coeffs_dict);
-        pp.query("beta_star", this->m_beta_star);
-        pp.query("alpha1", this->m_alpha1);
-        pp.query("alpha2", this->m_alpha2);
-        pp.query("beta1", this->m_beta1);
-        pp.query("beta2", this->m_beta2);
-        pp.query("sigma_k1", this->m_sigma_k1);
-        pp.query("sigma_k2", this->m_sigma_k2);
-        pp.query("sigma_omega1", this->m_sigma_omega1);
-        pp.query("sigma_omega2", this->m_sigma_omega2);
-    }
 
     // TKE source term to be added to PDE
     turb_utils::inject_turbulence_src_terms(pde::TKE::pde_name(), {"KwSSTSrc"});
@@ -52,6 +39,22 @@ KOmegaSST<Transport>::KOmegaSST(CFDSim& sim)
 
 template <typename Transport>
 KOmegaSST<Transport>::~KOmegaSST() = default;
+
+template <typename Transport>
+void KOmegaSST<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("beta_star", this->m_beta_star);
+    pp.query("alpha1", this->m_alpha1);
+    pp.query("alpha2", this->m_alpha2);
+    pp.query("beta1", this->m_beta1);
+    pp.query("beta2", this->m_beta2);
+    pp.query("sigma_k1", this->m_sigma_k1);
+    pp.query("sigma_k2", this->m_sigma_k2);
+    pp.query("sigma_omega1", this->m_sigma_omega1);
+    pp.query("sigma_omega2", this->m_sigma_omega2);
+}
 
 } // namespace turbulence
 } // namespace amr_wind

--- a/amr-wind/turbulence/RANS/KOmegaSSTI.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTI.H
@@ -14,6 +14,7 @@ namespace amr_wind {
 namespace turbulence {
 
 template <typename Transport>
+// cppcheck-suppress uninitMemberVar
 KOmegaSST<Transport>::KOmegaSST(CFDSim& sim)
     : TurbModelBase<Transport>(sim)
     , m_vel(sim.repo().get_field("velocity"))

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
@@ -42,6 +42,9 @@ public:
     //! No post advance work for this model
     virtual void post_advance_work() override {}
 
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() override;
+
     //! Return turbulence model coefficients
     TurbulenceModel::CoeffsDictType model_coeffs() const override;
 

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -25,6 +25,7 @@ KOmegaSSTIDDES<Transport>::KOmegaSSTIDDES(CFDSim& sim)
 template <typename Transport>
 void KOmegaSSTIDDES<Transport>::parse_model_coeffs()
 {
+    KOmegaSST<Transport>::parse_model_coeffs();
     const std::string coeffs_dict = this->model_name() + "_coeffs";
     amrex::ParmParse pp(coeffs_dict);
     pp.query("Cdes1", this->m_Cdes1);

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -20,18 +20,19 @@ KOmegaSSTIDDES<Transport>::~KOmegaSSTIDDES() = default;
 template <typename Transport>
 KOmegaSSTIDDES<Transport>::KOmegaSSTIDDES(CFDSim& sim)
     : KOmegaSST<Transport>(sim)
-{
+{}
 
-    {
-        const std::string coeffs_dict = this->model_name() + "_coeffs";
-        amrex::ParmParse pp(coeffs_dict);
-        pp.query("Cdes1", this->m_Cdes1);
-        pp.query("Cdes2", this->m_Cdes2);
-        pp.query("Cdt1", this->m_Cdt1);
-        pp.query("Cdt2", this->m_Cdt2);
-        pp.query("Cw", this->m_Cw);
-        pp.query("kappa", this->m_kappa);
-    }
+template <typename Transport>
+void KOmegaSSTIDDES<Transport>::parse_model_coeffs()
+{
+    const std::string coeffs_dict = this->model_name() + "_coeffs";
+    amrex::ParmParse pp(coeffs_dict);
+    pp.query("Cdes1", this->m_Cdes1);
+    pp.query("Cdes2", this->m_Cdes2);
+    pp.query("Cdt1", this->m_Cdt1);
+    pp.query("Cdt2", this->m_Cdt2);
+    pp.query("Cw", this->m_Cw);
+    pp.query("kappa", this->m_kappa);
 }
 
 template <typename Transport>

--- a/amr-wind/turbulence/TurbulenceModel.H
+++ b/amr-wind/turbulence/TurbulenceModel.H
@@ -97,6 +97,9 @@ public:
     //! Interface to update scalar diffusivity based on Schmidt number
     virtual void update_scalar_diff(Field& deff, const std::string& name) = 0;
 
+    //! Parse turbulence model coefficients
+    virtual void parse_model_coeffs() = 0;
+
     //! Return model coefficients dictionary
     virtual CoeffsDictType model_coeffs() const = 0;
 };


### PR DESCRIPTION
This fixes clang-tidy warnings of the type: `warning: Call to virtual
method 'OneEqKsgsS94::model_name' during construction bypasses virtual
dispatch [clang-analyzer-optin.cplusplus.VirtualCall]`