### PR TITLE
RANS ABL boundary conditions with mesh mapped coordinates

### DIFF
--- a/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
+++ b/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
@@ -43,6 +43,8 @@ private:
     //! User input parameters
     amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
     amrex::Vector<amrex::Real> m_delta0{{1.0, 1.0, 1.0}};
+    amrex::Vector<amrex::Real> m_transwid{{0.1, 0.1, 0.1}};
+    amrex::Vector<amrex::Real> m_transloc{{0.0, 0.0, 10.0}};
     amrex::Vector<int> m_map{{0, 0, 1}};
 
     amrex::Real m_eps{1e-11};

--- a/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
+++ b/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
@@ -1,0 +1,54 @@
+#ifndef ABL2CONSTANTSCALING_H
+#define ABL2CONSTANTSCALING_H
+
+#include "amr-wind/core/MeshMap.H"
+#include "amr-wind/core/Field.H"
+
+namespace amr_wind {
+namespace abl_map {
+
+/** Channel flow scaling mesh map
+ *  \ingroup mesh_map
+ */
+class ABL2ConstantScaling : public MeshMap::Register<ABL2ConstantScaling>
+{
+public:
+    static const std::string identifier() { return "ABL2ConstantScaling"; }
+
+    explicit ABL2ConstantScaling(const CFDSim& sim);
+
+    virtual ~ABL2ConstantScaling() = default;
+
+    //! Construct the mesh scaling field
+    void create_map(int, const amrex::Geometry&) override;
+
+    //! Construct mesh scaling field on cell centers and nodes
+    void create_cell_node_map(int, const amrex::Geometry&) override;
+
+    //! Construct mesh scaling field on cell faces
+    void create_face_map(int, const amrex::Geometry&) override;
+
+    //! Construct the non-uniform mesh field
+    void create_non_uniform_mesh(int, const amrex::Geometry&) override;
+
+private:
+    Field& m_mesh_scale_fac_cc;
+    Field& m_mesh_scale_fac_nd;
+    Field& m_mesh_scale_fac_xf;
+    Field& m_mesh_scale_fac_yf;
+    Field& m_mesh_scale_fac_zf;
+    Field& m_non_uniform_coord_cc;
+    Field& m_non_uniform_coord_nd;
+
+    //! User input parameters
+    amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
+    amrex::Vector<amrex::Real> m_delta0{{1.0, 1.0, 1.0}};
+    amrex::Vector<int> m_map{{0, 0, 1}};
+
+    amrex::Real m_eps{1e-11};
+};
+
+} // namespace abl_map
+} // namespace amr_wind
+
+#endif /* ABL2ConstantScaling_H */

--- a/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
+++ b/amr-wind/mesh_mapping_models/ABL2ConstantScaling.H
@@ -15,7 +15,7 @@ class ABL2ConstantScaling : public MeshMap::Register<ABL2ConstantScaling>
 public:
     static const std::string identifier() { return "ABL2ConstantScaling"; }
 
-    explicit ABL2ConstantScaling(const CFDSim& sim);
+    explicit ABL2ConstantScaling();
 
     virtual ~ABL2ConstantScaling() = default;
 
@@ -23,13 +23,13 @@ public:
     void create_map(int, const amrex::Geometry&) override;
 
     //! Construct mesh scaling field on cell centers and nodes
-    void create_cell_node_map(int, const amrex::Geometry&) override;
+    void create_cell_node_map(int, const amrex::Geometry&);
 
     //! Construct mesh scaling field on cell faces
-    void create_face_map(int, const amrex::Geometry&) override;
+    void create_face_map(int, const amrex::Geometry&);
 
     //! Construct the non-uniform mesh field
-    void create_non_uniform_mesh(int, const amrex::Geometry&) override;
+    void create_non_uniform_mesh(int, const amrex::Geometry&);
 
 private:
     Field& m_mesh_scale_fac_cc;

