### PR TITLE
adding DamBreak init, adding logic to avoid re-initializing the volum…

### DIFF
--- a/amr-wind/physics/multiphase/DamBreak.H
+++ b/amr-wind/physics/multiphase/DamBreak.H
@@ -33,8 +33,11 @@ public:
     void post_advance_work() override {}
 
 private:
+    const CFDSim& m_sim;
+
     Field& m_velocity;
     Field& m_levelset;
+    Field& m_density;
 
     //! Initial DamBreak location
     amrex::Vector<amrex::Real> m_loc{{0.0, 0.0, 0.0}};

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -34,7 +34,7 @@ public:
 
     void post_regrid_actions() override {}
 
-    void pre_advance_work() override {}
+    void pre_advance_work() override;
 
     void post_advance_work() override;
 
@@ -73,6 +73,8 @@ private:
     amrex::Real m_rho2{1.0};
 
     bool m_interface_smoothing{false};
+
+    int m_smooth_freq{10};
 
     // Multiphase model enum
     std::string m_interface_model{"vof"};

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -284,7 +284,7 @@ void MultiPhase::favre_filtering()
 void MultiPhase::levelset2vof()
 {
     const int nlevels = m_sim.repo().num_active_levels();
-    m_density.fillpatch(m_sim.time().current_time());
+    (*m_levelset).fillpatch(m_sim.time().current_time());
     const auto& geom = m_sim.mesh().Geom();
 
     for (int lev = 0; lev < nlevels; ++lev) {

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -62,7 +62,7 @@ InterfaceCapturingMethod MultiPhase::interface_capturing_method()
 void MultiPhase::post_init_actions()
 {
 
-    auto& io_mgr = m_sim.io_manager();
+    const auto& io_mgr = m_sim.io_manager();
     if (!io_mgr.is_restart()) {
         switch (m_interface_capturing_method) {
         case InterfaceCapturingMethod::VOF:


### PR DESCRIPTION
- adding to the dam break init function for initializing density
- adding logic to avoid re-initializing the volume fractions from the levelset function when using checkpoints to restart
- adding a smoothing frequency variable to control how often we apply interface smoothing