### PR TITLE
one-line fix to PR #571

### DIFF
--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -222,7 +222,7 @@ void MultiPhase::set_density_via_vof()
                 });
         }
     }
-    // m_density.fillpatch(m_sim.time().current_time());
+    m_density.fillpatch(m_sim.time().current_time());
 }
 
 void MultiPhase::favre_filtering()


### PR DESCRIPTION
uncommenting fillpatch for density, necessary for interpolating density in MAC projection