--- a/amr-wind/mesh_mapping_models/ABL2ConstantScaling.cpp
+++ b/amr-wind/mesh_mapping_models/ABL2ConstantScaling.cpp
@@ -1,0 +1,339 @@
+#include <cmath>
+
+#include "amr-wind/mesh_mapping_models/ABL2ConstantScaling.H"
+#include "amr-wind/CFDSim.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace abl_map {
+
+namespace {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_fac(
+    const amrex::Real x,
+    const amrex::Real sratio,
+    const amrex::Real delta0,
+    const amrex::Real len)
+{
+    // This is the derivative of eval_coord() below
+    return delta0/sratio/(1.0-sratio)*(x+1.0)*std::pow(sratio, x);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
+    const amrex::Real x,
+    const amrex::Real sratio,
+    const amrex::Real delta0,
+    const amrex::Real len)
+{
+    // TODO: switch to constant cell spacing after some height?
+    return delta0/sratio/(1.0-sratio)*(1.0-std::pow(sratio, x+1.0))-delta0/sratio;
+}
+
+} // namespace
+
+ABL2ConstantScaling::ABL2ConstantScaling(const CFDSim& sim)
+    : m_mesh_scale_fac_cc(sim.repo().get_field("mesh_scaling_factor_cc"))
+    , m_mesh_scale_fac_nd(sim.repo().get_field("mesh_scaling_factor_nd"))
+    , m_mesh_scale_fac_xf(sim.repo().get_field("mesh_scaling_factor_xf"))
+    , m_mesh_scale_fac_yf(sim.repo().get_field("mesh_scaling_factor_yf"))
+    , m_mesh_scale_fac_zf(sim.repo().get_field("mesh_scaling_factor_zf"))
+    , m_non_uniform_coord_cc(sim.repo().get_field("non_uniform_coord_cc"))
+    , m_non_uniform_coord_nd(sim.repo().get_field("non_uniform_coord_nd"))
+{
+    amrex::ParmParse pp("ABL2ConstantScaling");
+    pp.queryarr("sratio", m_sratio, 0, AMREX_SPACEDIM);
+    pp.queryarr("delta0", m_delta0, 0, AMREX_SPACEDIM);
+    pp.queryarr("do_map", m_map, 0, AMREX_SPACEDIM);
+}
+
+/** Construct the mesh mapping field
+ */
+void ABL2ConstantScaling::create_map(int lev, const amrex::Geometry& geom)
+{
+    create_cell_node_map(lev, geom);
+    create_face_map(lev, geom);
+    create_non_uniform_mesh(lev, geom);
+}
+
+/** Construct the mesh mapping field on cell centers and nodes
+ */
+void ABL2ConstantScaling::create_cell_node_map(
+    int lev, const amrex::Geometry& geom)
+{
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+         prob_hi[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_cc(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_cc =
+            m_mesh_scale_fac_cc(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                scale_fac_cc(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_cc(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_cc(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+
+        const auto& nbx = mfi.grownnodaltilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_nd =
+            m_mesh_scale_fac_nd(lev).array(mfi);
+        amrex::ParallelFor(
+            nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
+
+                scale_fac_nd(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_nd(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_nd(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    // TODO: Call fill patch operators
+}
+
+/** Construct the mesh mapping field on cell faces
+ */
+void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
+{
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+         prob_hi[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_xf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_xf =
+            m_mesh_scale_fac_xf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y > prob_lo[1]) && (y < prob_hi[1]) && (z > prob_lo[2]) &&
+                     (z < prob_hi[2]));
+
+                scale_fac_xf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_xf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_xf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_yf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_yf =
+            m_mesh_scale_fac_yf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                scale_fac_yf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_yf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_yf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_zf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_zf =
+            m_mesh_scale_fac_zf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z >= prob_lo[2] - eps) &&
+                     (z <= prob_hi[2] + eps));
+
+                scale_fac_zf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_zf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_zf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    // TODO: Call fill patch operators
+}
+
+/** Construct the non-uniform mesh field
+ */
+void ABL2ConstantScaling::create_non_uniform_mesh(
+    int lev, const amrex::Geometry& geom)
+{
+    amrex::Vector<amrex::Real> probhi_physical{{0.0, 0.0, 0.0}};
+    {
+        amrex::ParmParse pp("geometry");
+        if (pp.contains("prob_hi_physical")) {
+            pp.getarr("prob_hi_physical", probhi_physical);
+        } else {
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                probhi_physical[d] = geom.ProbHiArray()[d];
+            }
+        }
+    }
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {probhi_physical[0] - prob_lo[0], probhi_physical[1] - prob_lo[1],
+         probhi_physical[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_non_uniform_coord_cc(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& nu_coord_cc =
+            m_non_uniform_coord_cc(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real x_non_uni =
+                    eval_coord(x, sratio[0], delta0[0], len[0]);
+                amrex::Real y_non_uni =
+                    eval_coord(y, sratio[1], delta0[1], len[1]);
+                amrex::Real z_non_uni =
+                    eval_coord(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                nu_coord_cc(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? x_non_uni : x;
+                nu_coord_cc(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? y_non_uni : y;
+                nu_coord_cc(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? z_non_uni : z;
+            });
+
+        const auto& nbx = mfi.grownnodaltilebox();
+        amrex::Array4<amrex::Real> const& nu_coord_nd =
+            m_non_uniform_coord_nd(lev).array(mfi);
+        amrex::ParallelFor(
+            nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real x_non_uni =
+                    eval_coord(x, sratio[0], delta0[0], len[0]);
+                amrex::Real y_non_uni =
+                    eval_coord(y, sratio[1], delta0[1], len[1]);
+                amrex::Real z_non_uni =
+                    eval_coord(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
+
+                nu_coord_nd(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? x_non_uni : x;
+                nu_coord_nd(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? y_non_uni : y;
+                nu_coord_nd(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? z_non_uni : z;
+            });
+    }
+}
+
+} // namespace abl_map
+} // namespace amr_wind

--- a/amr-wind/mesh_mapping_models/ABLScaling.H
+++ b/amr-wind/mesh_mapping_models/ABLScaling.H
@@ -1,0 +1,54 @@
+#ifndef ABLSCALING_H
+#define ABLSCALING_H
+
+#include "amr-wind/core/MeshMap.H"
+#include "amr-wind/core/Field.H"
+
+namespace amr_wind {
+namespace abl_map {
+
+/** Channel flow scaling mesh map
+ *  \ingroup mesh_map
+ */
+class ABLScaling : public MeshMap::Register<ABLScaling>
+{
+public:
+    static const std::string identifier() { return "ABLScaling"; }
+
+    explicit ABLScaling(const CFDSim& sim);
+
+    virtual ~ABLScaling() = default;
+
+    //! Construct the mesh scaling field
+    void create_map(int, const amrex::Geometry&) override;
+
+    //! Construct mesh scaling field on cell centers and nodes
+    void create_cell_node_map(int, const amrex::Geometry&) override;
+
+    //! Construct mesh scaling field on cell faces
+    void create_face_map(int, const amrex::Geometry&) override;
+
+    //! Construct the non-uniform mesh field
+    void create_non_uniform_mesh(int, const amrex::Geometry&) override;
+
+private:
+    Field& m_mesh_scale_fac_cc;
+    Field& m_mesh_scale_fac_nd;
+    Field& m_mesh_scale_fac_xf;
+    Field& m_mesh_scale_fac_yf;
+    Field& m_mesh_scale_fac_zf;
+    Field& m_non_uniform_coord_cc;
+    Field& m_non_uniform_coord_nd;
+
+    //! User input parameters
+    amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
+    amrex::Vector<amrex::Real> m_delta0{{1.0, 1.0, 1.0}};
+    amrex::Vector<int> m_map{{0, 0, 1}};
+
+    amrex::Real m_eps{1e-11};
+};
+
+} // namespace abl_map
+} // namespace amr_wind
+
+#endif /* ABLSCALING_H */

--- a/amr-wind/mesh_mapping_models/ABLScaling.H
+++ b/amr-wind/mesh_mapping_models/ABLScaling.H
@@ -15,7 +15,7 @@ class ABLScaling : public MeshMap::Register<ABLScaling>
 public:
     static const std::string identifier() { return "ABLScaling"; }
 
-    explicit ABLScaling(const CFDSim& sim);
+    explicit ABLScaling();
 
     virtual ~ABLScaling() = default;
 
@@ -23,23 +23,15 @@ public:
     void create_map(int, const amrex::Geometry&) override;
 
     //! Construct mesh scaling field on cell centers and nodes
-    void create_cell_node_map(int, const amrex::Geometry&) override;
+    void create_cell_node_map(int, const amrex::Geometry&);
 
     //! Construct mesh scaling field on cell faces
-    void create_face_map(int, const amrex::Geometry&) override;
+    void create_face_map(int, const amrex::Geometry&);
 
     //! Construct the non-uniform mesh field
-    void create_non_uniform_mesh(int, const amrex::Geometry&) override;
+    void create_non_uniform_mesh(int, const amrex::Geometry&);
 
 private:
-    Field& m_mesh_scale_fac_cc;
-    Field& m_mesh_scale_fac_nd;
-    Field& m_mesh_scale_fac_xf;
-    Field& m_mesh_scale_fac_yf;
-    Field& m_mesh_scale_fac_zf;
-    Field& m_non_uniform_coord_cc;
-    Field& m_non_uniform_coord_nd;
-
     //! User input parameters
     amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
     amrex::Vector<amrex::Real> m_delta0{{1.0, 1.0, 1.0}};

--- a/amr-wind/mesh_mapping_models/ABLScaling.cpp
+++ b/amr-wind/mesh_mapping_models/ABLScaling.cpp
@@ -1,0 +1,339 @@
+#include <cmath>
+
+#include "amr-wind/mesh_mapping_models/ABLScaling.H"
+#include "amr-wind/CFDSim.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace abl_map {
+
+namespace {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_fac(
+    const amrex::Real x,
+    const amrex::Real sratio,
+    const amrex::Real delta0,
+    const amrex::Real len)
+{
+    // This is the derivative of eval_coord() below
+    return delta0*std::pow(sratio, x)*std::log(sratio);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
+    const amrex::Real x,
+    const amrex::Real sratio,
+    const amrex::Real delta0,
+    const amrex::Real len)
+{
+    // TODO: switch to constant cell spacing after some height?
+    return delta0*std::pow(sratio, x) - delta0;
+}
+
+} // namespace
+
+ABLScaling::ABLScaling(const CFDSim& sim)
+    : m_mesh_scale_fac_cc(sim.repo().get_field("mesh_scaling_factor_cc"))
+    , m_mesh_scale_fac_nd(sim.repo().get_field("mesh_scaling_factor_nd"))
+    , m_mesh_scale_fac_xf(sim.repo().get_field("mesh_scaling_factor_xf"))
+    , m_mesh_scale_fac_yf(sim.repo().get_field("mesh_scaling_factor_yf"))
+    , m_mesh_scale_fac_zf(sim.repo().get_field("mesh_scaling_factor_zf"))
+    , m_non_uniform_coord_cc(sim.repo().get_field("non_uniform_coord_cc"))
+    , m_non_uniform_coord_nd(sim.repo().get_field("non_uniform_coord_nd"))
+{
+    amrex::ParmParse pp("ABLScaling");
+    pp.queryarr("sratio", m_sratio, 0, AMREX_SPACEDIM);
+    pp.queryarr("delta0", m_delta0, 0, AMREX_SPACEDIM);
+    pp.queryarr("do_map", m_map, 0, AMREX_SPACEDIM);
+}
+
+/** Construct the mesh mapping field
+ */
+void ABLScaling::create_map(int lev, const amrex::Geometry& geom)
+{
+    create_cell_node_map(lev, geom);
+    create_face_map(lev, geom);
+    create_non_uniform_mesh(lev, geom);
+}
+
+/** Construct the mesh mapping field on cell centers and nodes
+ */
+void ABLScaling::create_cell_node_map(
+    int lev, const amrex::Geometry& geom)
+{
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+         prob_hi[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_cc(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_cc =
+            m_mesh_scale_fac_cc(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                scale_fac_cc(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_cc(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_cc(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+
+        const auto& nbx = mfi.grownnodaltilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_nd =
+            m_mesh_scale_fac_nd(lev).array(mfi);
+        amrex::ParallelFor(
+            nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
+
+                scale_fac_nd(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_nd(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_nd(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    // TODO: Call fill patch operators
+}
+
+/** Construct the mesh mapping field on cell faces
+ */
+void ABLScaling::create_face_map(int lev, const amrex::Geometry& geom)
+{
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+         prob_hi[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_xf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_xf =
+            m_mesh_scale_fac_xf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y > prob_lo[1]) && (y < prob_hi[1]) && (z > prob_lo[2]) &&
+                     (z < prob_hi[2]));
+
+                scale_fac_xf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_xf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_xf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_yf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_yf =
+            m_mesh_scale_fac_yf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                scale_fac_yf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_yf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_yf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    for (amrex::MFIter mfi(m_mesh_scale_fac_zf(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& scale_fac_zf =
+            m_mesh_scale_fac_zf(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real fac_x = eval_fac(x, sratio[0], delta0[0], len[0]);
+                amrex::Real fac_y = eval_fac(y, sratio[1], delta0[1], len[1]);
+                amrex::Real fac_z = eval_fac(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z >= prob_lo[2] - eps) &&
+                     (z <= prob_hi[2] + eps));
+
+                scale_fac_zf(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? fac_x : 1.0;
+                scale_fac_zf(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? fac_y : 1.0;
+                scale_fac_zf(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? fac_z : 1.0;
+            });
+    }
+
+    // TODO: Call fill patch operators
+}
+
+/** Construct the non-uniform mesh field
+ */
+void ABLScaling::create_non_uniform_mesh(
+    int lev, const amrex::Geometry& geom)
+{
+    amrex::Vector<amrex::Real> probhi_physical{{0.0, 0.0, 0.0}};
+    {
+        amrex::ParmParse pp("geometry");
+        if (pp.contains("prob_hi_physical")) {
+            pp.getarr("prob_hi_physical", probhi_physical);
+        } else {
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                probhi_physical[d] = geom.ProbHiArray()[d];
+            }
+        }
+    }
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
+        {m_sratio[0], m_sratio[1], m_sratio[2]}};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> delta0{
+        {m_delta0[0], m_delta0[1], m_delta0[2]}};
+    amrex::GpuArray<int, AMREX_SPACEDIM> do_map{{m_map[0], m_map[1], m_map[2]}};
+    const auto eps = m_eps;
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    const auto& prob_hi = geom.ProbHiArray();
+
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
+        {probhi_physical[0] - prob_lo[0], probhi_physical[1] - prob_lo[1],
+         probhi_physical[2] - prob_lo[2]}};
+
+    for (amrex::MFIter mfi(m_non_uniform_coord_cc(lev)); mfi.isValid(); ++mfi) {
+
+        const auto& bx = mfi.growntilebox();
+        amrex::Array4<amrex::Real> const& nu_coord_cc =
+            m_non_uniform_coord_cc(lev).array(mfi);
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+
+                amrex::Real x_non_uni =
+                    eval_coord(x, sratio[0], delta0[0], len[0]);
+                amrex::Real y_non_uni =
+                    eval_coord(y, sratio[1], delta0[1], len[1]);
+                amrex::Real z_non_uni =
+                    eval_coord(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
+                     (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
+
+                nu_coord_cc(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? x_non_uni : x;
+                nu_coord_cc(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? y_non_uni : y;
+                nu_coord_cc(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? z_non_uni : z;
+            });
+
+        const auto& nbx = mfi.grownnodaltilebox();
+        amrex::Array4<amrex::Real> const& nu_coord_nd =
+            m_non_uniform_coord_nd(lev).array(mfi);
+        amrex::ParallelFor(
+            nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                amrex::Real x = prob_lo[0] + i * dx[0];
+                amrex::Real y = prob_lo[1] + j * dx[1];
+                amrex::Real z = prob_lo[2] + k * dx[2];
+
+                amrex::Real x_non_uni =
+                    eval_coord(x, sratio[0], delta0[0], len[0]);
+                amrex::Real y_non_uni =
+                    eval_coord(y, sratio[1], delta0[1], len[1]);
+                amrex::Real z_non_uni =
+                    eval_coord(z, sratio[2], delta0[2], len[2]);
+
+                bool in_domain =
+                    ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
+                     (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
+                     (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
+
+                nu_coord_nd(i, j, k, 0) =
+                    (do_map[0] && in_domain) ? x_non_uni : x;
+                nu_coord_nd(i, j, k, 1) =
+                    (do_map[1] && in_domain) ? y_non_uni : y;
+                nu_coord_nd(i, j, k, 2) =
+                    (do_map[2] && in_domain) ? z_non_uni : z;
+            });
+    }
+}
+
+} // namespace abl_map
+} // namespace amr_wind

--- a/amr-wind/mesh_mapping_models/ABLScaling.cpp
+++ b/amr-wind/mesh_mapping_models/ABLScaling.cpp
@@ -17,7 +17,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_fac(
     const amrex::Real len)
 {
     // This is the derivative of eval_coord() below
-    return delta0*std::pow(sratio, x)*std::log(sratio);
+    return delta0/sratio/(1.0-sratio)*(x+1.0)*std::pow(sratio, x);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
@@ -27,7 +27,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
     const amrex::Real len)
 {
     // TODO: switch to constant cell spacing after some height?
-    return delta0*std::pow(sratio, x) - delta0;
+    return delta0/sratio/(1.0-sratio)*(1.0-std::pow(sratio, x+1.0))-delta0/sratio;
 }
 
 } // namespace

--- a/amr-wind/mesh_mapping_models/CMakeLists.txt
+++ b/amr-wind/mesh_mapping_models/CMakeLists.txt
@@ -1,6 +1,8 @@
 target_sources(${amr_wind_lib_name}
   PRIVATE
 
-  ChannelFlowMap.cpp
-  ConstantMap.cpp
+  ABLScaling.cpp
+  ABL2ConstantScaling.cpp
+  ChannelFlowScaling.cpp
+  ConstantScaling.cpp
   )

--- a/amr-wind/mesh_mapping_models/CMakeLists.txt
+++ b/amr-wind/mesh_mapping_models/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(${amr_wind_lib_name}
   PRIVATE
 
   ABLScaling.cpp
+  Geom2ConstantScaling.cpp
   ChannelFlowMap.cpp
   ConstantMap.cpp
   )

--- a/amr-wind/mesh_mapping_models/CMakeLists.txt
+++ b/amr-wind/mesh_mapping_models/CMakeLists.txt
@@ -2,7 +2,7 @@ target_sources(${amr_wind_lib_name}
   PRIVATE
 
   ABLScaling.cpp
-  ABL2ConstantScaling.cpp
-  ChannelFlowScaling.cpp
-  ConstantScaling.cpp
+  ChannelFlowMap.cpp
+  ConstantMap.cpp
   )
+# TODO: ADD  ABL2ConstantScaling.cpp

--- a/amr-wind/mesh_mapping_models/Geom2ConstantScaling.H
+++ b/amr-wind/mesh_mapping_models/Geom2ConstantScaling.H
@@ -1,5 +1,5 @@
-#ifndef ABL2CONSTANTSCALING_H
-#define ABL2CONSTANTSCALING_H
+#ifndef GEOM2CONSTANTSCALING_H
+#define GEOM2CONSTANTSCALING_H
 
 #include "amr-wind/core/MeshMap.H"
 #include "amr-wind/core/Field.H"
@@ -10,14 +10,14 @@ namespace abl_map {
 /** Channel flow scaling mesh map
  *  \ingroup mesh_map
  */
-class ABL2ConstantScaling : public MeshMap::Register<ABL2ConstantScaling>
+class Geom2ConstantScaling : public MeshMap::Register<Geom2ConstantScaling>
 {
 public:
-    static const std::string identifier() { return "ABL2ConstantScaling"; }
+    static const std::string identifier() { return "Geom2ConstantScaling"; }
 
-    explicit ABL2ConstantScaling();
+    explicit Geom2ConstantScaling();
 
-    virtual ~ABL2ConstantScaling() = default;
+    virtual ~Geom2ConstantScaling() = default;
 
     //! Construct the mesh scaling field
     void create_map(int, const amrex::Geometry&) override;
@@ -32,14 +32,6 @@ public:
     void create_non_uniform_mesh(int, const amrex::Geometry&);
 
 private:
-    Field& m_mesh_scale_fac_cc;
-    Field& m_mesh_scale_fac_nd;
-    Field& m_mesh_scale_fac_xf;
-    Field& m_mesh_scale_fac_yf;
-    Field& m_mesh_scale_fac_zf;
-    Field& m_non_uniform_coord_cc;
-    Field& m_non_uniform_coord_nd;
-
     //! User input parameters
     amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
     amrex::Vector<amrex::Real> m_delta0{{1.0, 1.0, 1.0}};
@@ -53,4 +45,4 @@ private:
 } // namespace abl_map
 } // namespace amr_wind
 
-#endif /* ABL2ConstantScaling_H */
+#endif /* Geom2ConstantScaling_H */

--- a/amr-wind/mesh_mapping_models/Geom2ConstantScaling.H
+++ b/amr-wind/mesh_mapping_models/Geom2ConstantScaling.H
@@ -5,7 +5,7 @@
 #include "amr-wind/core/Field.H"
 
 namespace amr_wind {
-namespace abl_map {
+namespace geom2constant_map {
 
 /** Channel flow scaling mesh map
  *  \ingroup mesh_map
@@ -31,6 +31,25 @@ public:
     //! Construct the non-uniform mesh field
     void create_non_uniform_mesh(int, const amrex::Geometry&);
 
+    //! Used for debugging eval_coord function
+    amrex::Real dump_coord(
+			   const amrex::Real ,
+			   const amrex::Real ,
+			   const amrex::Real ,
+			   const amrex::Real ,
+			   const amrex::Real ,
+			   const amrex::Real ,
+			   const int);
+    //! Used for debugging eval_fac function
+    amrex::Real dump_fac(
+			 const amrex::Real ,
+			 const amrex::Real ,
+			 const amrex::Real ,
+			 const amrex::Real ,
+			 const amrex::Real ,
+			 const amrex::Real ,
+			 const int);
+
 private:
     //! User input parameters
     amrex::Vector<amrex::Real> m_sratio{{1.0, 1.0, 1.05}};
@@ -43,6 +62,6 @@ private:
 };
 
 } // namespace abl_map
-} // namespace amr_wind
+} // namespace geom2constant_map
 
 #endif /* Geom2ConstantScaling_H */

--- a/amr-wind/mesh_mapping_models/Geom2ConstantScaling.cpp
+++ b/amr-wind/mesh_mapping_models/Geom2ConstantScaling.cpp
@@ -1,6 +1,6 @@
 #include <cmath>
 
-#include "amr-wind/mesh_mapping_models/ABL2ConstantScaling.H"
+#include "amr-wind/mesh_mapping_models/Geom2ConstantScaling.H"
 #include "amr-wind/CFDSim.H"
 
 #include "AMReX_ParmParse.H"
@@ -72,16 +72,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
 
 } // namespace
 
-ABL2ConstantScaling::ABL2ConstantScaling(const CFDSim& sim)
-    : m_mesh_scale_fac_cc(sim.repo().get_field("mesh_scaling_factor_cc"))
-    , m_mesh_scale_fac_nd(sim.repo().get_field("mesh_scaling_factor_nd"))
-    , m_mesh_scale_fac_xf(sim.repo().get_field("mesh_scaling_factor_xf"))
-    , m_mesh_scale_fac_yf(sim.repo().get_field("mesh_scaling_factor_yf"))
-    , m_mesh_scale_fac_zf(sim.repo().get_field("mesh_scaling_factor_zf"))
-    , m_non_uniform_coord_cc(sim.repo().get_field("non_uniform_coord_cc"))
-    , m_non_uniform_coord_nd(sim.repo().get_field("non_uniform_coord_nd"))
+Geom2ConstantScaling::Geom2ConstantScaling()
 {
-    amrex::ParmParse pp("ABL2ConstantScaling");
+    amrex::ParmParse pp("Geom2ConstantScaling");
     pp.queryarr("sratio", m_sratio, 0, AMREX_SPACEDIM);
     pp.queryarr("delta0", m_delta0, 0, AMREX_SPACEDIM);
     pp.queryarr("transwidth", m_transwid, 0, AMREX_SPACEDIM);
@@ -91,7 +84,7 @@ ABL2ConstantScaling::ABL2ConstantScaling(const CFDSim& sim)
 
 /** Construct the mesh mapping field
  */
-void ABL2ConstantScaling::create_map(int lev, const amrex::Geometry& geom)
+void Geom2ConstantScaling::create_map(int lev, const amrex::Geometry& geom)
 {
     create_cell_node_map(lev, geom);
     create_face_map(lev, geom);
@@ -100,7 +93,7 @@ void ABL2ConstantScaling::create_map(int lev, const amrex::Geometry& geom)
 
 /** Construct the mesh mapping field on cell centers and nodes
  */
-void ABL2ConstantScaling::create_cell_node_map(
+void Geom2ConstantScaling::create_cell_node_map(
     int lev, const amrex::Geometry& geom)
 {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
@@ -128,11 +121,13 @@ void ABL2ConstantScaling::create_cell_node_map(
     amrex::Print() << "Transition Location:    " << transloc[0] << transloc[1] << transloc[2]
                        << std::endl;
 
-    for (amrex::MFIter mfi(m_mesh_scale_fac_cc(lev)); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi((*m_mesh_scale_fac_cc)(lev)); mfi.isValid(); ++mfi) {
 
         const auto& bx = mfi.growntilebox();
         amrex::Array4<amrex::Real> const& scale_fac_cc =
-            m_mesh_scale_fac_cc(lev).array(mfi);
+            (*m_mesh_scale_fac_cc)(lev).array(mfi);
+        amrex::Array4<amrex::Real> const& scale_detJ_cc =
+            (*m_mesh_scale_detJ_cc)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
@@ -150,17 +145,20 @@ void ABL2ConstantScaling::create_cell_node_map(
                     ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
                      (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
 
-                scale_fac_cc(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? fac_x : 1.0;
-                scale_fac_cc(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? fac_y : 1.0;
-                scale_fac_cc(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? fac_z : 1.0;
+                scale_fac_cc(i, j, k, 0) = in_domain ? fac_x : 1.0;
+                scale_fac_cc(i, j, k, 1) = in_domain ? fac_y : 1.0;
+                scale_fac_cc(i, j, k, 2) = in_domain ? fac_z : 1.0;
+
+                scale_detJ_cc(i, j, k) = scale_fac_cc(i, j, k, 0) *
+                                         scale_fac_cc(i, j, k, 1) *
+                                         scale_fac_cc(i, j, k, 2);
             });
 
         const auto& nbx = mfi.grownnodaltilebox();
         amrex::Array4<amrex::Real> const& scale_fac_nd =
-            m_mesh_scale_fac_nd(lev).array(mfi);
+            (*m_mesh_scale_fac_nd)(lev).array(mfi);
+        amrex::Array4<amrex::Real> const& scale_detJ_nd =
+            (*m_mesh_scale_detJ_nd)(lev).array(mfi);
         amrex::ParallelFor(
             nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + i * dx[0];
@@ -179,12 +177,13 @@ void ABL2ConstantScaling::create_cell_node_map(
                      (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
                      (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
 
-                scale_fac_nd(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? fac_x : 1.0;
-                scale_fac_nd(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? fac_y : 1.0;
-                scale_fac_nd(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? fac_z : 1.0;
+                scale_fac_nd(i, j, k, 0) = in_domain ? fac_x : 1.0;
+                scale_fac_nd(i, j, k, 1) = in_domain ? fac_y : 1.0;
+                scale_fac_nd(i, j, k, 2) = in_domain ? fac_z : 1.0;
+
+                scale_detJ_nd(i, j, k) = scale_fac_nd(i, j, k, 0) *
+                                         scale_fac_nd(i, j, k, 1) *
+                                         scale_fac_nd(i, j, k, 2);
             });
     }
 
@@ -193,7 +192,7 @@ void ABL2ConstantScaling::create_cell_node_map(
 
 /** Construct the mesh mapping field on cell faces
  */
-void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
+void Geom2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
 {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> sratio{
         {m_sratio[0], m_sratio[1], m_sratio[2]}};
@@ -214,11 +213,13 @@ void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
         {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
          prob_hi[2] - prob_lo[2]}};
 
-    for (amrex::MFIter mfi(m_mesh_scale_fac_xf(lev)); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi((*m_mesh_scale_fac_xf)(lev)); mfi.isValid(); ++mfi) {
 
         const auto& bx = mfi.growntilebox();
         amrex::Array4<amrex::Real> const& scale_fac_xf =
-            m_mesh_scale_fac_xf(lev).array(mfi);
+            (*m_mesh_scale_fac_xf)(lev).array(mfi);
+        amrex::Array4<amrex::Real> const& scale_detJ_xf =
+            (*m_mesh_scale_detJ_xf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + i * dx[0];
@@ -237,20 +238,23 @@ void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
                      (y > prob_lo[1]) && (y < prob_hi[1]) && (z > prob_lo[2]) &&
                      (z < prob_hi[2]));
 
-                scale_fac_xf(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? fac_x : 1.0;
-                scale_fac_xf(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? fac_y : 1.0;
-                scale_fac_xf(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? fac_z : 1.0;
+                scale_fac_xf(i, j, k, 0) = in_domain ? fac_x : 1.0;
+                scale_fac_xf(i, j, k, 1) = in_domain ? fac_y : 1.0;
+                scale_fac_xf(i, j, k, 2) = in_domain ? fac_z : 1.0;
+
+                scale_detJ_xf(i, j, k) = scale_fac_xf(i, j, k, 0) *
+                                         scale_fac_xf(i, j, k, 1) *
+                                         scale_fac_xf(i, j, k, 2);
             });
     }
 
-    for (amrex::MFIter mfi(m_mesh_scale_fac_yf(lev)); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi((*m_mesh_scale_fac_yf)(lev)); mfi.isValid(); ++mfi) {
 
         const auto& bx = mfi.growntilebox();
         amrex::Array4<amrex::Real> const& scale_fac_yf =
-            m_mesh_scale_fac_yf(lev).array(mfi);
+            (*m_mesh_scale_fac_yf)(lev).array(mfi);
+        amrex::Array4<amrex::Real> const& scale_detJ_yf =
+            (*m_mesh_scale_detJ_yf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
@@ -269,20 +273,23 @@ void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
                      (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
                      (z > prob_lo[2]) && (z < prob_hi[2]));
 
-                scale_fac_yf(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? fac_x : 1.0;
-                scale_fac_yf(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? fac_y : 1.0;
-                scale_fac_yf(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? fac_z : 1.0;
+                scale_fac_yf(i, j, k, 0) = in_domain ? fac_x : 1.0;
+                scale_fac_yf(i, j, k, 1) = in_domain ? fac_y : 1.0;
+                scale_fac_yf(i, j, k, 2) = in_domain ? fac_z : 1.0;
+
+                scale_detJ_yf(i, j, k) = scale_fac_yf(i, j, k, 0) *
+                                         scale_fac_yf(i, j, k, 1) *
+                                         scale_fac_yf(i, j, k, 2);
             });
     }
 
-    for (amrex::MFIter mfi(m_mesh_scale_fac_zf(lev)); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi((*m_mesh_scale_fac_zf)(lev)); mfi.isValid(); ++mfi) {
 
         const auto& bx = mfi.growntilebox();
         amrex::Array4<amrex::Real> const& scale_fac_zf =
-            m_mesh_scale_fac_zf(lev).array(mfi);
+            (*m_mesh_scale_fac_zf)(lev).array(mfi);
+        amrex::Array4<amrex::Real> const& scale_detJ_zf =
+            (*m_mesh_scale_detJ_zf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
@@ -301,12 +308,13 @@ void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
                      (y < prob_hi[1]) && (z >= prob_lo[2] - eps) &&
                      (z <= prob_hi[2] + eps));
 
-                scale_fac_zf(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? fac_x : 1.0;
-                scale_fac_zf(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? fac_y : 1.0;
-                scale_fac_zf(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? fac_z : 1.0;
+                scale_fac_zf(i, j, k, 0) = in_domain ? fac_x : 1.0;
+                scale_fac_zf(i, j, k, 1) = in_domain ? fac_y : 1.0;
+                scale_fac_zf(i, j, k, 2) = in_domain ? fac_z : 1.0;
+
+                scale_detJ_zf(i, j, k) = scale_fac_zf(i, j, k, 0) *
+                                         scale_fac_zf(i, j, k, 1) *
+                                         scale_fac_zf(i, j, k, 2);
             });
     }
 
@@ -315,7 +323,7 @@ void ABL2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
 
 /** Construct the non-uniform mesh field
  */
-void ABL2ConstantScaling::create_non_uniform_mesh(
+void Geom2ConstantScaling::create_non_uniform_mesh(
     int lev, const amrex::Geometry& geom)
 {
     amrex::Vector<amrex::Real> probhi_physical{{0.0, 0.0, 0.0}};
@@ -349,11 +357,12 @@ void ABL2ConstantScaling::create_non_uniform_mesh(
         {probhi_physical[0] - prob_lo[0], probhi_physical[1] - prob_lo[1],
          probhi_physical[2] - prob_lo[2]}};
 
-    for (amrex::MFIter mfi(m_non_uniform_coord_cc(lev)); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi((*m_non_uniform_coord_cc)(lev)); mfi.isValid();
+         ++mfi) {
 
         const auto& bx = mfi.growntilebox();
         amrex::Array4<amrex::Real> const& nu_coord_cc =
-            m_non_uniform_coord_cc(lev).array(mfi);
+            (*m_non_uniform_coord_cc)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
@@ -371,17 +380,14 @@ void ABL2ConstantScaling::create_non_uniform_mesh(
                     ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
                      (y < prob_hi[1]) && (z > prob_lo[2]) && (z < prob_hi[2]));
 
-                nu_coord_cc(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? x_non_uni : x;
-                nu_coord_cc(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? y_non_uni : y;
-                nu_coord_cc(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? z_non_uni : z;
+                nu_coord_cc(i, j, k, 0) = in_domain ? x_non_uni : x;
+                nu_coord_cc(i, j, k, 1) = in_domain ? y_non_uni : y;
+                nu_coord_cc(i, j, k, 2) = in_domain ? z_non_uni : z;
             });
 
         const auto& nbx = mfi.grownnodaltilebox();
         amrex::Array4<amrex::Real> const& nu_coord_nd =
-            m_non_uniform_coord_nd(lev).array(mfi);
+            (*m_non_uniform_coord_nd)(lev).array(mfi);
         amrex::ParallelFor(
             nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::Real x = prob_lo[0] + i * dx[0];
@@ -400,12 +406,9 @@ void ABL2ConstantScaling::create_non_uniform_mesh(
                      (y >= prob_lo[1] - eps) && (y <= prob_hi[1] + eps) &&
                      (z >= prob_lo[2] - eps) && (z <= prob_hi[2] + eps));
 
-                nu_coord_nd(i, j, k, 0) =
-                    (do_map[0] && in_domain) ? x_non_uni : x;
-                nu_coord_nd(i, j, k, 1) =
-                    (do_map[1] && in_domain) ? y_non_uni : y;
-                nu_coord_nd(i, j, k, 2) =
-                    (do_map[2] && in_domain) ? z_non_uni : z;
+                nu_coord_nd(i, j, k, 0) = in_domain ? x_non_uni : x;
+                nu_coord_nd(i, j, k, 1) = in_domain ? y_non_uni : y;
+                nu_coord_nd(i, j, k, 2) = in_domain ? z_non_uni : z;
             });
     }
 }

--- a/amr-wind/mesh_mapping_models/Geom2ConstantScaling.cpp
+++ b/amr-wind/mesh_mapping_models/Geom2ConstantScaling.cpp
@@ -6,7 +6,7 @@
 #include "AMReX_ParmParse.H"
 
 namespace amr_wind {
-namespace abl_map {
+namespace geom2constant_map {
 
 namespace {
 
@@ -32,26 +32,28 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real x_inv(
     const amrex::Real sratio,
     const amrex::Real delta0)
 {
-    return std::round(std::log(1.0-(trans_loc-delta0/sratio)*sratio*(1.0-sratio)/delta0)/std::log(sratio));
+    return int(std::log(1.0-(trans_loc-delta0/sratio)*sratio*(1.0-sratio)/delta0)/std::log(sratio));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_fac(
     const amrex::Real x,
-    const amrex::Real trans_width,
     const amrex::Real trans_loc,
+    const amrex::Real trans_width,
     const amrex::Real sratio,
     const amrex::Real delta0,
-    const amrex::Real len)
+    const amrex::Real dxscale,
+    const int domap)
 {
     // This is the derivative of eval_coord() below
     const amrex::Real xinv = x_inv(trans_loc, sratio, delta0);
-    const amrex::Real h = 0.5*(1.0+std::tanh((x-xinv)/trans_width));
-    const amrex::Real hprime = 0.5*std::pow(std::acosh((x-xinv)/trans_width),2.0)/trans_width;
+    const amrex::Real h = 0.5*(1.0+std::tanh((x*dxscale-xinv)/trans_width));
+    const amrex::Real hprime = 0.5*std::pow(std::cosh((x*dxscale-xinv)/trans_width),-2.0)/trans_width;
     const amrex::Real lmatch = x_geom(xinv, sratio, delta0);
     const amrex::Real slope = lmatch-x_geom(xinv-1.0, sratio, delta0);
     const amrex::Real xprime_geom = delta0/sratio/(sratio-1.0)*std::pow(sratio, x-1.0)*std::log(sratio);
 
-    return (1.0-h)*xprime_geom - hprime*x_geom(x,sratio,delta0) + h*slope + hprime*x_const(x,slope,xinv,lmatch);
+    if (domap==0) return 1.0;
+    return ((1.0-h)*xprime_geom - hprime*x_geom(x,sratio,delta0) + h*slope + hprime*x_const(x,slope,xinv,lmatch))*dxscale;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
@@ -60,14 +62,16 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real eval_coord(
     const amrex::Real trans_width,
     const amrex::Real sratio,
     const amrex::Real delta0,
-    const amrex::Real len)
+    const amrex::Real dxscale,
+    const int domap)
 {
     const amrex::Real xinv = x_inv(trans_loc, sratio, delta0);
-    const amrex::Real h = 0.5*(1.0+std::tanh((x-xinv)/trans_width));
+    const amrex::Real h = 0.5*(1.0+std::tanh((x*dxscale-xinv)/trans_width));
     const amrex::Real lmatch = x_geom(xinv, sratio, delta0);
     const amrex::Real slope = lmatch-x_geom(xinv-1.0, sratio, delta0);
 
-    return x_geom(x,sratio,delta0)*(1.0-h) + h*x_const(x,slope,xinv,lmatch);
+    if (domap==0) return x;
+    return x_geom(x*dxscale,sratio,delta0)*(1.0-h) + h*x_const(x*dxscale,slope,xinv,lmatch);
 }
 
 } // namespace
@@ -108,6 +112,13 @@ void Geom2ConstantScaling::create_cell_node_map(
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dxscale{{1.0, 1.0, 1.0}};
+    for (int i=0; i<AMREX_SPACEDIM; i++) {
+      if (do_map[i]) {
+	dxscale[i] = 1.0/dx[i];
+      }
+    }
+
     const auto& prob_lo = geom.ProbLoArray();
     const auto& prob_hi = geom.ProbHiArray();
 
@@ -115,10 +126,10 @@ void Geom2ConstantScaling::create_cell_node_map(
         {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
          prob_hi[2] - prob_lo[2]}};
 
-    amrex::Print() << "Transition Width:    " << transwid[0] << transwid[1] << transwid[2]
+    amrex::Print() << "Transition Width:    " << transwid[0] <<" "<< transwid[1] <<" "<< transwid[2]
                        << std::endl;
 
-    amrex::Print() << "Transition Location:    " << transloc[0] << transloc[1] << transloc[2]
+    amrex::Print() << "Transition Location:    " << transloc[0] <<" "<< transloc[1] <<" "<< transloc[2]
                        << std::endl;
 
     for (amrex::MFIter mfi((*m_mesh_scale_fac_cc)(lev)); mfi.isValid(); ++mfi) {
@@ -130,16 +141,16 @@ void Geom2ConstantScaling::create_cell_node_map(
             (*m_mesh_scale_detJ_cc)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
-                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
-                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+	      amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+	      amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+	      amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
                 amrex::Real fac_x = 
-                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+    		    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real fac_y = 
-                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real fac_z = 
-                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
@@ -161,16 +172,16 @@ void Geom2ConstantScaling::create_cell_node_map(
             (*m_mesh_scale_detJ_nd)(lev).array(mfi);
         amrex::ParallelFor(
             nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + i * dx[0];
-                amrex::Real y = prob_lo[1] + j * dx[1];
-                amrex::Real z = prob_lo[2] + k * dx[2];
+	      amrex::Real x = prob_lo[0] + i * dx[0];
+	      amrex::Real y = prob_lo[1] + j * dx[1];
+	      amrex::Real z = prob_lo[2] + k * dx[2];
 
                 amrex::Real fac_x = 
-                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real fac_y = 
-                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real fac_z = 
-                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
@@ -206,6 +217,13 @@ void Geom2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dxscale{{1.0, 1.0, 1.0}};
+    for (int i=0; i<AMREX_SPACEDIM; i++) {
+      if (do_map[i]) {
+	dxscale[i] = 1.0/dx[i];
+      }
+    }
+
     const auto& prob_lo = geom.ProbLoArray();
     const auto& prob_hi = geom.ProbHiArray();
 
@@ -222,16 +240,16 @@ void Geom2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
             (*m_mesh_scale_detJ_xf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + i * dx[0];
-                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
-                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+	      amrex::Real x = prob_lo[0] + i * dx[0];
+	      amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+	      amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
                 amrex::Real fac_x = 
-                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real fac_y = 
-                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real fac_z = 
-                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
@@ -257,16 +275,16 @@ void Geom2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
             (*m_mesh_scale_detJ_yf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
-                amrex::Real y = prob_lo[1] + j * dx[1];
-                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+	      amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+	      amrex::Real y = prob_lo[1] + j * dx[1];
+	      amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
                 amrex::Real fac_x = 
-                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real fac_y = 
-                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real fac_z = 
-                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x > prob_lo[0]) && (x < prob_hi[0]) &&
@@ -292,16 +310,16 @@ void Geom2ConstantScaling::create_face_map(int lev, const amrex::Geometry& geom)
             (*m_mesh_scale_detJ_zf)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
-                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
-                amrex::Real z = prob_lo[2] + k * dx[2];
+	        amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+	        amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+	        amrex::Real z = prob_lo[2] + k * dx[2];
 
                 amrex::Real fac_x = 
-                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_fac(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real fac_y = 
-                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_fac(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real fac_z = 
-                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_fac(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
@@ -350,6 +368,13 @@ void Geom2ConstantScaling::create_non_uniform_mesh(
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dxscale{{1.0, 1.0, 1.0}};
+    for (int i=0; i<AMREX_SPACEDIM; i++) {
+      if (do_map[i]) {
+	dxscale[i] = 1.0/dx[i];
+      }
+    }
+
     const auto& prob_lo = geom.ProbLoArray();
     const auto& prob_hi = geom.ProbHiArray();
 
@@ -365,16 +390,16 @@ void Geom2ConstantScaling::create_non_uniform_mesh(
             (*m_non_uniform_coord_cc)(lev).array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
-                amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
-                amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+	        amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+	        amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+	        amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
                 amrex::Real x_non_uni =
-                    eval_coord(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_coord(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real y_non_uni =
-                    eval_coord(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_coord(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real z_non_uni =
-                    eval_coord(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_coord(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x > prob_lo[0]) && (x < prob_hi[0]) && (y > prob_lo[1]) &&
@@ -390,16 +415,16 @@ void Geom2ConstantScaling::create_non_uniform_mesh(
             (*m_non_uniform_coord_nd)(lev).array(mfi);
         amrex::ParallelFor(
             nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                amrex::Real x = prob_lo[0] + i * dx[0];
-                amrex::Real y = prob_lo[1] + j * dx[1];
-                amrex::Real z = prob_lo[2] + k * dx[2];
+  	        amrex::Real x = prob_lo[0] + i * dx[0];
+		amrex::Real y = prob_lo[1] + j * dx[1];
+		amrex::Real z = prob_lo[2] + k * dx[2];
 
                 amrex::Real x_non_uni =
-                    eval_coord(x, transloc[0], transwid[0], sratio[0], delta0[0], len[0]);
+                    eval_coord(x, transloc[0], transwid[0], sratio[0], delta0[0], dxscale[0], do_map[0]);
                 amrex::Real y_non_uni =
-                    eval_coord(y, transloc[1], transwid[1], sratio[1], delta0[1], len[1]);
+                    eval_coord(y, transloc[1], transwid[1], sratio[1], delta0[1], dxscale[1], do_map[1]);
                 amrex::Real z_non_uni =
-                    eval_coord(z, transloc[2], transwid[2], sratio[2], delta0[2], len[2]);
+                    eval_coord(z, transloc[2], transwid[2], sratio[2], delta0[2], dxscale[2], do_map[2]);
 
                 bool in_domain =
                     ((x >= prob_lo[0] - eps) && (x <= prob_hi[0] + eps) &&
@@ -413,5 +438,31 @@ void Geom2ConstantScaling::create_non_uniform_mesh(
     }
 }
 
-} // namespace abl_map
+  // Used for debugging eval_coord function
+  amrex::Real Geom2ConstantScaling::dump_coord(
+					       const amrex::Real x,
+					       const amrex::Real trans_loc,
+					       const amrex::Real trans_width,
+					       const amrex::Real sratio,
+					       const amrex::Real delta0,
+					       const amrex::Real len,
+					       const int domap)
+  {
+    return eval_coord(x, trans_loc, trans_width, sratio, delta0, len, domap);
+  }
+
+  // Used for debugging eval_fac function
+  amrex::Real Geom2ConstantScaling::dump_fac(
+					     const amrex::Real x,
+					     const amrex::Real trans_loc,
+					     const amrex::Real trans_width,
+					     const amrex::Real sratio,
+					     const amrex::Real delta0,
+					     const amrex::Real len,
+					     const int domap)
+  {
+    return eval_fac(x, trans_loc, trans_width, sratio, delta0, len, domap);
+  }
+
+} // namespace geom2constant_map
 } // namespace amr_wind

--- a/amr-wind/turbulence/RANS/CMakeLists.txt
+++ b/amr-wind/turbulence/RANS/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(${amr_wind_lib_name} PRIVATE
   KOmegaSST.cpp
+  KOmegaSSTABL.cpp
   KOmegaSSTIDDES.cpp
   )

--- a/amr-wind/turbulence/RANS/KOmegaSSTABL.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTABL.H
@@ -1,0 +1,51 @@
+#ifndef KOMEGASSTABL_H
+#define KOMEGASSTABL_H
+
+#include <string>
+#include "amr-wind/turbulence/RANS/KOmegaSST.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+/** K-Omega-SST RANS model for ABL
+ *
+ *
+ *
+ */
+template <typename Transport>
+class KOmegaSSTABL : public KOmegaSST<Transport>
+{
+public:
+    static std::string identifier()
+    {
+        return "KOmegaSSTABL-" + Transport::identifier();
+    }
+
+    explicit KOmegaSSTABL(CFDSim& sim);
+
+    virtual ~KOmegaSSTABL();
+
+    virtual std::string model_name() const override { return "KOmegaSSTABL"; }
+
+    //! Update the turbulent viscosity field
+    virtual void update_turbulent_viscosity(const FieldState fstate) override;
+
+    //! No post advance work for this model
+    virtual void post_advance_work() override {}
+
+    //! Update the effective scalar diffusivity field
+    virtual void
+    update_scalar_diff(Field& deff, const std::string& name) override;
+
+    //! Return turbulence model coefficients
+    TurbulenceModel::CoeffsDictType model_coeffs() const override;
+
+protected:
+    //! Turbulence constants
+    //  Add extra vars in here
+};
+
+} // namespace turbulence
+} // namespace amr_wind
+
+#endif /* KOMEGASSTABL_H */

--- a/amr-wind/turbulence/RANS/KOmegaSSTABL.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTABL.cpp
@@ -1,0 +1,238 @@
+#include "amr-wind/turbulence/RANS/KOmegaSSTABL.H"
+#include "amr-wind/turbulence/RANS/KOmegaSSTI.H"
+#include "amr-wind/equation_systems/PDEBase.H"
+#include "amr-wind/turbulence/TurbModelDefs.H"
+#include "amr-wind/fvm/gradient.H"
+#include "amr-wind/fvm/strainrate.H"
+#include "amr-wind/turbulence/turb_utils.H"
+#include "amr-wind/equation_systems/tke/TKE.H"
+#include "amr-wind/equation_systems/sdr/SDR.H"
+
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+namespace turbulence {
+
+template <typename Transport>
+KOmegaSSTABL<Transport>::~KOmegaSSTABL() = default;
+
+template <typename Transport>
+KOmegaSSTABL<Transport>::KOmegaSSTABL(CFDSim& sim)
+    : KOmegaSST<Transport>(sim)
+{
+
+    {
+        const std::string coeffs_dict = this->model_name() + "_coeffs";
+        amrex::ParmParse pp(coeffs_dict);
+    }
+}
+
+
+template <typename Transport>
+TurbulenceModel::CoeffsDictType KOmegaSSTABL<Transport>::model_coeffs() const
+{
+    return TurbulenceModel::CoeffsDictType{
+        {"beta_star", this->m_beta_star},
+        {"alpha1", this->m_alpha1},
+        {"alpha2", this->m_alpha2},
+        {"beta1", this->m_beta1},
+        {"beta2", this->m_beta2},
+        {"sigma_k1", this->m_sigma_k1},
+        {"sigma_k2", this->m_sigma_k2},
+        {"sigma_omega1", this->m_sigma_omega1},
+        {"sigma_omega2", this->m_sigma_omega2},
+        {"a1", this->m_a1}};
+}
+
+template <typename Transport>
+void KOmegaSSTABL<Transport>::update_turbulent_viscosity(
+			      const FieldState fstate)
+{
+    BL_PROFILE(
+        "amr-wind::" + this->identifier() + "::update_turbulent_viscosity");
+
+    auto& mu_turb = this->mu_turb();
+    const amrex::Real beta_star = this->m_beta_star;
+    const amrex::Real alpha1 = this->m_alpha1;
+    const amrex::Real alpha2 = this->m_alpha2;
+    const amrex::Real beta1 = this->m_beta1;
+    const amrex::Real beta2 = this->m_beta2;
+    const amrex::Real sigma_omega2 = this->m_sigma_omega2;
+    const amrex::Real a1 = this->m_a1;
+
+    auto lam_mu = (this->m_transport).mu();
+    const auto& den = this->m_rho.state(fstate);
+    const auto& tke = (*this->m_tke).state(fstate);
+    const auto& sdr = (*this->m_sdr).state(fstate);
+    auto& repo = mu_turb.repo();
+
+    const int nlevels = repo.num_active_levels();
+
+    auto gradK = (this->m_sim.repo()).create_scratch_field(3, 0);
+    fvm::gradient(*gradK, tke);
+
+    auto gradOmega = (this->m_sim.repo()).create_scratch_field(3, 0);
+    fvm::gradient(*gradOmega, sdr);
+
+    const auto& vel = this->m_vel.state(fstate);
+    // Compute strain rate into shear production term
+    fvm::strainrate(this->m_shear_prod, vel);
+
+    auto& tke_lhs = (this->m_sim).repo().get_field("tke_lhs_src_term");
+    tke_lhs.setVal(0.0);
+    // cppcheck-suppress constVariable
+    auto& sdr_lhs = (this->m_sim).repo().get_field("sdr_lhs_src_term");
+
+    const amrex::Real deltaT = (this->m_sim).time().deltaT();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        for (amrex::MFIter mfi(mu_turb(lev)); mfi.isValid(); ++mfi) {
+            const auto& bx = mfi.tilebox();
+            const auto& lam_mu_arr = (*lam_mu)(lev).array(mfi);
+            const auto& mu_arr = mu_turb(lev).array(mfi);
+            const auto& rho_arr = den(lev).const_array(mfi);
+            const auto& gradK_arr = (*gradK)(lev).array(mfi);
+            const auto& gradOmega_arr = (*gradOmega)(lev).array(mfi);
+            const auto& tke_arr = tke(lev).array(mfi);
+            const auto& sdr_arr = sdr(lev).array(mfi);
+            const auto& wd_arr = (this->m_walldist)(lev).array(mfi);
+            const auto& shear_prod_arr = (this->m_shear_prod)(lev).array(mfi);
+            const auto& diss_arr = (this->m_diss)(lev).array(mfi);
+            const auto& sdr_src_arr = (this->m_sdr_src)(lev).array(mfi);
+            const auto& sdr_diss_arr = (this->m_sdr_diss)(lev).array(mfi);
+            const auto& f1_arr = (this->m_f1)(lev).array(mfi);
+            const auto& tke_lhs_arr = tke_lhs(lev).array(mfi);
+            const auto& sdr_lhs_arr = sdr_lhs(lev).array(mfi);
+
+            amrex::ParallelFor(
+                bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    amrex::Real gko =
+                        (gradK_arr(i, j, k, 0) * gradOmega_arr(i, j, k, 0) +
+                         gradK_arr(i, j, k, 1) * gradOmega_arr(i, j, k, 1) +
+                         gradK_arr(i, j, k, 2) * gradOmega_arr(i, j, k, 2));
+
+                    amrex::Real cdkomega = amrex::max(
+                        1e-10, 2.0 * rho_arr(i, j, k) * sigma_omega2 * gko /
+                                   (sdr_arr(i, j, k) + 1e-15));
+
+                    amrex::Real tmp1 =
+                        4.0 * rho_arr(i, j, k) * sigma_omega2 *
+                        tke_arr(i, j, k) /
+                        (cdkomega * wd_arr(i, j, k) * wd_arr(i, j, k));
+                    amrex::Real tmp2 =
+                        std::sqrt(tke_arr(i, j, k)) /
+                        (beta_star * sdr_arr(i, j, k) * wd_arr(i, j, k) +
+                         1e-15);
+                    amrex::Real tmp3 =
+                        500.0 * lam_mu_arr(i, j, k) /
+                        (wd_arr(i, j, k) * wd_arr(i, j, k) * sdr_arr(i, j, k) *
+                             rho_arr(i, j, k) +
+                         1e-15);
+                    amrex::Real tmp4 = shear_prod_arr(i, j, k);
+
+                    amrex::Real arg1 = amrex::min(amrex::max(tmp2, tmp3), tmp1);
+                    amrex::Real tmp_f1 = std::tanh(arg1 * arg1 * arg1 * arg1);
+
+                    amrex::Real alpha = tmp_f1 * (alpha1 - alpha2) + alpha2;
+                    amrex::Real beta = tmp_f1 * (beta1 - beta2) + beta2;
+
+                    amrex::Real arg2 = amrex::max(2.0 * tmp2, tmp3);
+                    amrex::Real f2 = std::tanh(arg2 * arg2);
+
+                    mu_arr(i, j, k) =
+                        rho_arr(i, j, k) * a1 * tke_arr(i, j, k) /
+                        amrex::max(a1 * sdr_arr(i, j, k), tmp4 * f2);
+
+                    f1_arr(i, j, k) = tmp_f1;
+
+                    diss_arr(i, j, k) = -beta_star * rho_arr(i, j, k) *
+                                        tke_arr(i, j, k) * sdr_arr(i, j, k);
+                    tke_lhs_arr(i, j, k) = 0.5 * beta_star * rho_arr(i, j, k) *
+                                           sdr_arr(i, j, k) * deltaT;
+
+                    shear_prod_arr(i, j, k) = amrex::min(
+                        mu_arr(i, j, k) * tmp4 * tmp4,
+                        10.0 * beta_star * rho_arr(i, j, k) * tke_arr(i, j, k) *
+                            sdr_arr(i, j, k));
+
+                    sdr_lhs_arr(i, j, k) = 0.5 * rho_arr(i, j, k) * beta *
+                                           sdr_arr(i, j, k) * deltaT;
+                    sdr_src_arr(i, j, k) =
+                        rho_arr(i, j, k) * alpha * shear_prod_arr(i, j, k) /
+                            amrex::max(mu_arr(i, j, k), 1.0e-16) +
+                        (1.0 - tmp_f1) * cdkomega;
+                    sdr_diss_arr(i, j, k) = -rho_arr(i, j, k) * beta *
+                                            sdr_arr(i, j, k) * sdr_arr(i, j, k);
+                });
+        }
+    }
+
+    mu_turb.fillpatch(this->m_sim.time().current_time());
+}
+
+template <typename Transport>
+void KOmegaSSTABL<Transport>::update_scalar_diff(
+    Field& deff, const std::string& name)
+{
+
+    BL_PROFILE("amr-wind::" + this->identifier() + "::update_scalar_diff");
+
+    auto lam_mu = (this->m_transport).mu();
+    const auto& mu_turb = this->mu_turb();
+
+    if (name == pde::TKE::var_name()) {
+        const amrex::Real sigma_k1 = this->m_sigma_k1;
+        const amrex::Real sigma_k2 = this->m_sigma_k2;
+        auto& repo = deff.repo();
+        const int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            for (amrex::MFIter mfi(deff(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& lam_mu_arr = (*lam_mu)(lev).array(mfi);
+                const auto& mu_arr = mu_turb(lev).array(mfi);
+                const auto& f1_arr = (this->m_f1)(lev).array(mfi);
+                const auto& deff_arr = deff(lev).array(mfi);
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        deff_arr(i, j, k) =
+                            lam_mu_arr(i, j, k) +
+                            (f1_arr(i, j, k) * (sigma_k1 - sigma_k2) +
+                             sigma_k2) *
+                                mu_arr(i, j, k);
+                    });
+            }
+        }
+
+    } else if (name == pde::SDR::var_name()) {
+        const amrex::Real sigma_omega1 = this->m_sigma_omega1;
+        const amrex::Real sigma_omega2 = this->m_sigma_omega2;
+        auto& repo = deff.repo();
+        const int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            for (amrex::MFIter mfi(deff(lev)); mfi.isValid(); ++mfi) {
+                const auto& bx = mfi.tilebox();
+                const auto& lam_mu_arr = (*lam_mu)(lev).array(mfi);
+                const auto& mu_arr = mu_turb(lev).array(mfi);
+                const auto& f1_arr = (this->m_f1)(lev).array(mfi);
+                const auto& deff_arr = deff(lev).array(mfi);
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        deff_arr(i, j, k) =
+                            lam_mu_arr(i, j, k) +
+                            (f1_arr(i, j, k) * (sigma_omega1 - sigma_omega2) +
+                             sigma_omega2) *
+                                mu_arr(i, j, k);
+                    });
+            }
+        }
+    } else {
+        amrex::Abort(
+            "KOmegaSSTABL:update_scalar_diff not implemented for field "+name);
+    }
+}
+
+} // namespace turbulence
+
+INSTANTIATE_TURBULENCE_MODEL(KOmegaSSTABL);
+
+} // namespace amr_wind

--- a/amr-wind/turbulence/RANS/KOmegaSSTABL.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTABL.cpp
@@ -17,8 +17,7 @@ template <typename Transport>
 KOmegaSSTABL<Transport>::~KOmegaSSTABL() = default;
 
 template <typename Transport>
-KOmegaSSTABL<Transport>::KOmegaSSTABL(CFDSim& sim)
-    : KOmegaSST<Transport>(sim)
+KOmegaSSTABL<Transport>::KOmegaSSTABL(CFDSim& sim): KOmegaSST<Transport>(sim)
 {
 
     {
@@ -26,7 +25,6 @@ KOmegaSSTABL<Transport>::KOmegaSSTABL(CFDSim& sim)
         amrex::ParmParse pp(coeffs_dict);
     }
 }
-
 
 template <typename Transport>
 TurbulenceModel::CoeffsDictType KOmegaSSTABL<Transport>::model_coeffs() const
@@ -46,7 +44,7 @@ TurbulenceModel::CoeffsDictType KOmegaSSTABL<Transport>::model_coeffs() const
 
 template <typename Transport>
 void KOmegaSSTABL<Transport>::update_turbulent_viscosity(
-			      const FieldState fstate)
+    const FieldState fstate)
 {
     BL_PROFILE(
         "amr-wind::" + this->identifier() + "::update_turbulent_viscosity");
@@ -227,7 +225,8 @@ void KOmegaSSTABL<Transport>::update_scalar_diff(
         }
     } else {
         amrex::Abort(
-            "KOmegaSSTABL:update_scalar_diff not implemented for field "+name);
+            "KOmegaSSTABL:update_scalar_diff not implemented for field " + 
+            name);
     }
 }
 

--- a/amr-wind/wind_energy/ABL.H
+++ b/amr-wind/wind_energy/ABL.H
@@ -95,6 +95,7 @@ private:
     Field* m_temperature{nullptr};
     Field* m_tke{nullptr};
     Field* m_sdr{nullptr};
+    Field* m_eps{nullptr};
 
     ABLWallFunction m_abl_wall_func;
 

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -108,12 +108,15 @@ void ABL::post_init_actions()
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
     (*m_temperature).register_custom_bc<ABLTempWallFunc>(m_abl_wall_func);
 
-    // Register wall functions for TKE and SDR
+    // Register wall functions for TKE, EPS, and SDR variables
     if (m_sim.repo().field_exists("tke")) {
       (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
     }
     if (m_sim.repo().field_exists("sdr")) {
       (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
+    }
+    if (m_sim.repo().field_exists("eps")) {
+      (*m_eps).register_custom_bc<ABLEpsWallFunc>(m_abl_wall_func);
     }
 
     m_bndry_plane->post_init_actions();

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -82,6 +82,12 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
         m_field_init->init_sdr(level, geom, sdr);
     }
 
+    if (m_sim.repo().field_exists("eps")) {
+        m_eps = &(m_sim.repo().get_field("eps"));
+        auto& eps = (*m_eps)(level);
+        m_field_init->init_eps(level, geom, eps);
+    }
+
 }
 
 void ABL::post_init_actions()

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -102,6 +102,10 @@ void ABL::post_init_actions()
     m_velocity.register_custom_bc<ABLVelWallFunc>(m_abl_wall_func);
     (*m_temperature).register_custom_bc<ABLTempWallFunc>(m_abl_wall_func);
 
+    // Register wall functions for TKE and SDR
+    (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
+    (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
+
     m_bndry_plane->post_init_actions();
 }
 

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -103,8 +103,12 @@ void ABL::post_init_actions()
     (*m_temperature).register_custom_bc<ABLTempWallFunc>(m_abl_wall_func);
 
     // Register wall functions for TKE and SDR
-    (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
-    (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
+    if (m_sim.repo().field_exists("tke")) {
+      (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
+    }
+    if (m_sim.repo().field_exists("sdr")) {
+      (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
+    }
 
     m_bndry_plane->post_init_actions();
 }

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -37,7 +37,7 @@ ABL::ABL(CFDSim& sim)
     }
 
     // Instantiate the ABL field initializer
-    m_field_init = std::make_unique<ABLFieldInit>();
+    m_field_init = std::make_unique<ABLFieldInit>(sim);
 
     // Instantiate the ABL boundary plane IO
     m_bndry_plane = std::make_unique<ABLBoundaryPlane>(sim);
@@ -66,15 +66,22 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
         const auto& vbx = mfi.validbox();
 
         (*m_field_init)(
-            vbx, geom, velocity.array(mfi), density.array(mfi),
+	    level, mfi, vbx, geom, velocity.array(mfi), density.array(mfi),
             temp.array(mfi));
     }
 
     if (m_sim.repo().field_exists("tke")) {
         m_tke = &(m_sim.repo().get_field("tke"));
         auto& tke = (*m_tke)(level);
-        m_field_init->init_tke(geom, tke);
+        m_field_init->init_tke(level, geom, tke);
     }
+
+    if (m_sim.repo().field_exists("sdr")) {
+        m_sdr = &(m_sim.repo().get_field("sdr"));
+        auto& sdr = (*m_sdr)(level);
+        m_field_init->init_sdr(level, geom, sdr);
+    }
+
 }
 
 void ABL::post_init_actions()

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -66,7 +66,7 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
         const auto& vbx = mfi.validbox();
 
         (*m_field_init)(
-	    level, mfi, vbx, geom, velocity.array(mfi), density.array(mfi),
+            level, mfi, vbx, geom, velocity.array(mfi), density.array(mfi),
             temp.array(mfi));
     }
 
@@ -87,7 +87,6 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
         auto& eps = (*m_eps)(level);
         m_field_init->init_eps(level, geom, eps);
     }
-
 }
 
 void ABL::post_init_actions()
@@ -110,13 +109,13 @@ void ABL::post_init_actions()
 
     // Register wall functions for TKE, EPS, and SDR variables
     if (m_sim.repo().field_exists("tke")) {
-      (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
+        (*m_tke).register_custom_bc<ABLTKEWallFunc>(m_abl_wall_func);
     }
     if (m_sim.repo().field_exists("sdr")) {
-      (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
+        (*m_sdr).register_custom_bc<ABLSDRWallFunc>(m_abl_wall_func);
     }
     if (m_sim.repo().field_exists("eps")) {
-      (*m_eps).register_custom_bc<ABLEpsWallFunc>(m_abl_wall_func);
+        (*m_eps).register_custom_bc<ABLEpsWallFunc>(m_abl_wall_func);
     }
 
     m_bndry_plane->post_init_actions();

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -2,6 +2,7 @@
 #define ABLFIELDINIT_H
 
 #include "amr-wind/core/Field.H"
+#include "amr-wind/CFDSim.H"
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -20,9 +21,11 @@ class ABLFieldInit
     static_assert(AMREX_SPACEDIM == 3, "ABL requires 3 dimensional mesh");
 
 public:
-    ABLFieldInit();
+    ABLFieldInit(CFDSim&);
 
     void operator()(
+	const int level,
+	const amrex::MFIter& mfi,
         const amrex::Box& vbx,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::Real>& velocity,
@@ -41,13 +44,19 @@ public:
     bool add_temperature_perturbations() const { return m_perturb_theta; }
 
     //! Initialize TKE field
-    void init_tke(const amrex::Geometry& geom, amrex::MultiFab& tke) const;
+    void init_tke(const int level,
+		  const amrex::Geometry& geom, 
+		  amrex::MultiFab& tke) const;
 
     //! Initialize SDR field
-    void init_sdr(const amrex::Geometry& geom, amrex::MultiFab& sdr) const;
+    void init_sdr(const int level,
+		  const amrex::Geometry& geom, 
+		  amrex::MultiFab& sdr) const;
 
     //! Initialize epsilon field
-    void init_eps(const amrex::Geometry& geom, amrex::MultiFab& sdr) const;
+    void init_eps(const int level,
+		  const amrex::Geometry& geom, 
+		  amrex::MultiFab& sdr) const;
 
 private:
     //! Initial velocity components
@@ -63,6 +72,9 @@ private:
     // Device copies of the above arrays
     amrex::Gpu::DeviceVector<amrex::Real> m_thht_d;
     amrex::Gpu::DeviceVector<amrex::Real> m_thvv_d;
+
+    //! Non-uniform mesh coordinates (cell-center)
+    Field& m_nu_coord_cc;
 
     //! Initial density field
     amrex::Real m_rho;

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -43,6 +43,12 @@ public:
     //! Initialize TKE field
     void init_tke(const amrex::Geometry& geom, amrex::MultiFab& tke) const;
 
+    //! Initialize SDR field
+    void init_sdr(const amrex::Geometry& geom, amrex::MultiFab& sdr) const;
+
+    //! Initialize epsilon field
+    void init_eps(const amrex::Geometry& geom, amrex::MultiFab& sdr) const;
+
 private:
     //! Initial velocity components
     amrex::Vector<amrex::Real> m_vel;
@@ -90,6 +96,13 @@ private:
 
     //! Initial value for tke field
     amrex::Real m_tke_init{0.1};
+
+    //! Initial value for eps field
+    amrex::Real m_eps_init{0.1};
+
+    //! Initial value for sdr field
+    //! Default value set based on https://turbmodels.larc.nasa.gov/sst.html
+    amrex::Real m_sdr_init{25.0};
 
     //! Perturb initial velocity field with sinusoidal fluctuations
     bool m_perturb_vel{true};

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -24,8 +24,8 @@ public:
     ABLFieldInit(CFDSim&);
 
     void operator()(
-	const int level,
-	const amrex::MFIter& mfi,
+        const int level,
+        const amrex::MFIter& mfi,
         const amrex::Box& vbx,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::Real>& velocity,
@@ -44,19 +44,22 @@ public:
     bool add_temperature_perturbations() const { return m_perturb_theta; }
 
     //! Initialize TKE field
-    void init_tke(const int level,
-		  const amrex::Geometry& geom, 
-		  amrex::MultiFab& tke) const;
+    void init_tke(
+        const int level,
+        const amrex::Geometry& geom, 
+	amrex::MultiFab& tke) const;
 
     //! Initialize SDR field
-    void init_sdr(const int level,
-		  const amrex::Geometry& geom, 
-		  amrex::MultiFab& sdr) const;
+    void init_sdr(
+        const int level,
+        const amrex::Geometry& geom, 
+        amrex::MultiFab& sdr) const;
 
     //! Initialize epsilon field
-    void init_eps(const int level,
-		  const amrex::Geometry& geom, 
-		  amrex::MultiFab& sdr) const;
+    void init_eps(
+        const int level,
+        const amrex::Geometry& geom, 
+        amrex::MultiFab& sdr) const;
 
 private:
     const FieldRepo& m_repo;

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -59,6 +59,8 @@ public:
 		  amrex::MultiFab& sdr) const;
 
 private:
+    const FieldRepo& m_repo;
+
     //! Initial velocity components
     amrex::Vector<amrex::Real> m_vel;
 
@@ -73,8 +75,8 @@ private:
     amrex::Gpu::DeviceVector<amrex::Real> m_thht_d;
     amrex::Gpu::DeviceVector<amrex::Real> m_thvv_d;
 
-    //! Non-uniform mesh coordinates (cell-center)
-    Field& m_nu_coord_cc;
+    //! Using mesh mapping field or not
+    bool m_mesh_mapping{false};
 
     //! Initial density field
     amrex::Real m_rho;

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -32,6 +32,10 @@ ABLFieldInit::ABLFieldInit()
 
     pp_abl.query("init_tke", m_tke_init);
 
+    pp_abl.query("initial_sdr_value", m_sdr_init);
+
+    pp_abl.query("init_eps", m_eps_init);
+
     // TODO: Modify this to accept velocity as a function of height
     // Extract velocity field from incflo
     amrex::ParmParse pp_incflo("incflo");
@@ -158,6 +162,22 @@ void ABLFieldInit::init_tke(
     const amrex::Geometry& /* geom */, amrex::MultiFab& tke) const
 {
     tke.setVal(m_tke_init, 1);
+}
+
+//! Initialize SDR field at the beginning of the simulation
+//! (applicable to K-Omega SST model)
+void ABLFieldInit::init_sdr(
+    const amrex::Geometry& /* geom */, amrex::MultiFab& sdr) const
+{
+    sdr.setVal(m_sdr_init, 1);
+}
+
+//! Initialize epsilon field at the beginning of the simulation
+//! (applicable to K-Epsilon model)
+void ABLFieldInit::init_eps(
+    const amrex::Geometry& /* geom */, amrex::MultiFab& eps) const
+{
+    eps.setVal(m_eps_init, 1);
 }
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -6,7 +6,8 @@
 
 namespace amr_wind {
 
-ABLFieldInit::ABLFieldInit()
+ABLFieldInit::ABLFieldInit(CFDSim& sim)
+: m_nu_coord_cc(sim.repo().get_field("non_uniform_coord_cc"))
 {
     amrex::ParmParse pp_abl("ABL");
 
@@ -54,6 +55,8 @@ ABLFieldInit::ABLFieldInit()
 }
 
 void ABLFieldInit::operator()(
+    const int level,
+    const amrex::MFIter& mfi,
     const amrex::Box& vbx,
     const amrex::Geometry& geom,
     const amrex::Array4<amrex::Real>& velocity,
@@ -79,11 +82,13 @@ void ABLFieldInit::operator()(
     const int ntvals = m_theta_heights.size();
     const amrex::Real* th = m_thht_d.data();
     const amrex::Real* tv = m_thvv_d.data();
+    auto& nu_coord_cc     = m_nu_coord_cc(level);
+    const auto& nu_cc     = nu_coord_cc.array(mfi);
 
     amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
-        const amrex::Real y = problo[1] + (j + 0.5) * dx[1];
-        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+	const amrex::Real x = nu_cc(i, j, k, 0);
+	const amrex::Real y = nu_cc(i, j, k, 1);
+	const amrex::Real z = nu_cc(i, j, k, 2);
 
         density(i, j, k) = rho_init;
         // Mean velocity field
@@ -142,12 +147,14 @@ void ABLFieldInit::perturb_temperature(
          ++mfi) {
         const auto& bx = mfi.tilebox();
         const auto& theta = theta_fab.array(mfi);
+	const auto& nu_cc = m_nu_coord_cc(lev).array(mfi);
 
         amrex::ParallelForRNG(
             bx, [=] AMREX_GPU_DEVICE(
                     int i, int j, int k,
                     const amrex::RandomEngine& engine) noexcept {
-                const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+		const amrex::Real z = nu_cc(i, j, k, 2);
+
                 if (z < theta_cutoff_height) {
                     theta(i, j, k) =
                         deltaT * amrex::RandomNormal(
@@ -159,6 +166,7 @@ void ABLFieldInit::perturb_temperature(
 
 //! Initialize sfs tke field at the beginning of the simulation
 void ABLFieldInit::init_tke(
+    const int level,
     const amrex::Geometry& /* geom */, amrex::MultiFab& tke) const
 {
     tke.setVal(m_tke_init, 1);
@@ -167,7 +175,9 @@ void ABLFieldInit::init_tke(
 //! Initialize SDR field at the beginning of the simulation
 //! (applicable to K-Omega SST model)
 void ABLFieldInit::init_sdr(
-    const amrex::Geometry& /* geom */, amrex::MultiFab& sdr) const
+    const int level,
+    const amrex::Geometry& /* geom */, 
+    amrex::MultiFab& sdr) const
 {
     sdr.setVal(m_sdr_init, 1);
 }
@@ -175,7 +185,9 @@ void ABLFieldInit::init_sdr(
 //! Initialize epsilon field at the beginning of the simulation
 //! (applicable to K-Epsilon model)
 void ABLFieldInit::init_eps(
-    const amrex::Geometry& /* geom */, amrex::MultiFab& eps) const
+    const int level,
+    const amrex::Geometry& /* geom */, 
+    amrex::MultiFab& eps) const
 {
     eps.setVal(m_eps_init, 1);
 }

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -7,9 +7,7 @@
 namespace amr_wind {
 
 ABLFieldInit::ABLFieldInit(CFDSim& sim)
-: m_repo(sim.repo())
-, m_mesh_mapping(sim.has_mesh_mapping())
-  //m_nu_coord_cc(sim.repo().get_field("non_uniform_coord_cc"))
+    : m_repo(sim.repo()), m_mesh_mapping(sim.has_mesh_mapping())
 {
     amrex::ParmParse pp_abl("ABL");
 
@@ -93,12 +91,12 @@ void ABLFieldInit::operator()(
                        : amrex::Array4<amrex::Real const>();
 
     amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-	const amrex::Real x = m_mesh_mapping ? nu_cc(i, j, k, 0)
-	                                     : problo[0] + (i + 0.5) * dx[0];
-	const amrex::Real y = m_mesh_mapping ? nu_cc(i, j, k, 1)
-	                                     : problo[1] + (j + 0.5) * dx[1];
-	const amrex::Real z = m_mesh_mapping ? nu_cc(i, j, k, 2)
-	                                     : problo[2] + (k + 0.5) * dx[2];
+	const amrex::Real x = 
+            m_mesh_mapping ? nu_cc(i, j, k, 0) : problo[0] + (i + 0.5) * dx[0];
+	const amrex::Real y = 
+            m_mesh_mapping ? nu_cc(i, j, k, 1) : problo[1] + (j + 0.5) * dx[1];
+	const amrex::Real z = 
+            m_mesh_mapping ? nu_cc(i, j, k, 2) : problo[2] + (k + 0.5) * dx[2];
 
         density(i, j, k) = rho_init;
         // Mean velocity field
@@ -150,8 +148,7 @@ void ABLFieldInit::perturb_temperature(
     const auto theta_gauss_var = m_theta_gauss_var;
     const auto deltaT = m_deltaT;
     Field const* nu_coord_cc =
-      m_mesh_mapping ? &(m_repo.get_field("non_uniform_coord_cc")) 
-                     : nullptr;
+        m_mesh_mapping ? &(m_repo.get_field("non_uniform_coord_cc")) : nullptr;
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -160,15 +157,16 @@ void ABLFieldInit::perturb_temperature(
          ++mfi) {
         const auto& bx = mfi.tilebox();
         const auto& theta = theta_fab.array(mfi);
-	amrex::Array4<amrex::Real const> nu_cc =
-	  m_mesh_mapping ? ((*nu_coord_cc)(lev).array(mfi))
-                         : amrex::Array4<amrex::Real const>();
+        amrex::Array4<amrex::Real const> nu_cc =
+            m_mesh_mapping ? ((*nu_coord_cc)(lev).array(mfi))
+                           : amrex::Array4<amrex::Real const>();
         amrex::ParallelForRNG(
             bx, [=] AMREX_GPU_DEVICE(
                     int i, int j, int k,
                     const amrex::RandomEngine& engine) noexcept {
-        	const amrex::Real z = m_mesh_mapping ? nu_cc(i, j, k, 2)
-	                              : problo[2] + (k + 0.5) * dx[2];
+                const amrex::Real z = m_mesh_mapping 
+                                          ? nu_cc(i, j, k, 2)
+                                          : problo[2] + (k + 0.5) * dx[2];
 
                 if (z < theta_cutoff_height) {
                     theta(i, j, k) =
@@ -182,7 +180,8 @@ void ABLFieldInit::perturb_temperature(
 //! Initialize sfs tke field at the beginning of the simulation
 void ABLFieldInit::init_tke(
     const int /* level */,
-    const amrex::Geometry& /* geom */, amrex::MultiFab& tke) const
+    const amrex::Geometry& /* geom */,
+    amrex::MultiFab& tke) const
 {
     tke.setVal(m_tke_init, 1);
 }
@@ -191,7 +190,7 @@ void ABLFieldInit::init_tke(
 //! (applicable to K-Omega SST model)
 void ABLFieldInit::init_sdr(
     const int /* level */,
-    const amrex::Geometry& /* geom */, 
+    const amrex::Geometry& /* geom */,
     amrex::MultiFab& sdr) const
 {
     sdr.setVal(m_sdr_init, 1);
@@ -201,7 +200,7 @@ void ABLFieldInit::init_sdr(
 //! (applicable to K-Epsilon model)
 void ABLFieldInit::init_eps(
     const int /* level */,
-    const amrex::Geometry& /* geom */, 
+    const amrex::Geometry& /* geom */,
     amrex::MultiFab& eps) const
 {
     eps.setVal(m_eps_init, 1);

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -5,6 +5,7 @@
 #include "amr-wind/utilities/FieldPlaneAveraging.H"
 #include "amr-wind/core/FieldBCOps.H"
 #include "amr-wind/wind_energy/MOData.H"
+#include "amr-wind/turbulence/TurbulenceModel.H"
 
 namespace amr_wind {
 
@@ -35,6 +36,13 @@ public:
     //! Update the mean velocity at a given timestep
     void
     update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
+
+    //! Returns Cmu constant used in RANS ABL wall functions
+    amrex::Real Cmu() const { 
+      AMREX_ALWAYS_ASSERT(m_sim.turbulence_model().model_name() == "KOmegaSSTABL");
+      auto coeffs = m_sim.turbulence_model().model_coeffs();
+      return coeffs["beta_star"]; 
+    }
 
 private:
     const CFDSim& m_sim;

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -137,6 +137,22 @@ private:
     std::string m_wall_shear_stress_type{"alinot"};
 };
 
+class ABLEpsWallFunc : public FieldBCIface
+{
+public:
+    ABLEpsWallFunc(Field& eps, const ABLWallFunction& wall_fuc);
+
+    void operator()(Field& eps, const FieldState rho_state) override;
+
+    template <typename ShearStress>
+    void wall_model(
+        Field& eps, const FieldState rho_state, const ShearStress& tau);
+
+private:
+    const ABLWallFunction& m_wall_func;
+    std::string m_wall_shear_stress_type{"alinot"};
+};
+
 } // namespace amr_wind
 
 #endif /* ABLWALLFUNCTION_H */

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -110,7 +110,7 @@ public:
 
 private:
     const ABLWallFunction& m_wall_func;
-    std::string m_wall_shear_stress_type{"moeng"};
+    std::string m_wall_shear_stress_type{"alinot"};
 };
 
 class ABLSDRWallFunc : public FieldBCIface
@@ -126,7 +126,7 @@ public:
 
 private:
     const ABLWallFunction& m_wall_func;
-    std::string m_wall_shear_stress_type{"moeng"};
+    std::string m_wall_shear_stress_type{"alinot"};
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -97,6 +97,38 @@ private:
     std::string m_wall_shear_stress_type{"moeng"};
 };
 
+class ABLTKEWallFunc : public FieldBCIface
+{
+public:
+    ABLTKEWallFunc(Field& tke, const ABLWallFunction& wall_fuc);
+
+    void operator()(Field& tke, const FieldState rho_state) override;
+
+    template <typename ShearStress>
+    void wall_model(
+        Field& tke, const FieldState rho_state, const ShearStress& tau);
+
+private:
+    const ABLWallFunction& m_wall_func;
+    std::string m_wall_shear_stress_type{"moeng"};
+};
+
+class ABLSDRWallFunc : public FieldBCIface
+{
+public:
+    ABLSDRWallFunc(Field& sdr, const ABLWallFunction& wall_fuc);
+
+    void operator()(Field& sdr, const FieldState rho_state) override;
+
+    template <typename ShearStress>
+    void wall_model(
+        Field& sdr, const FieldState rho_state, const ShearStress& tau);
+
+private:
+    const ABLWallFunction& m_wall_func;
+    std::string m_wall_shear_stress_type{"moeng"};
+};
+
 } // namespace amr_wind
 
 #endif /* ABLWALLFUNCTION_H */

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -38,7 +38,7 @@ public:
     update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
 
     //! Returns Cmu constant used in RANS ABL wall functions
-    amrex::Real Cmu() const 
+    amrex::Real Cmu() const
     {
         AMREX_ALWAYS_ASSERT(
             m_sim.turbulence_model().model_name() == "KOmegaSSTABL");
@@ -118,7 +118,7 @@ public:
     void operator()(Field& tke, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void 
+    void
     wall_model(Field& tke, const FieldState rho_state, const ShearStress& tau);
 
 private:
@@ -134,7 +134,7 @@ public:
     void operator()(Field& sdr, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void 
+    void
     wall_model(Field& sdr, const FieldState rho_state, const ShearStress& tau);
 
 private:
@@ -150,7 +150,7 @@ public:
     void operator()(Field& eps, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void 
+    void
     wall_model(Field& eps, const FieldState rho_state, const ShearStress& tau);
 
 private:

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -38,10 +38,11 @@ public:
     update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
 
     //! Returns Cmu constant used in RANS ABL wall functions
-    amrex::Real Cmu() const { 
-      AMREX_ALWAYS_ASSERT(m_sim.turbulence_model().model_name() == "KOmegaSSTABL");
-      auto coeffs = m_sim.turbulence_model().model_coeffs();
-      return coeffs["beta_star"]; 
+    amrex::Real Cmu() const {
+        AMREX_ALWAYS_ASSERT(
+            m_sim.turbulence_model().model_name() == "KOmegaSSTABL");
+        auto coeffs = m_sim.turbulence_model().model_coeffs();
+        return coeffs["beta_star"]; 
     }
 
 private:
@@ -117,7 +118,7 @@ public:
 
     template <typename ShearStress>
     void wall_model(
-        Field& tke, const FieldState rho_state, const ShearStress& tau);
+    Field& tke, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;
@@ -133,7 +134,7 @@ public:
 
     template <typename ShearStress>
     void wall_model(
-        Field& sdr, const FieldState rho_state, const ShearStress& tau);
+    Field& sdr, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;
@@ -149,7 +150,7 @@ public:
 
     template <typename ShearStress>
     void wall_model(
-        Field& eps, const FieldState rho_state, const ShearStress& tau);
+    Field& eps, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -38,11 +38,12 @@ public:
     update_umean(const VelPlaneAveraging& vpa, const FieldPlaneAveraging& tpa);
 
     //! Returns Cmu constant used in RANS ABL wall functions
-    amrex::Real Cmu() const {
+    amrex::Real Cmu() const 
+    {
         AMREX_ALWAYS_ASSERT(
             m_sim.turbulence_model().model_name() == "KOmegaSSTABL");
         auto coeffs = m_sim.turbulence_model().model_coeffs();
-        return coeffs["beta_star"]; 
+        return coeffs["beta_star"];
     }
 
 private:
@@ -117,8 +118,8 @@ public:
     void operator()(Field& tke, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void wall_model(
-    Field& tke, const FieldState rho_state, const ShearStress& tau);
+    void 
+    wall_model(Field& tke, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;
@@ -133,8 +134,8 @@ public:
     void operator()(Field& sdr, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void wall_model(
-    Field& sdr, const FieldState rho_state, const ShearStress& tau);
+    void 
+    wall_model(Field& sdr, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;
@@ -149,8 +150,8 @@ public:
     void operator()(Field& eps, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void wall_model(
-    Field& eps, const FieldState rho_state, const ShearStress& tau);
+    void 
+    wall_model(Field& eps, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -48,6 +48,9 @@ private:
     const CFDSim& m_sim;
 
     const amrex::AmrCore& m_mesh;
+    const FieldRepo& m_repo;
+
+    bool m_mesh_mapping{false};
 
     //! Monin-Obukhov instance
     MOData m_mo;

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -379,4 +379,77 @@ void ABLTempWallFunc::operator()(Field& temperature, const FieldState rho_state)
     }
 }
 
+template <typename ShearStress>
+void ABLTKEWallFunc::wall_model(
+    Field& tke, const FieldState rho_state, const ShearStress& tau)
+{
+    constexpr int idim = 2;
+    auto& repo = tke.repo();
+
+    // TODO: FILL IN HERE
+}
+
+void ABLTKEWallFunc::operator()(Field& tke, const FieldState rho_state)
+{
+    const auto& mo = m_wall_func.mo();
+
+    if (m_wall_shear_stress_type == "moeng") {
+
+        auto tau = ShearStressMoeng(mo);
+        wall_model(tke, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "constant") {
+
+        auto tau = ShearStressConstant(mo);
+        wall_model(tke, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "local") {
+
+        auto tau = ShearStressLocal(mo);
+        wall_model(tke, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "schumann") {
+
+        auto tau = ShearStressSchumann(mo);
+        wall_model(tke, rho_state, tau);
+    }
+}
+
+template <typename ShearStress>
+void ABLSDRWallFunc::wall_model(
+    Field& sdr, const FieldState rho_state, const ShearStress& tau)
+{
+    constexpr int idim = 2;
+    auto& repo = sdr.repo();
+
+    // TODO: FILL IN HERE
+}
+
+void ABLSDRWallFunc::operator()(Field& sdr, const FieldState rho_state)
+{
+    const auto& mo = m_wall_func.mo();
+
+    if (m_wall_shear_stress_type == "moeng") {
+
+        auto tau = ShearStressMoeng(mo);
+        wall_model(sdr, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "constant") {
+
+        auto tau = ShearStressConstant(mo);
+        wall_model(sdr, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "local") {
+
+        auto tau = ShearStressLocal(mo);
+        wall_model(sdr, rho_state, tau);
+
+    } else if (m_wall_shear_stress_type == "schumann") {
+
+        auto tau = ShearStressSchumann(mo);
+        wall_model(sdr, rho_state, tau);
+    }
+}
+
+
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -87,7 +87,7 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
 
     m_mo.alg_type =
         m_tempflux ? MOData::HEAT_FLUX : MOData::SURFACE_TEMPERATURE;
-    m_mo.gravity = utils::vec_mag(m_gravity.data());
+    m_mo.gravity = utils::vec_mag(m_gravity.data());    
 }
 
 void ABLWallFunction::init_log_law_height()
@@ -470,9 +470,10 @@ void ABLTKEWallFunc::wall_model(
 void ABLTKEWallFunc::operator()(Field& tke, const FieldState rho_state)
 {
     const auto& mo = m_wall_func.mo();
+    amrex::Real Cmu = m_wall_func.Cmu();
 
     if (m_wall_shear_stress_type == "alinot") {
-        auto tau = ShearStressAlinot(mo);
+        auto tau = ShearStressAlinot(mo, Cmu);
         wall_model(tke, rho_state, tau);
     }
 }
@@ -540,9 +541,10 @@ void ABLSDRWallFunc::wall_model(
 void ABLSDRWallFunc::operator()(Field& sdr, const FieldState rho_state)
 {
     const auto& mo = m_wall_func.mo();
+    amrex::Real Cmu = m_wall_func.Cmu();
 
     if (m_wall_shear_stress_type == "alinot") {
-        auto tau = ShearStressAlinot(mo);
+        auto tau = ShearStressAlinot(mo, Cmu);
         wall_model(sdr, rho_state, tau);
     }
 }

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -405,12 +405,33 @@ void ABLTempWallFunc::operator()(Field& temperature, const FieldState rho_state)
     }
 }
 
+ABLTKEWallFunc::ABLTKEWallFunc(
+    Field& /*unused*/, const ABLWallFunction& wall_fuc)
+    : m_wall_func(wall_fuc)
+{
+    amrex::ParmParse pp("ABL");
+    pp.query("wall_shear_stress_type", m_wall_shear_stress_type);
+    m_wall_shear_stress_type = amrex::toLower(m_wall_shear_stress_type);
+}
+
+
 template <typename ShearStress>
 void ABLTKEWallFunc::wall_model(
     Field& tke, const FieldState rho_state, const ShearStress& tau)
 {
     constexpr int idim = 2;
     auto& repo = tke.repo();
+
+    // Return early if the user hasn't requested a wall model BC for tke
+    amrex::Orientation zlo(amrex::Direction::z, amrex::Orientation::low);
+    amrex::Orientation zhi(amrex::Direction::z, amrex::Orientation::high);
+
+    if (!(tke.bc_type()[zlo] == BC::wall_model ||
+          tke.bc_type()[zhi] == BC::wall_model)) {
+        return;
+    }
+
+    BL_PROFILE("amr-wind::ABLTKEWallFunc");
 
     // TODO: FILL IN HERE
 }
@@ -441,12 +462,32 @@ void ABLTKEWallFunc::operator()(Field& tke, const FieldState rho_state)
     }
 }
 
+ABLSDRWallFunc::ABLSDRWallFunc(
+    Field& /*unused*/, const ABLWallFunction& wall_fuc)
+    : m_wall_func(wall_fuc)
+{
+    amrex::ParmParse pp("ABL");
+    pp.query("wall_shear_stress_type", m_wall_shear_stress_type);
+    m_wall_shear_stress_type = amrex::toLower(m_wall_shear_stress_type);
+}
+
 template <typename ShearStress>
 void ABLSDRWallFunc::wall_model(
     Field& sdr, const FieldState rho_state, const ShearStress& tau)
 {
     constexpr int idim = 2;
     auto& repo = sdr.repo();
+
+    // Return early if the user hasn't requested a wall model BC for tke
+    amrex::Orientation zlo(amrex::Direction::z, amrex::Orientation::low);
+    amrex::Orientation zhi(amrex::Direction::z, amrex::Orientation::high);
+
+    if (!(sdr.bc_type()[zlo] == BC::wall_model ||
+          sdr.bc_type()[zhi] == BC::wall_model)) {
+        return;
+    }
+
+    BL_PROFILE("amr-wind::ABLSDRWallFunc");
 
     // TODO: FILL IN HERE
 }

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -434,17 +434,12 @@ void ABLTKEWallFunc::wall_model(
     }
 
     BL_PROFILE("amr-wind::ABLTKEWallFunc");
-    auto& velocity = repo.get_field("velocity");
-    const auto& density = repo.get_field("density", rho_state);
     const int nlevels = repo.num_active_levels();
 
     for (int lev = 0; lev < nlevels; ++lev) {
         const auto& geom = repo.mesh().Geom(lev);
         const auto& domain = geom.Domain();
         amrex::MFItInfo mfi_info{};
-	const auto& rho_lev = density(lev);
-        auto& vold_lev = velocity.state(FieldState::Old)(lev);
-	auto& kold_lev = tke.state(FieldState::Old)(lev);
         auto& k_tke    = tke(lev);
 
         if (amrex::Gpu::notInLaunchRegion()) {
@@ -455,23 +450,15 @@ void ABLTKEWallFunc::wall_model(
 #endif
 	for (amrex::MFIter mfi(k_tke, mfi_info); mfi.isValid(); ++mfi) {
             const auto& bx = mfi.validbox();
-            auto vold_arr = vold_lev.array(mfi);
-            auto kold_arr = kold_lev.array(mfi);
             auto karr     = k_tke.array(mfi);
-            auto den      = rho_lev.array(mfi);
 
             if (bx.smallEnd(idim) == domain.smallEnd(idim) &&
                 tke.bc_type()[zlo] == BC::wall_model) {
                 amrex::ParallelFor(
                     amrex::bdryLo(bx, idim),
                     [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real uu = vold_arr(i, j, k, 0);
-                        const amrex::Real vv = vold_arr(i, j, k, 1);
-                        const amrex::Real wspd = std::sqrt(uu * uu + vv * vv);
-                        const amrex::Real k2 = kold_arr(i, j, k);
 
-			// TODO: FILL IN TKE ENTRY HERE
-                        karr(i, j, k - 1) = 0.0;
+                        karr(i, j, k - 1) = tau.calc_tke();
                     });
             }
 	    // TODO: FILL IN ZHI TKE
@@ -484,24 +471,8 @@ void ABLTKEWallFunc::operator()(Field& tke, const FieldState rho_state)
 {
     const auto& mo = m_wall_func.mo();
 
-    if (m_wall_shear_stress_type == "moeng") {
-
-        auto tau = ShearStressMoeng(mo);
-        wall_model(tke, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "constant") {
-
-        auto tau = ShearStressConstant(mo);
-        wall_model(tke, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "local") {
-
-        auto tau = ShearStressLocal(mo);
-        wall_model(tke, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "schumann") {
-
-        auto tau = ShearStressSchumann(mo);
+    if (m_wall_shear_stress_type == "alinot") {
+        auto tau = ShearStressAlinot(mo);
         wall_model(tke, rho_state, tau);
     }
 }
@@ -534,17 +505,12 @@ void ABLSDRWallFunc::wall_model(
     }
 
     BL_PROFILE("amr-wind::ABLSDRWallFunc");
-    auto& velocity = repo.get_field("velocity");
-    const auto& density = repo.get_field("density", rho_state);
     const int nlevels = repo.num_active_levels();
 
     for (int lev = 0; lev < nlevels; ++lev) {
         const auto& geom = repo.mesh().Geom(lev);
         const auto& domain = geom.Domain();
         amrex::MFItInfo mfi_info{};
-	const auto& rho_lev = density(lev);
-        auto& vold_lev = velocity.state(FieldState::Old)(lev);
-	auto& sdrold_lev = sdr.state(FieldState::Old)(lev);
         auto& omega    = sdr(lev);
 
         if (amrex::Gpu::notInLaunchRegion()) {
@@ -555,23 +521,15 @@ void ABLSDRWallFunc::wall_model(
 #endif
 	for (amrex::MFIter mfi(omega, mfi_info); mfi.isValid(); ++mfi) {
             const auto& bx  = mfi.validbox();
-            auto vold_arr   = vold_lev.array(mfi);
-            auto sdrold_arr = sdrold_lev.array(mfi);
             auto omegaarr   = omega.array(mfi);
-            auto den        = rho_lev.array(mfi);
 	    
             if (bx.smallEnd(idim) == domain.smallEnd(idim) &&
                 sdr.bc_type()[zlo] == BC::wall_model) {
                 amrex::ParallelFor(
                     amrex::bdryLo(bx, idim),
                     [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real uu   = vold_arr(i, j, k, 0);
-                        const amrex::Real vv   = vold_arr(i, j, k, 1);
-                        const amrex::Real wspd = std::sqrt(uu * uu + vv * vv);
-                        const amrex::Real sdr2 = sdrold_arr(i, j, k);
 
-			// TODO: FILL IN OMEGA ENTRY HERE
-                        omegaarr(i, j, k - 1) = 0.0;
+		      omegaarr(i, j, k - 1) = tau.calc_omega();
                     });
             }
 	    // TODO: FILL IN SDR ZHI HERE
@@ -583,24 +541,8 @@ void ABLSDRWallFunc::operator()(Field& sdr, const FieldState rho_state)
 {
     const auto& mo = m_wall_func.mo();
 
-    if (m_wall_shear_stress_type == "moeng") {
-
-        auto tau = ShearStressMoeng(mo);
-        wall_model(sdr, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "constant") {
-
-        auto tau = ShearStressConstant(mo);
-        wall_model(sdr, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "local") {
-
-        auto tau = ShearStressLocal(mo);
-        wall_model(sdr, rho_state, tau);
-
-    } else if (m_wall_shear_stress_type == "schumann") {
-
-        auto tau = ShearStressSchumann(mo);
+    if (m_wall_shear_stress_type == "alinot") {
+        auto tau = ShearStressAlinot(mo);
         wall_model(sdr, rho_state, tau);
     }
 }

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -98,34 +98,34 @@ void ABLWallFunction::init_log_law_height()
     if (m_use_fch) {
         if (m_mesh_mapping) {
             // Average over all of the first cell center heights at level 0
-            const auto& velocity_f  = m_sim.repo().get_field("velocity");
-            const int level         = 0;
-            auto& velocity          = velocity_f(level);
+            const auto& velocity_f = m_sim.repo().get_field("velocity");
+            const int level = 0;
+            auto& velocity = velocity_f(level);
 
             Field const* nu_coord_cc =
                 &(m_repo.get_field("non_uniform_coord_cc"));
 
-            int npt=0;
-            amrex::Real avg_cc_height=0.0;
+            int npt = 0;
+            amrex::Real avg_cc_height = 0.0;
             // Loop through and sum over all points on the lower surface
-            for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {	
-                const auto& vbx   = mfi.validbox();
+            for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {
+                const auto& vbx = mfi.validbox();
                 amrex::Array4<amrex::Real const> nu_cc =
                     ((*nu_coord_cc)(level).array(mfi));
                 amrex::Loop(
-                    vbx, 
+                    vbx,
                     [=, &npt, &avg_cc_height](int i, int j, int k) noexcept {
-                        if (((m_direction==2) && (k==0)) ||
-                            ((m_direction==1) && (j==0)) ||
-                            ((m_direction==0) && (i==0))) {
+                        if (((m_direction == 2) && (k == 0)) ||
+                            ((m_direction == 1) && (j == 0)) ||
+                            ((m_direction == 0) && (i == 0))) {
                             avg_cc_height += nu_cc(i, j, k, m_direction);
                             npt++;
                         }
                     });
-	    }
+            }
             avg_cc_height = avg_cc_height / (amrex::Real)npt;
             m_mo.zref = avg_cc_height;
-	} else {
+        } else {
             // Use the first cell center height for zref
             const auto& geom = m_mesh.Geom(0);
             m_mo.zref =
@@ -424,7 +424,6 @@ ABLTKEWallFunc::ABLTKEWallFunc(
     amrex::Print() << "TKE model: " << m_wall_shear_stress_type << std::endl;
 }
 
-
 template <typename ShearStress>
 void ABLTKEWallFunc::wall_model(
     Field& tke, const FieldState /*unused*/, const ShearStress& tau)
@@ -469,7 +468,7 @@ void ABLTKEWallFunc::wall_model(
                     });
             }
             // TODO: FILL IN ZHI TKE
-	}
+        }
     }
 }
 
@@ -537,7 +536,7 @@ void ABLSDRWallFunc::wall_model(
                         omegaarr(i, j, k - 1) = tau.calc_omega();
                 });
             }
-            // TODO: FILL IN SDR ZHI HERE
+        // TODO: FILL IN SDR ZHI HERE
         }
     }
 }

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -14,7 +14,8 @@
 namespace amr_wind {
 
 ABLWallFunction::ABLWallFunction(const CFDSim& sim)
-    : m_sim(sim), m_mesh(sim.mesh())
+  : m_sim(sim), m_mesh(sim.mesh())
+  , m_repo(sim.repo()), m_mesh_mapping(sim.has_mesh_mapping())
 {
     amrex::ParmParse pp("ABL");
 
@@ -93,35 +94,40 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
 void ABLWallFunction::init_log_law_height()
 {
     if (m_use_fch) {
-        const auto& nu_coord_cc = m_sim.repo().get_field("non_uniform_coord_cc");
-        const auto& velocity_f  = m_sim.repo().get_field("velocity");
-	const int level         = 0;
-	auto& nu_coord_cc_lev   = nu_coord_cc(level);
-	auto& velocity          = velocity_f(level);
+        if (m_mesh_mapping) {
+	    // Average over all of the first cell center heights at level 0
+	    const auto& velocity_f  = m_sim.repo().get_field("velocity");
+	    const int level         = 0;
+	    auto& velocity          = velocity_f(level);
 
-	int npt=0;
-	amrex::Real avg_cc_height=0.0;
-	// Loop through and sum over all points on the lower surface
-	for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {	
-	  const auto& vbx   = mfi.validbox();
-	  const auto& nu_cc = nu_coord_cc_lev.array(mfi);
-	  amrex::Loop(vbx, [=, &npt, &avg_cc_height](int i, int j, int k) noexcept {
-	      if (((m_direction==2) && (k==0)) ||
-		  ((m_direction==1) && (j==0)) ||
-		  ((m_direction==0) && (i==0))) {
-			avg_cc_height += nu_cc(i, j, k, m_direction);
+	    Field const* nu_coord_cc =
+	        &(m_repo.get_field("non_uniform_coord_cc"));
+
+	    int npt=0;
+	    amrex::Real avg_cc_height=0.0;
+	    // Loop through and sum over all points on the lower surface
+	    for (amrex::MFIter mfi(velocity); mfi.isValid(); ++mfi) {	
+	        const auto& vbx   = mfi.validbox();
+		amrex::Array4<amrex::Real const> nu_cc =
+		  ((*nu_coord_cc)(level).array(mfi));
+		amrex::Loop(vbx, [=, &npt, &avg_cc_height](int i, int j, int k) noexcept {
+		    if (((m_direction==2) && (k==0)) ||
+			((m_direction==1) && (j==0)) ||
+			((m_direction==0) && (i==0))) {
+		        avg_cc_height += nu_cc(i, j, k, m_direction);
 			npt++;
-	      }
-	    });
+		    }
+		  });
 	  
+	    }
+	    avg_cc_height = avg_cc_height/(amrex::Real)npt;
+	    m_mo.zref = avg_cc_height;
+	} else {
+	    // Use the first cell center height for zref
+	    const auto& geom = m_mesh.Geom(0);
+	    m_mo.zref =
+                (geom.ProbLo(m_direction) + 0.5 * geom.CellSize(m_direction));
 	}
-	avg_cc_height = avg_cc_height/(amrex::Real)npt;
-	m_mo.zref = avg_cc_height;
-
-	// -- DELETE THIS AFTER VERIFICATION --
-        // const auto& geom = m_mesh.Geom(0);
-        // m_mo.zref =
-        //     (geom.ProbLo(m_direction) + 0.5 * geom.CellSize(m_direction));
     }
 }
 

--- a/amr-wind/wind_energy/MOData.H
+++ b/amr-wind/wind_energy/MOData.H
@@ -69,6 +69,32 @@ struct MOData
     amrex::Real calc_psi_m(amrex::Real zeta) const;
     amrex::Real calc_psi_h(amrex::Real zeta) const;
     void update_fluxes(int max_iters = 25);
+
+    // The following are used for the RANS ABL k-omega/k-epsilon model
+    amrex::Real calc_phi_m_alinot(amrex::Real zeta) const;
+    amrex::Real calc_phi_eps_alinot(amrex::Real zeta) const;
+
+    amrex::Real phi_m_alinot() const
+    {
+        return calc_phi_m_alinot(zref / obukhov_len);
+    }
+
+    amrex::Real phi_m_alinot(amrex::Real z) const
+    {
+        return calc_phi_m_alinot(z / obukhov_len);
+    }
+
+    amrex::Real phi_eps_alinot() const
+    {
+        return calc_phi_eps_alinot(zref / obukhov_len);
+    }
+
+    amrex::Real phi_eps_alinot(amrex::Real z) const
+    {
+        return calc_phi_eps_alinot(z / obukhov_len);
+    }
+
+
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/MOData.H
+++ b/amr-wind/wind_energy/MOData.H
@@ -93,8 +93,6 @@ struct MOData
     {
         return calc_phi_eps_alinot(z / obukhov_len);
     }
-
-
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -87,4 +87,30 @@ void MOData::update_fluxes(int max_iters)
     }
 }
 
+
+/*
+ * See the reference at 
+ * 
+ * Alinot, C., & Masson, C. (2005). k-Epsilon Model for the
+ * Atmospheric Boundary Layer Under Various Thermal
+ * Stratifications. Journal of Solar Energy Engineering, 127(4),
+ * 438-443. doi:10.1115/1.2035704
+ */
+amrex::Real MOData::calc_phi_m_alinot(amrex::Real zeta) const
+{
+    if (zeta > 0) {
+        return 1.0 + gamma_m * zeta;
+    }
+    amrex::Real x = std::sqrt(std::sqrt(1 - beta_m * zeta));
+    return 1.0/x;
+}
+
+amrex::Real MOData::calc_phi_eps_alinot(amrex::Real zeta) const
+{
+    if (zeta > 0) {
+      return calc_phi_m_alinot(zeta) - zeta;
+    }  
+    return 1.0 - zeta;
+}
+
 } // namespace amr_wind

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -89,8 +89,8 @@ void MOData::update_fluxes(int max_iters)
 
 
 /*
- * See the reference at 
- * 
+ * See the reference at
+ *
  * Alinot, C., & Masson, C. (2005). k-Epsilon Model for the
  * Atmospheric Boundary Layer Under Various Thermal
  * Stratifications. Journal of Solar Energy Engineering, 127(4),
@@ -102,14 +102,14 @@ amrex::Real MOData::calc_phi_m_alinot(amrex::Real zeta) const
         return 1.0 + gamma_m * zeta;
     }
     amrex::Real x = std::sqrt(std::sqrt(1 - beta_m * zeta));
-    return 1.0/x;
+    return 1.0 / x;
 }
 
 amrex::Real MOData::calc_phi_eps_alinot(amrex::Real zeta) const
 {
     if (zeta > 0) {
-      return calc_phi_m_alinot(zeta) - zeta;
-    }  
+        return calc_phi_m_alinot(zeta) - zeta;
+    }
     return 1.0 - zeta;
 }
 

--- a/amr-wind/wind_energy/MOData.cpp
+++ b/amr-wind/wind_energy/MOData.cpp
@@ -87,7 +87,6 @@ void MOData::update_fluxes(int max_iters)
     }
 }
 
-
 /*
  * See the reference at
  *

--- a/amr-wind/wind_energy/ShearStress.H
+++ b/amr-wind/wind_energy/ShearStress.H
@@ -161,4 +161,40 @@ struct ShearStressMoeng
     amrex::Real term1;
 };
 
+struct ShearStressAlinot
+{
+    explicit ShearStressAlinot(const amr_wind::MOData& mo)
+      : zref(mo.zref),
+	kappa(mo.kappa),
+	utau(mo.utau),
+	phi_m(mo.phi_m_alinot()),
+	phi_e(mo.phi_eps_alinot())
+    {}
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+    calc_eps() const
+    {
+        return utau*utau*utau/kappa/zref*phi_e;
+    };
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+    calc_tke() const
+    {
+        return std::sqrt((kappa*utau*zref*calc_eps())/(Cmu*phi_m));
+    };
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+    calc_omega() const
+    {
+        return calc_eps()/Cmu/calc_tke();
+    };
+
+    amrex::Real zref;
+    amrex::Real kappa;
+    amrex::Real utau;
+    amrex::Real phi_m;
+    amrex::Real phi_e;
+    amrex::Real Cmu = 1.0/5.48/5.48;
+
+};
 #endif /* ShearStress_H */

--- a/amr-wind/wind_energy/ShearStress.H
+++ b/amr-wind/wind_energy/ShearStress.H
@@ -163,12 +163,14 @@ struct ShearStressMoeng
 
 struct ShearStressAlinot
 {
-    explicit ShearStressAlinot(const amr_wind::MOData& mo)
+    explicit ShearStressAlinot(const amr_wind::MOData& mo, 
+			       const amrex::Real Cmu)
       : zref(mo.zref),
 	kappa(mo.kappa),
 	utau(mo.utau),
 	phi_m(mo.phi_m_alinot()),
-	phi_e(mo.phi_eps_alinot())
+	phi_e(mo.phi_eps_alinot()),
+	m_Cmu(Cmu)
     {}
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
@@ -180,13 +182,13 @@ struct ShearStressAlinot
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
     calc_tke() const
     {
-        return std::sqrt((kappa*utau*zref*calc_eps())/(Cmu*phi_m));
+        return std::sqrt((kappa*utau*zref*calc_eps())/(m_Cmu*phi_m));
     };
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
     calc_omega() const
     {
-        return calc_eps()/Cmu/calc_tke();
+        return calc_eps()/m_Cmu/calc_tke();
     };
 
     amrex::Real zref;
@@ -194,7 +196,7 @@ struct ShearStressAlinot
     amrex::Real utau;
     amrex::Real phi_m;
     amrex::Real phi_e;
-    amrex::Real Cmu = 1.0/5.48/5.48;
+    amrex::Real m_Cmu = 1.0/5.48/5.48;
 
 };
 #endif /* ShearStress_H */

--- a/amr-wind/wind_energy/ShearStress.H
+++ b/amr-wind/wind_energy/ShearStress.H
@@ -163,8 +163,8 @@ struct ShearStressMoeng
 
 struct ShearStressAlinot
 {
-    explicit ShearStressAlinot(const amr_wind::MOData& mo,
-        const amrex::Real Cmu)
+    explicit ShearStressAlinot(
+        const amr_wind::MOData& mo, const amrex::Real Cmu)
         : zref(mo.zref)
         , kappa(mo.kappa)
         , utau(mo.utau)
@@ -194,6 +194,5 @@ struct ShearStressAlinot
     amrex::Real phi_m;
     amrex::Real phi_e;
     amrex::Real m_Cmu = 1.0 / 5.48 / 5.48;
-
 };
 #endif /* ShearStress_H */

--- a/amr-wind/wind_energy/ShearStress.H
+++ b/amr-wind/wind_energy/ShearStress.H
@@ -163,32 +163,29 @@ struct ShearStressMoeng
 
 struct ShearStressAlinot
 {
-    explicit ShearStressAlinot(const amr_wind::MOData& mo, 
-			       const amrex::Real Cmu)
-      : zref(mo.zref),
-	kappa(mo.kappa),
-	utau(mo.utau),
-	phi_m(mo.phi_m_alinot()),
-	phi_e(mo.phi_eps_alinot()),
-	m_Cmu(Cmu)
+    explicit ShearStressAlinot(const amr_wind::MOData& mo,
+        const amrex::Real Cmu)
+        : zref(mo.zref)
+        , kappa(mo.kappa)
+        , utau(mo.utau)
+        , phi_m(mo.phi_m_alinot())
+        , phi_e(mo.phi_eps_alinot())
+        , m_Cmu(Cmu)
     {}
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-    calc_eps() const
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real calc_eps() const
     {
-        return utau*utau*utau/kappa/zref*phi_e;
+        return utau * utau * utau / kappa / zref * phi_e;
     };
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-    calc_tke() const
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real calc_tke() const
     {
-        return std::sqrt((kappa*utau*zref*calc_eps())/(m_Cmu*phi_m));
+        return std::sqrt((kappa * utau * zref * calc_eps()) / (m_Cmu * phi_m));
     };
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-    calc_omega() const
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real calc_omega() const
     {
-        return calc_eps()/m_Cmu/calc_tke();
+        return calc_eps() / m_Cmu / calc_tke();
     };
 
     amrex::Real zref;
@@ -196,7 +193,7 @@ struct ShearStressAlinot
     amrex::Real utau;
     amrex::Real phi_m;
     amrex::Real phi_e;
-    amrex::Real m_Cmu = 1.0/5.48/5.48;
+    amrex::Real m_Cmu = 1.0 / 5.48 / 5.48;
 
 };
 #endif /* ShearStress_H */

--- a/unit_tests/wind_energy/CMakeLists.txt
+++ b/unit_tests/wind_energy/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${amr_wind_unit_test_exe_name} PRIVATE
   # test cases
   test_abl_init.cpp
   test_abl_src.cpp
+  test_abl_meshmap.cpp
   )
 
 add_subdirectory(actuator)

--- a/unit_tests/wind_energy/test_abl_init.cpp
+++ b/unit_tests/wind_energy/test_abl_init.cpp
@@ -19,6 +19,11 @@ TEST_F(ABLMeshTest, abl_initialization)
     }
 
     initialize_mesh();
+    sim().activate_mesh_map();
+    for (int ilev = 0; ilev<mesh().num_levels(); ilev++) { 
+        // TODO: switch to run_algorithm()
+        sim().mesh_mapping()->create_map(ilev, mesh().Geom(ilev));
+    }
     auto& frepo = mesh().field_repo();
     auto& velocityf = frepo.declare_field("velocity", 3, 0);
     auto& densityf = frepo.declare_field("density");
@@ -28,7 +33,7 @@ TEST_F(ABLMeshTest, abl_initialization)
     auto density = densityf.vec_ptrs();
     auto temperature = temperaturef.vec_ptrs();
 
-    amr_wind::ABLFieldInit ablinit;
+    amr_wind::ABLFieldInit ablinit(sim());
     run_algorithm(
         mesh().num_levels(), density,
         [&](const int lev, const amrex::MFIter& mfi) {
@@ -37,7 +42,7 @@ TEST_F(ABLMeshTest, abl_initialization)
             auto theta = temperature[lev]->array(mfi);
 
             const auto& bx = mfi.validbox();
-            ablinit(bx, mesh().Geom(lev), vel, rho, theta);
+            ablinit(lev, mfi, bx, mesh().Geom(lev), vel, rho, theta);
         });
 
     const int nlevels = mesh().num_levels();

--- a/unit_tests/wind_energy/test_abl_init.cpp
+++ b/unit_tests/wind_energy/test_abl_init.cpp
@@ -19,11 +19,6 @@ TEST_F(ABLMeshTest, abl_initialization)
     }
 
     initialize_mesh();
-    sim().activate_mesh_map();
-    for (int ilev = 0; ilev<mesh().num_levels(); ilev++) { 
-        // TODO: switch to run_algorithm()
-        sim().mesh_mapping()->create_map(ilev, mesh().Geom(ilev));
-    }
     auto& frepo = mesh().field_repo();
     auto& velocityf = frepo.declare_field("velocity", 3, 0);
     auto& densityf = frepo.declare_field("density");

--- a/unit_tests/wind_energy/test_abl_meshmap.cpp
+++ b/unit_tests/wind_energy/test_abl_meshmap.cpp
@@ -1,0 +1,138 @@
+#include "abl_test_utils.H"
+#include "aw_test_utils/iter_tools.H"
+#include "aw_test_utils/test_utils.H"
+#include "amr-wind/wind_energy/ABLFieldInit.H"
+#include "amr-wind/mesh_mapping_models/Geom2ConstantScaling.H"
+#include "amr-wind/CFDSim.H"
+
+namespace amr_wind_tests {
+namespace {} // namespace
+
+
+TEST_F(ABLMeshTest, abl_map_initialization)
+{
+    const amrex::Real tol = 1.0e-12;
+
+    amrex::Real trans_loc   = 0.20;
+    amrex::Real trans_width = 0.1;
+    amrex::Real sratio      = 1.1;
+    amrex::Real delta0      = 0.1;
+    amrex::Real len         = 1.0;
+  
+    // Test the mapping coord and fac functions
+    auto g_mesh_map = amr_wind::geom2constant_map::Geom2ConstantScaling();
+    amrex::Real xcoord  = g_mesh_map.dump_coord(19.0, trans_loc, trans_width, sratio, delta0, len, 1);
+    amrex::Real dxcoord = g_mesh_map.dump_fac(19.0, trans_loc, trans_width, sratio, delta0, len, 1);
+    EXPECT_NEAR(xcoord,  1.9, tol);
+    EXPECT_NEAR(dxcoord, 0.1, tol);
+
+    populate_parameters();
+    utils::populate_abl_params();
+
+    // Adjust computational domain to be more like ABL mesh in the z direction
+    {
+        amrex::ParmParse pp("amr");
+        amrex::Vector<int> ncell{{8, 8, 48}};
+        pp.addarr("n_cell", ncell);
+    }
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<amrex::Real> probhi{{120.0, 120.0, 48.0}};
+        pp.addarr("prob_hi", probhi);
+    }
+
+    // Initial conditions (Mesh map)
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<std::string> mapping{"Geom2ConstantScaling"};
+        pp.addarr("mesh_mapping", mapping);
+    }
+
+    // Initial conditions (Scaling)
+    {
+        amrex::ParmParse pp("Geom2ConstantScaling");
+        amrex::Vector<amrex::Real> pp_sratio{{1.1, 1.1, 1.1}};
+        amrex::Vector<amrex::Real> pp_delta0{{0.1, 0.1, 1000.0/48.0}}; 
+        amrex::Vector<amrex::Real> pp_transwidth{{0.1, 0.1, 0.1}};
+        amrex::Vector<amrex::Real> pp_transloc{{0.2, 0.2, 50.0}};
+        amrex::Vector<int>         pp_do_map{{0, 0, 1}};
+
+        pp.addarr("sratio",        pp_sratio);
+        pp.addarr("delta0",        pp_delta0);
+        pp.addarr("transwidth",    pp_transwidth);
+        pp.addarr("translocation", pp_transloc);
+        pp.addarr("do_map",        pp_do_map);
+
+    }
+
+    initialize_mesh();
+
+    sim().activate_mesh_map();
+
+    const int nlevels = mesh().num_levels();
+
+    if (sim().has_mesh_mapping()) {
+      for (int lev=0; lev<nlevels; lev++) {
+	sim().mesh_mapping()->create_map(lev, mesh().Geom(lev));
+      }
+    } 
+    auto& frepo = mesh().field_repo();
+    auto& velocityf = frepo.declare_field("velocity", 3, 0);
+    auto& densityf = frepo.declare_field("density");
+    auto& temperaturef = frepo.declare_field("temperature");
+
+    auto velocity = velocityf.vec_ptrs();
+    auto density = densityf.vec_ptrs();
+    auto temperature = temperaturef.vec_ptrs();
+
+    amr_wind::ABLFieldInit ablinit(sim());
+    run_algorithm(
+        mesh().num_levels(), density,
+        [&](const int lev, const amrex::MFIter& mfi) {
+            auto vel = velocity[lev]->array(mfi);
+            auto rho = density[lev]->array(mfi);
+            auto theta = temperature[lev]->array(mfi);
+
+            const auto& bx = mfi.validbox();
+            ablinit(lev, mfi, bx, mesh().Geom(lev), vel, rho, theta);
+        });
+
+    const int level   = 0;
+    const int m_direction = 2;
+    if (sim().has_mesh_mapping()) {
+      const auto& velocity_f  = sim().repo().get_field("velocity");
+      auto& vel               = velocity_f(level);
+      amrex::ParmParse pp("amr");
+      amrex::Vector<int> ncell(0.0, AMREX_SPACEDIM);
+      pp.queryarr("n_cell", ncell, 0, AMREX_SPACEDIM);
+      amrex::Vector<amrex::Real> zpts;
+      amrex::Vector<amrex::Real> zfac;
+      zpts.resize(ncell[2]);
+      zfac.resize(ncell[2]);
+
+      amr_wind::Field const* nu_coord_cc =
+	&(sim().repo().get_field("non_uniform_coord_cc"));
+      amr_wind::Field const* mesh_scale_fac_cc =
+	&(sim().repo().get_field("mesh_scaling_factor_cc"));
+
+      // Loop through and sum over all points on the lower surface
+      for (amrex::MFIter mfi(vel); mfi.isValid(); ++mfi) {	
+	  const auto& vbx   = mfi.validbox();
+	  amrex::Array4<amrex::Real const> nu_cc =
+	    ((*nu_coord_cc)(level).array(mfi));
+	  amrex::Array4<amrex::Real const> fac_cc =
+	    ((*mesh_scale_fac_cc)(level).array(mfi));
+	  
+	  amrex::Loop(vbx, [=, &zpts, &zfac](int i, int j, int k) noexcept {
+	      if ((i==0)&&(j==0)){
+		  zpts[k] = nu_cc(i, j, k, m_direction);
+		  zfac[k] = fac_cc(i, j, k, m_direction);
+		}
+	    });
+      }
+      EXPECT_NEAR(zpts[46], 968.75, tol);
+      EXPECT_NEAR(zfac[46], 1000.0/48.0, tol);
+    } // if (sim().has_mesh_mapping())
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/wind_energy/test_abl_meshmap.cpp
+++ b/unit_tests/wind_energy/test_abl_meshmap.cpp
@@ -8,22 +8,23 @@
 namespace amr_wind_tests {
 namespace {} // namespace
 
-
 TEST_F(ABLMeshTest, abl_map_initialization)
 {
     const amrex::Real tol = 1.0e-12;
 
-    amrex::Real trans_loc   = 0.20;
+    amrex::Real trans_loc = 0.20;
     amrex::Real trans_width = 0.1;
-    amrex::Real sratio      = 1.1;
-    amrex::Real delta0      = 0.1;
-    amrex::Real len         = 1.0;
-  
+    amrex::Real sratio = 1.1;
+    amrex::Real delta0 = 0.1;
+    amrex::Real len = 1.0;
+
     // Test the mapping coord and fac functions
     auto g_mesh_map = amr_wind::geom2constant_map::Geom2ConstantScaling();
-    amrex::Real xcoord  = g_mesh_map.dump_coord(19.0, trans_loc, trans_width, sratio, delta0, len, 1);
-    amrex::Real dxcoord = g_mesh_map.dump_fac(19.0, trans_loc, trans_width, sratio, delta0, len, 1);
-    EXPECT_NEAR(xcoord,  1.9, tol);
+    amrex::Real xcoord  = g_mesh_map.dump_coord(
+        19.0, trans_loc, trans_width, sratio, delta0, len, 1);
+    amrex::Real dxcoord = g_mesh_map.dump_fac(
+        19.0, trans_loc, trans_width, sratio, delta0, len, 1);
+    EXPECT_NEAR(xcoord, 1.9, tol);
     EXPECT_NEAR(dxcoord, 0.1, tol);
 
     populate_parameters();
@@ -52,17 +53,16 @@ TEST_F(ABLMeshTest, abl_map_initialization)
     {
         amrex::ParmParse pp("Geom2ConstantScaling");
         amrex::Vector<amrex::Real> pp_sratio{{1.1, 1.1, 1.1}};
-        amrex::Vector<amrex::Real> pp_delta0{{0.1, 0.1, 1000.0/48.0}}; 
+        amrex::Vector<amrex::Real> pp_delta0{{0.1, 0.1, 1000.0 / 48.0}}; 
         amrex::Vector<amrex::Real> pp_transwidth{{0.1, 0.1, 0.1}};
         amrex::Vector<amrex::Real> pp_transloc{{0.2, 0.2, 50.0}};
-        amrex::Vector<int>         pp_do_map{{0, 0, 1}};
+        amrex::Vector<int> pp_do_map{{0, 0, 1}};
 
-        pp.addarr("sratio",        pp_sratio);
-        pp.addarr("delta0",        pp_delta0);
-        pp.addarr("transwidth",    pp_transwidth);
+        pp.addarr("sratio", pp_sratio);
+        pp.addarr("delta0", pp_delta0);
+        pp.addarr("transwidth", pp_transwidth);
         pp.addarr("translocation", pp_transloc);
-        pp.addarr("do_map",        pp_do_map);
-
+        pp.addarr("do_map", pp_do_map);
     }
 
     initialize_mesh();
@@ -72,10 +72,10 @@ TEST_F(ABLMeshTest, abl_map_initialization)
     const int nlevels = mesh().num_levels();
 
     if (sim().has_mesh_mapping()) {
-      for (int lev=0; lev<nlevels; lev++) {
-	sim().mesh_mapping()->create_map(lev, mesh().Geom(lev));
-      }
-    } 
+        for (int lev=0; lev<nlevels; lev++) {
+	    sim().mesh_mapping()->create_map(lev, mesh().Geom(lev));
+        }
+    }
     auto& frepo = mesh().field_repo();
     auto& velocityf = frepo.declare_field("velocity", 3, 0);
     auto& densityf = frepo.declare_field("density");
@@ -97,41 +97,41 @@ TEST_F(ABLMeshTest, abl_map_initialization)
             ablinit(lev, mfi, bx, mesh().Geom(lev), vel, rho, theta);
         });
 
-    const int level   = 0;
+    const int level = 0;
     const int m_direction = 2;
     if (sim().has_mesh_mapping()) {
-      const auto& velocity_f  = sim().repo().get_field("velocity");
-      auto& vel               = velocity_f(level);
-      amrex::ParmParse pp("amr");
-      amrex::Vector<int> ncell(0.0, AMREX_SPACEDIM);
-      pp.queryarr("n_cell", ncell, 0, AMREX_SPACEDIM);
-      amrex::Vector<amrex::Real> zpts;
-      amrex::Vector<amrex::Real> zfac;
-      zpts.resize(ncell[2]);
-      zfac.resize(ncell[2]);
+        const auto& velocity_f = sim().repo().get_field("velocity");
+        auto& vel = velocity_f(level);
+        amrex::ParmParse pp("amr");
+        amrex::Vector<int> ncell(0.0, AMREX_SPACEDIM);
+        pp.queryarr("n_cell", ncell, 0, AMREX_SPACEDIM);
+        amrex::Vector<amrex::Real> zpts;
+        amrex::Vector<amrex::Real> zfac;
+        zpts.resize(ncell[2]);
+        zfac.resize(ncell[2]);
 
-      amr_wind::Field const* nu_coord_cc =
-	&(sim().repo().get_field("non_uniform_coord_cc"));
-      amr_wind::Field const* mesh_scale_fac_cc =
-	&(sim().repo().get_field("mesh_scaling_factor_cc"));
+        amr_wind::Field const* nu_coord_cc =
+            &(sim().repo().get_field("non_uniform_coord_cc"));
+        amr_wind::Field const* mesh_scale_fac_cc =
+	    &(sim().repo().get_field("mesh_scaling_factor_cc"));
 
-      // Loop through and sum over all points on the lower surface
-      for (amrex::MFIter mfi(vel); mfi.isValid(); ++mfi) {	
-	  const auto& vbx   = mfi.validbox();
-	  amrex::Array4<amrex::Real const> nu_cc =
-	    ((*nu_coord_cc)(level).array(mfi));
-	  amrex::Array4<amrex::Real const> fac_cc =
-	    ((*mesh_scale_fac_cc)(level).array(mfi));
+        // Loop through and sum over all points on the lower surface
+        for (amrex::MFIter mfi(vel); mfi.isValid(); ++mfi) {	
+            const auto& vbx = mfi.validbox();
+            amrex::Array4<amrex::Real const> nu_cc =
+	        ((*nu_coord_cc)(level).array(mfi));
+	    amrex::Array4<amrex::Real const> fac_cc =
+	        ((*mesh_scale_fac_cc)(level).array(mfi));
 	  
-	  amrex::Loop(vbx, [=, &zpts, &zfac](int i, int j, int k) noexcept {
-	      if ((i==0)&&(j==0)){
-		  zpts[k] = nu_cc(i, j, k, m_direction);
-		  zfac[k] = fac_cc(i, j, k, m_direction);
+	    amrex::Loop(vbx, [=, &zpts, &zfac](int i, int j, int k) noexcept {
+                if ((i == 0) && (j == 0)){
+                    zpts[k] = nu_cc(i, j, k, m_direction);
+                    zfac[k] = fac_cc(i, j, k, m_direction);
 		}
 	    });
-      }
-      EXPECT_NEAR(zpts[46], 968.75, tol);
-      EXPECT_NEAR(zfac[46], 1000.0/48.0, tol);
+        }
+        EXPECT_NEAR(zpts[46], 968.75, tol);
+        EXPECT_NEAR(zfac[46], 1000.0/48.0, tol);
     } // if (sim().has_mesh_mapping())
 }
 


### PR DESCRIPTION
This PR should add the following two main features:  
- Implement k-omega and k-epsilon boundary conditions into the `ABLWallFunction` framework
- Make the `ABLWallFunction` methods compatible with the mesh mapping functionality included in [PR 545](https://github.com/Exawind/amr-wind/pull/545).

The full detailed list of all additions is documented at the [AMRWind_RANSBC repo](https://github.com/lawrenceccheung/AMRWind_RANSBC), but a quick summary is below:
- Implemented mesh mapping functions for ABL's based on geometry grid stretching
- Created a version of `KOmegaSSTABL` specifically for ABL RANS runs
- Edit `ABL::initialize_fields` to account for mesh mapping, sdr/tke init
- Added in `ABLTKEWallFunc::wall_model()`, `ABLEpsWallFunc::wall_model()`, and `ABLSDRWallFunc::wall_model()`
- Added the Monin-Obkuhov calculation functions for RANS variables in `MOData.H`, `MOData.cpp`.
- Added mu, epsilon, tke calculations in `ShearStress.H`.

Still to do are the inclusion of additional unit tests and a bit of clean up after some more successful testing.

Before a full RANS ABL case with mesh mapping can be run successfully, we need to also merge in contributions from the following branches:
o https://github.com/ashesh2512/amr-wind/commits/mesh_map_turb
o https://github.com/lawrenceccheung/amr-wind/tree/mesh_map_subsetsampling
However, I'd like to get this PR request going first so that things can be merged into main in smaller chunks.
