### PR TITLE
Update OpenFAST interface to work with OF-3.0

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
@@ -72,6 +72,9 @@ protected:
 
     int m_num_sc_inputs{0};
     int m_num_sc_outputs{0};
+    int m_num_sc_inputs_glob{0};
+    float m_init_sc_inputs_glob{0.0}; 
+    float m_init_sc_inputs_turbine{0.0};
 
     bool m_is_initialized{false};
 };

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -201,9 +201,10 @@ void FastIface::fast_init_turbine(FastTurbine& fi)
     char inp_file[fast_strlen()];
     copy_filename(fi.input_file, inp_file);
 
-    fast_func(
+    fast_func( 
         FAST_OpFM_Init, &fi.tid_local, &fi.stop_time, inp_file, &fi.tid_global,
-        &m_num_sc_inputs, &m_num_sc_outputs, &fi.num_pts_blade,
+        &m_num_sc_inputs_glob, &m_num_sc_inputs, &m_num_sc_outputs, 
+        &m_init_sc_inputs_glob, &m_init_sc_inputs_turbine, &fi.num_pts_blade,
         &fi.num_pts_tower, fi.base_pos, &abort_lev, &fi.dt_fast, &fi.num_blades,
         &fi.num_blade_elem, &fi.to_cfd, &fi.from_cfd, &fi.to_sc, &fi.from_sc);
 

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_types.H
@@ -77,8 +77,8 @@ struct FastTurbine
     exw_fast::OpFM_InputType to_cfd;
     exw_fast::OpFM_OutputType from_cfd;
 
-    exw_fast::SC_InputType to_sc;
-    exw_fast::SC_OutputType from_sc;
+    exw_fast::SC_DX_InputType to_sc;
+    exw_fast::SC_DX_OutputType from_sc;
 };
 
 } // namespace exw_fast

--- a/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/fast_wrapper.H
@@ -23,9 +23,9 @@ struct OpFM_InputType
 {};
 struct OpFM_OutputType
 {};
-struct SC_InputType
+struct SC_DX_InputType
 {};
-struct SC_OutputType
+struct SC_DX_OutputType
 {};
 
 inline constexpr int fast_strlen() { return 1025; }
@@ -39,14 +39,15 @@ inline void FAST_OpFM_Step(int*, int*, char*) {}
 
 // clang-format off
 inline void FAST_OpFM_Init(
-    int*, double*, const char*, int*, int*, int*, int*, int*, float*,
-    int*, double*, int*, int*, OpFM_InputType*, OpFM_OutputType*,
-    SC_InputType*, SC_OutputType*, int*, char*) {}
+    int*, double*, const char*, int*, int*, int*, int*, float*, 
+    float*, int*, int*, float*, int*, double*, int*, int*, 
+    OpFM_InputType*, OpFM_OutputType*, SC_DX_InputType*, 
+    SC_DX_OutputType*, int*, char*) {}
 
 inline void FAST_OpFM_Restart(
     int*, char*, int*, double*, int*, int*, int*,
     OpFM_InputType*, OpFM_OutputType*,
-    SC_InputType*, SC_OutputType*, int*, char*) {}
+    SC_DX_InputType*, SC_DX_OutputType*, int*, char*) {}
 // clang-format on
 #endif
 } // namespace exw_fast


### PR DESCRIPTION
This makes two changes to allow AMR-Wind build with OpenFAST 3.0+:

1. Add _DX_ to data type names -> SC_InputType and SC_OutputType
2. Align "FAST_OpFM_Init" with definition in Fast_Library.h

CRITICAL: without any other changes, this will break builds with OF-2.6 and lower

To remedy this, does anyone have any good ideas about passing OF version to AMR-Wind to split the fast_func into version specific definitions? Or is there a more fancy/elegant solution that doesn't involve version specific definitions?


