### PR TITLE
Revert "Add in readability-avoid-const-params-in-decls check"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'bugprone-*,clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-readability-identifier-naming,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-isolate-declaration,-modernize-make-unique'
+Checks:          'bugprone-*,clang-diagnostic-*,clang-analyzer-*,corecppguidelines-*,modernize-*,readability-*,-readability-magic-numbers,-readability-identifier-naming,-modernize-avoid-c-arrays,-modernize-use-trailing-return-type,-readability-isolate-declaration,-readability-avoid-const-params-in-decls,-modernize-make-unique'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/amr-wind/boundary_conditions/BCInterface.H
+++ b/amr-wind/boundary_conditions/BCInterface.H
@@ -43,7 +43,7 @@ public:
     virtual ~BCIface() = default;
 
     //! Operator that performs init actions and syncs the BC data to device
-    virtual void operator()(amrex::Real value = 0.0);
+    virtual void operator()(const amrex::Real value = 0.0);
 
     //! User-defined functions for Dirichlet-type boundaries
     std::pair<const std::string, const std::string> get_dirichlet_udfs();
@@ -62,7 +62,7 @@ protected:
     virtual void set_bcfuncs();
 
     //! Set default BC values for the field
-    inline void set_default_value(amrex::Real value);
+    inline void set_default_value(const amrex::Real value);
 
     //! Set AMReX mathematical boundary types for the lower boundaries
     inline void

--- a/amr-wind/boundary_conditions/FixedGradientBC.H
+++ b/amr-wind/boundary_conditions/FixedGradientBC.H
@@ -19,7 +19,7 @@ class FixedGradientBC : public FieldBCIface
 public:
     FixedGradientBC(Field& field, amrex::Orientation ori);
 
-    void operator()(Field& field, FieldState /*rho_state*/) override;
+    void operator()(Field& field, const FieldState /*rho_state*/) override;
 
 private:
     Field& m_field;

--- a/amr-wind/core/Field.H
+++ b/amr-wind/core/Field.H
@@ -31,7 +31,11 @@ struct FieldInfo
     static constexpr int max_field_states = 5;
 
     FieldInfo(
-        std::string basename, int ncomp, int ngrow, int nstates, FieldLoc floc);
+        std::string basename,
+        const int ncomp,
+        const int ngrow,
+        const int nstates,
+        const FieldLoc floc);
 
     ~FieldInfo();
 
@@ -218,7 +222,7 @@ public:
      */
     void set_default_fillpatch_bc(
         const SimTime& time,
-        amrex::BCType::mathematicalBndryTypes bctype =
+        const amrex::BCType::mathematicalBndryTypes bctype =
             amrex::BCType::hoextrap) noexcept;
 
     /** Map field to the uniform mesh
@@ -240,8 +244,8 @@ public:
     void to_stretched_space() noexcept;
 
     //! Return field at a different time state
-    Field& state(FieldState fstate);
-    const Field& state(FieldState fstate) const;
+    Field& state(const FieldState fstate);
+    const Field& state(const FieldState fstate) const;
 
     //! Return MultiFab instance for a given level
     amrex::MultiFab& operator()(int lev) noexcept;
@@ -260,7 +264,7 @@ public:
     void copy_state(FieldState to_state, FieldState from_state) noexcept;
 
     //! Create a new time state after the field has been created
-    Field& create_state(FieldState fstate) noexcept;
+    Field& create_state(const FieldState fstate) noexcept;
 
     // NOTE: We break naming rules for methods here to provide 1-1 mapping with
     // the underlying MultiFab method names.
@@ -318,7 +322,7 @@ public:
     void fillphysbc(amrex::Real time) noexcept;
     void fillphysbc(amrex::Real time, amrex::IntVect ng) noexcept;
 
-    void apply_bc_funcs(FieldState rho_state) noexcept;
+    void apply_bc_funcs(const FieldState rho_state) noexcept;
 
     void fillpatch(
         int lev,
@@ -379,7 +383,7 @@ protected:
         FieldRepo& repo,
         std::string name,
         std::shared_ptr<FieldInfo> finfo,
-        unsigned fid,
+        const unsigned fid,
         FieldState state);
 
     //! Reference to the FieldRepository instance

--- a/amr-wind/core/FieldBCOps.H
+++ b/amr-wind/core/FieldBCOps.H
@@ -33,7 +33,7 @@ class FieldBCIface
 public:
     virtual ~FieldBCIface() = default;
 
-    virtual void operator()(Field& field, FieldState rho_state) = 0;
+    virtual void operator()(Field& field, const FieldState rho_state) = 0;
 };
 
 /** A no-op BC

--- a/amr-wind/core/FieldFillPatchOps.H
+++ b/amr-wind/core/FieldFillPatchOps.H
@@ -48,7 +48,7 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) = 0;
+        const FieldState fstate = FieldState::New) = 0;
 
     //! Implementation that handles filling patches from a coarse to fine level
     virtual void fillpatch_from_coarse(
@@ -56,7 +56,7 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) = 0;
+        const FieldState fstate = FieldState::New) = 0;
 
     //! Implementation that handles filling physical boundary conditions
     virtual void fillphysbc(
@@ -64,14 +64,14 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) = 0;
+        const FieldState fstate = FieldState::New) = 0;
 
     virtual void set_inflow(
         int lev,
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) = 0;
+        const FieldState fstate = FieldState::New) = 0;
 };
 
 /** Implementation that just fills a constant value on newly created grids

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -137,10 +137,10 @@ public:
      */
     Field& declare_field(
         const std::string& name,
-        int ncomp = 1,
-        int ngrow = 0,
-        int nstates = 1,
-        FieldLoc floc = FieldLoc::CELL);
+        const int ncomp = 1,
+        const int ngrow = 0,
+        const int nstates = 1,
+        const FieldLoc floc = FieldLoc::CELL);
 
     /** Declare a cell-centered field
      *
@@ -238,7 +238,8 @@ public:
     /** Return a previously created field identified by name and time state
      */
     Field& get_field(
-        const std::string& name, FieldState fstate = FieldState::New) const;
+        const std::string& name,
+        const FieldState fstate = FieldState::New) const;
 
     /** Return a previously created field using a unique identifier
      */
@@ -258,7 +259,8 @@ public:
     //! Query if field uniquely identified by name and time state exists in
     //! repository
     bool field_exists(
-        const std::string& name, FieldState fstate = FieldState::New) const;
+        const std::string& name,
+        const FieldState fstate = FieldState::New) const;
 
     /** Declare an integer field
      *
@@ -268,14 +270,15 @@ public:
      */
     IntField& declare_int_field(
         const std::string& name,
-        int ncomp = 1,
-        int ngrow = 0,
-        int nstates = 1,
-        FieldLoc floc = FieldLoc::CELL);
+        const int ncomp = 1,
+        const int ngrow = 0,
+        const int nstates = 1,
+        const FieldLoc floc = FieldLoc::CELL);
 
     //! Return a reference to an integer field
     IntField& get_int_field(
-        const std::string& name, FieldState fstate = FieldState::New) const;
+        const std::string& name,
+        const FieldState fstate = FieldState::New) const;
 
     /** Return a reference to a previously created integer field using unique
      * identifier
@@ -287,7 +290,8 @@ public:
 
     //! Query if an integer field exists
     bool int_field_exists(
-        const std::string& name, FieldState fstate = FieldState::New) const;
+        const std::string& name,
+        const FieldState fstate = FieldState::New) const;
 
     /** Create a scratch field
      *
@@ -301,9 +305,9 @@ public:
      */
     std::unique_ptr<ScratchField> create_scratch_field(
         const std::string& name,
-        int ncomp = 1,
-        int nghost = 0,
-        FieldLoc floc = FieldLoc::CELL) const;
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
 
     /** Create a scratch field
      *
@@ -316,7 +320,9 @@ public:
      *  the ScratchField object across timesteps.
      */
     std::unique_ptr<ScratchField> create_scratch_field(
-        int ncomp = 1, int nghost = 0, FieldLoc floc = FieldLoc::CELL) const;
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
 
     //! Advance all fields with more than one timestate to the new timestep
     void advance_states() noexcept;
@@ -369,7 +375,7 @@ protected:
     }
 
     //! Create a new state for a field
-    Field& create_state(Field& field, FieldState fstate);
+    Field& create_state(Field& field, const FieldState fstate);
 
     //! Allocate field data for a single level outside of regrid
     void allocate_field_data(

--- a/amr-wind/core/IntField.H
+++ b/amr-wind/core/IntField.H
@@ -61,10 +61,10 @@ protected:
     IntField(
         FieldRepo& repo,
         std::string name,
-        unsigned fid,
-        int ncomp = 1,
-        int ngrow = 1,
-        FieldLoc floc = FieldLoc::CELL);
+        const unsigned fid,
+        const int ncomp = 1,
+        const int ngrow = 1,
+        const FieldLoc floc = FieldLoc::CELL);
 
     FieldRepo& m_repo;
 

--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -53,7 +53,9 @@ public:
      *
      */
     void set_current_cfl(
-        amrex::Real conv_cfl, amrex::Real diff_cfl, amrex::Real src_cfl);
+        const amrex::Real conv_cfl,
+        const amrex::Real diff_cfl,
+        const amrex::Real src_cfl);
 
     /** Set start time and index based on checkpoint/restart file
      *

--- a/amr-wind/core/Slice.H
+++ b/amr-wind/core/Slice.H
@@ -63,7 +63,8 @@ struct Slice
 };
 
 template <typename T>
-inline Slice<T> slice(std::vector<T>& vec, size_t start, size_t count)
+inline Slice<T>
+slice(std::vector<T>& vec, const size_t start, const size_t count)
 {
     AMREX_ASSERT((start + count) <= vec.size());
     return Slice<T>{&vec[start], count};

--- a/amr-wind/core/ViewField.H
+++ b/amr-wind/core/ViewField.H
@@ -62,7 +62,7 @@ public:
     const T& source_field() const { return m_src; }
 
 private:
-    ViewField(T& src, int scomp = 0, int ncomp = 1);
+    ViewField(T& src, const int scomp = 0, const int ncomp = 1);
 
     //! The base field
     T& m_src;

--- a/amr-wind/core/vs/tensor.H
+++ b/amr-wind/core/vs/tensor.H
@@ -44,7 +44,7 @@ struct TensorT
         const VectorT<T>& x,
         const VectorT<T>& y,
         const VectorT<T>& z,
-        bool transpose = false);
+        const bool transpose = false);
 
     ~TensorT() = default;
     TensorT(const TensorT&) = default;

--- a/amr-wind/core/vs/vector.H
+++ b/amr-wind/core/vs/vector.H
@@ -110,9 +110,9 @@ struct VectorT
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator-() const;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator*=(T val);
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator*=(const T val);
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator/=(T val);
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> operator/=(const T val);
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE T& operator[](size_type pos) &
     {

--- a/amr-wind/diffusion/diffusion.H
+++ b/amr-wind/diffusion/diffusion.H
@@ -9,20 +9,20 @@ namespace diffusion {
 
 void wall_model_bc_moeng(
     amr_wind::Field& velocity,
-    amrex::Real utau,
-    amr_wind::FieldState fstate,
+    const amrex::Real utau,
+    const amr_wind::FieldState fstate,
     const amrex::FArrayBox& instplanar);
 
 void wall_model_bc(
     amr_wind::Field& velocity,
-    amrex::Real utau,
-    amrex::Real umag,
-    amr_wind::FieldState fstate);
+    const amrex::Real utau,
+    const amrex::Real umag,
+    const amr_wind::FieldState fstate);
 
 void temp_wall_model_bc(
     amr_wind::Field& temperature,
     const amrex::FArrayBox& instplanar,
-    amr_wind::FieldState fstate);
+    const amr_wind::FieldState fstate);
 
 amrex::Vector<amrex::Array<amrex::LinOpBCType, AMREX_SPACEDIM>>
 get_diffuse_tensor_bc(

--- a/amr-wind/equation_systems/DiffusionOps.H
+++ b/amr-wind/equation_systems/DiffusionOps.H
@@ -32,8 +32,8 @@ class DiffSolverIface
 public:
     DiffSolverIface(
         PDEFields& fields,
-        bool has_overset,
-        bool mesh_mapping,
+        const bool has_overset,
+        const bool mesh_mapping,
         const std::string& prefix = "diffusion");
 
     virtual ~DiffSolverIface() = default;
@@ -42,11 +42,11 @@ public:
      *
      *  \param dt timestep size
      */
-    virtual void linsys_solve(amrex::Real dt);
+    virtual void linsys_solve(const amrex::Real dt);
 
     virtual void linsys_solve_impl();
 
-    virtual void set_acoeffs(LinOp& linop, FieldState fstate);
+    virtual void set_acoeffs(LinOp& linop, const FieldState fstate);
 
     template <typename L>
     void set_bcoeffs(
@@ -93,7 +93,10 @@ public:
 protected:
     //! Sets up the linear operator (e.g., setup BCs, etc.)
     virtual void setup_operator(
-        LinOp& linop, amrex::Real alpha, amrex::Real beta, FieldState fstate);
+        LinOp& linop,
+        const amrex::Real alpha,
+        const amrex::Real beta,
+        const FieldState fstate);
 
     virtual void setup_solver(amrex::MLMG& mlmg);
 

--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -63,19 +63,19 @@ public:
     virtual void post_regrid_actions() = 0;
 
     //! Compute the source (forcing) terms for this PDE
-    virtual void compute_source_term(FieldState fstate) = 0;
+    virtual void compute_source_term(const FieldState fstate) = 0;
 
     //! Compute the effective dynamic viscosity for this PDE
-    virtual void compute_mueff(FieldState fstate) = 0;
+    virtual void compute_mueff(const FieldState fstate) = 0;
 
     //! Compute the diffusion term used in the RHS of the PDE system
-    virtual void compute_diffusion_term(FieldState fstate) = 0;
+    virtual void compute_diffusion_term(const FieldState fstate) = 0;
 
     //! Perform necessary steps to prepare for advection calculations
-    virtual void pre_advection_actions(FieldState fstate) = 0;
+    virtual void pre_advection_actions(const FieldState fstate) = 0;
 
     //! Compute the time derivative and advective term for the PDE system
-    virtual void compute_advection_term(FieldState fstate) = 0;
+    virtual void compute_advection_term(const FieldState fstate) = 0;
 
     /** Combine the source, diffusion, and advection term to obtain RHS
      *
@@ -83,7 +83,7 @@ public:
      *  term is treated implicitly, with Crank-Nicolson scheme, or explicitly.
      *  The predictor step only uses the "old" states for RHS computation.
      */
-    virtual void compute_predictor_rhs(DiffusionType difftype) = 0;
+    virtual void compute_predictor_rhs(const DiffusionType difftype) = 0;
 
     /** Combine the source, diffusion, and advection term to obtain RHS
      *
@@ -92,10 +92,10 @@ public:
      *  The corrector step uses both "old" state as well as the updated "new"
      *  state from predictor step to compute the RHS term.
      */
-    virtual void compute_corrector_rhs(DiffusionType difftype) = 0;
+    virtual void compute_corrector_rhs(const DiffusionType difftype) = 0;
 
     //! Solve the diffusion linear system and update the field
-    virtual void solve(amrex::Real dt) = 0;
+    virtual void solve(const amrex::Real dt) = 0;
 
     //! Perform post-processing actions after a system solve
     virtual void post_solve_actions() = 0;
@@ -134,7 +134,7 @@ public:
 
     //! Call fillpatch operator on state variables for all registered PDEs
     void fillpatch_state_fields(
-        amrex::Real time, FieldState fstate = FieldState::New);
+        const amrex::Real time, const FieldState fstate = FieldState::New);
 
     /** Return the vector containing all registered PDE instances
      *

--- a/amr-wind/equation_systems/SourceTerm.H
+++ b/amr-wind/equation_systems/SourceTerm.H
@@ -23,10 +23,10 @@ public:
     ~SourceTerm() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/density/DensitySource.H
+++ b/amr-wind/equation_systems/density/DensitySource.H
@@ -21,10 +21,10 @@ public:
     ~DensitySource() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/icns/MomentumSource.H
+++ b/amr-wind/equation_systems/icns/MomentumSource.H
@@ -26,10 +26,10 @@ public:
     ~MomentumSource() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -23,7 +23,7 @@ public:
         bool /*variable_density*/,
         bool /*mesh_mapping*/);
 
-    void operator()(FieldState fstate, amrex::Real dt);
+    void operator()(const FieldState fstate, const amrex::Real dt);
 
     static void mac_proj_to_uniform_space(
         const amr_wind::FieldRepo& /*repo*/,
@@ -36,7 +36,7 @@ public:
 
 private:
     void init_projector(const FaceFabPtrVec& /*beta*/) noexcept;
-    void init_projector(amrex::Real /*beta*/) noexcept;
+    void init_projector(const amrex::Real /*beta*/) noexcept;
 
     FieldRepo& m_repo;
     std::unique_ptr<Hydro::MacProjector> m_mac_proj;

--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -23,10 +23,10 @@ public:
     ~ABLForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
     inline void set_mean_velocities(amrex::Real ux, amrex::Real uy)

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
@@ -26,10 +26,10 @@ public:
     ~ABLMeanBoussinesq() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
     void mean_temperature_init(const FieldPlaneAveraging& /*tavg*/);

--- a/amr-wind/equation_systems/icns/source_terms/ActuatorForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ActuatorForcing.H
@@ -24,10 +24,10 @@ public:
     ~ActuatorForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/BodyForce.H
+++ b/amr-wind/equation_systems/icns/source_terms/BodyForce.H
@@ -24,10 +24,10 @@ public:
     ~BodyForce() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.H
+++ b/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.H
@@ -25,10 +25,10 @@ public:
     ~BoussinesqBuoyancy() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.H
@@ -22,10 +22,10 @@ public:
     ~CoriolisForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.H
+++ b/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.H
@@ -28,10 +28,10 @@ public:
     ~DensityBuoyancy() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& vel_forces) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.H
@@ -21,10 +21,10 @@ public:
     ~GeostrophicForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
@@ -21,10 +21,10 @@ public:
     ~GravityForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& vel_forces) const override;
 
 private:

--- a/amr-wind/equation_systems/icns/source_terms/SynthTurbForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/SynthTurbForcing.H
@@ -20,10 +20,10 @@ public:
     ~SynthTurbForcing() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/sdr/SDRSource.H
+++ b/amr-wind/equation_systems/sdr/SDRSource.H
@@ -26,10 +26,10 @@ public:
     ~SDRSource() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/sdr/source_terms/SDRSrc.H
+++ b/amr-wind/equation_systems/sdr/source_terms/SDRSrc.H
@@ -22,10 +22,10 @@ public:
     ~SDRSrc() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/temperature/TemperatureSource.H
+++ b/amr-wind/equation_systems/temperature/TemperatureSource.H
@@ -26,10 +26,10 @@ public:
     ~TemperatureSource() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/tke/TKESource.H
+++ b/amr-wind/equation_systems/tke/TKESource.H
@@ -24,10 +24,10 @@ public:
     ~TKESource() override = default;
 
     virtual void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const = 0;
 };
 

--- a/amr-wind/equation_systems/tke/source_terms/KsgsM84Src.H
+++ b/amr-wind/equation_systems/tke/source_terms/KsgsM84Src.H
@@ -20,10 +20,10 @@ public:
     ~KsgsM84Src() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/tke/source_terms/KwSSTSrc.H
+++ b/amr-wind/equation_systems/tke/source_terms/KwSSTSrc.H
@@ -22,10 +22,10 @@ public:
     ~KwSSTSrc() override;
 
     void operator()(
-        int lev,
+        const int lev,
         const amrex::MFIter& mfi,
         const amrex::Box& bx,
-        FieldState fstate,
+        const FieldState fstate,
         const amrex::Array4<amrex::Real>& src_term) const override;
 
 private:

--- a/amr-wind/equation_systems/vof/SplitAdvection.H
+++ b/amr-wind/equation_systems/vof/SplitAdvection.H
@@ -21,7 +21,7 @@ void split_advection(
     bool is_lagrangian);
 
 void sweep(
-    int dir,
+    const int dir,
     amrex::Box const& bx,
     amrex::Real dtdx,
     amrex::Array4<amrex::Real const> const& vel_mac,
@@ -30,8 +30,8 @@ void sweep(
     amrex::Array4<amrex::Real> const& fluxC,
     amrex::Array4<amrex::Real> const& fluxR,
     amrex::BCRec const* pbc,
-    int dimLow,
-    int dimHigh,
+    const int dimLow,
+    const int dimHigh,
     bool is_lagrangian);
 
 } // namespace multiphase

--- a/amr-wind/immersed_boundary/bluff_body/bluff_body_ops.H
+++ b/amr-wind/immersed_boundary/bluff_body/bluff_body_ops.H
@@ -43,7 +43,7 @@ void write_netcdf(
     const std::string& /*ncfile*/,
     const BluffBodyBaseData& /*meta*/,
     const IBInfo& /*info*/,
-    amrex::Real /*time*/);
+    const amrex::Real /*time*/);
 
 } // namespace bluff_body
 

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -21,7 +21,7 @@ struct AMROversetInfo
      *  \param nglobal Total number of patches
      *  \param nlocal  Number of patches on the current MPI rank
      */
-    AMROversetInfo(int nglobal, int nlocal);
+    AMROversetInfo(const int nglobal, const int nlocal);
 
     // Arrays of size ngrids_global
     AType<int> level;

--- a/amr-wind/physics/ChannelFlow.H
+++ b/amr-wind/physics/ChannelFlow.H
@@ -29,7 +29,7 @@ public:
         int level,
         const amrex::Geometry& geom,
         const IndexSelector& idxOp,
-        int n_idx);
+        const int n_idx);
 
     template <typename IndexSelector>
     amrex::Real compute_error(const IndexSelector& idxOp);

--- a/amr-wind/physics/ConvectingTaylorVortex.H
+++ b/amr-wind/physics/ConvectingTaylorVortex.H
@@ -12,72 +12,72 @@ namespace {
 struct UExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*u0*/,
-        amrex::Real /*v0*/,
-        amrex::Real /*omega*/,
-        amrex::Real /*x*/,
-        amrex::Real /*y*/,
-        amrex::Real /*t*/) const;
+        const amrex::Real /*u0*/,
+        const amrex::Real /*v0*/,
+        const amrex::Real /*omega*/,
+        const amrex::Real /*x*/,
+        const amrex::Real /*y*/,
+        const amrex::Real /*t*/) const;
     const int m_comp{0};
 };
 
 struct VExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*u0*/,
-        amrex::Real /*v0*/,
-        amrex::Real /*omega*/,
-        amrex::Real /*x*/,
-        amrex::Real /*y*/,
-        amrex::Real /*t*/) const;
+        const amrex::Real /*u0*/,
+        const amrex::Real /*v0*/,
+        const amrex::Real /*omega*/,
+        const amrex::Real /*x*/,
+        const amrex::Real /*y*/,
+        const amrex::Real /*t*/) const;
     const int m_comp{1};
 };
 
 struct WExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/) const;
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/) const;
     const int m_comp{2};
 };
 
 struct GpxExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*u0*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*omega*/,
-        amrex::Real /*x*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*t*/) const;
+        const amrex::Real /*u0*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*omega*/,
+        const amrex::Real /*x*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*t*/) const;
     const int m_comp{0};
 };
 
 struct GpyExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*unused*/,
-        amrex::Real /*v0*/,
-        amrex::Real /*omega*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*y*/,
-        amrex::Real /*t*/) const;
+        const amrex::Real /*unused*/,
+        const amrex::Real /*v0*/,
+        const amrex::Real /*omega*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*y*/,
+        const amrex::Real /*t*/) const;
     const int m_comp{1};
 };
 
 struct GpzExact
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/) const;
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/) const;
     const int m_comp{2};
 };
 

--- a/amr-wind/physics/VortexRing.H
+++ b/amr-wind/physics/VortexRing.H
@@ -56,15 +56,15 @@ private:
 struct FatCore
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*r*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*z*/,
-        amrex::Real /*R*/,
-        amrex::Real /*Gamma*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/,
-        int /*unused*/,
+        const amrex::Real /*r*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*z*/,
+        const amrex::Real /*R*/,
+        const amrex::Real /*Gamma*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/,
+        const int /*unused*/,
         const int* /*unused*/,
         const amrex::Real* /*unused*/,
         const amrex::Real* /*unused*/) const;
@@ -73,15 +73,15 @@ struct FatCore
 struct CollidingRings
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real operator()(
-        amrex::Real /*r*/,
-        amrex::Real /*theta*/,
-        amrex::Real /*z*/,
-        amrex::Real /*R*/,
-        amrex::Real /*Gamma*/,
-        amrex::Real /*delta*/,
-        amrex::Real /*dz*/,
-        amrex::Real /*perturbation_amplitude*/,
-        int /*num_modes*/,
+        const amrex::Real /*r*/,
+        const amrex::Real /*theta*/,
+        const amrex::Real /*z*/,
+        const amrex::Real /*R*/,
+        const amrex::Real /*Gamma*/,
+        const amrex::Real /*delta*/,
+        const amrex::Real /*dz*/,
+        const amrex::Real /*perturbation_amplitude*/,
+        const int /*num_modes*/,
         const int* /*perturbation_modes*/,
         const amrex::Real* /*perturbation_phases_1*/,
         const amrex::Real* /*perturbation_phases_2*/) const;

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -56,7 +56,7 @@ public:
     std::string model_name() const override { return "OneEqKsgsM84"; }
 
     //! Update the turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! Do any post advance work
     void post_advance_work() override;
@@ -110,7 +110,7 @@ public:
     std::string model_name() const override { return "OneEqKsgsS94"; }
 
     //! Update the turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! No post advance work for this model
     void post_advance_work() override {}

--- a/amr-wind/turbulence/LES/Smagorinsky.H
+++ b/amr-wind/turbulence/LES/Smagorinsky.H
@@ -26,7 +26,7 @@ public:
     std::string model_name() const override { return "Smagorinsky"; }
 
     //! Update the turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! No post advance work for this model
     void post_advance_work() override {}

--- a/amr-wind/turbulence/LaminarModel.H
+++ b/amr-wind/turbulence/LaminarModel.H
@@ -28,7 +28,7 @@ public:
     std::string model_name() const override { return "laminar"; }
 
     //! Update the effective/turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! No post advance work for this model
     void post_advance_work() override {}

--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -46,7 +46,7 @@ public:
     std::string model_name() const override { return "KOmegaSST"; }
 
     //! Update the turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! No post advance work for this model
     void post_advance_work() override {}

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
@@ -37,7 +37,7 @@ public:
     std::string model_name() const override { return "KOmegaSSTIDDES"; }
 
     //! Update the turbulent viscosity field
-    void update_turbulent_viscosity(FieldState fstate) override;
+    void update_turbulent_viscosity(const FieldState fstate) override;
 
     //! No post advance work for this model
     void post_advance_work() override {}

--- a/amr-wind/turbulence/TurbulenceModel.H
+++ b/amr-wind/turbulence/TurbulenceModel.H
@@ -47,7 +47,7 @@ public:
      *  \param fstate State used for updates to differentiate logic in predictor
      *  and corrector steps.
      */
-    virtual void update_turbulent_viscosity(FieldState fstate) = 0;
+    virtual void update_turbulent_viscosity(const FieldState fstate) = 0;
 
     //! Do any post advance actions for the turbulence model
     virtual void post_advance_work() = 0;

--- a/amr-wind/utilities/DerivedQtyDefs.H
+++ b/amr-wind/utilities/DerivedQtyDefs.H
@@ -16,7 +16,7 @@ struct VorticityMag : public DerivedQty::Register<VorticityMag>
 
     int num_comp() const override { return ncomp; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field& m_vel;
@@ -33,7 +33,7 @@ struct QCriterion : public DerivedQty::Register<QCriterion>
 
     int num_comp() const override { return ncomp; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field& m_vel;
@@ -51,7 +51,7 @@ struct QCriterionNondim : public DerivedQty::Register<QCriterionNondim>
 
     int num_comp() const override { return ncomp; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field& m_vel;
@@ -68,7 +68,7 @@ struct StrainRateMag : public DerivedQty::Register<StrainRateMag>
 
     int num_comp() const override { return ncomp; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field& m_vel;
@@ -84,7 +84,7 @@ struct Gradient : public DerivedQty::Register<Gradient>
 
     int num_comp() const override { return AMREX_SPACEDIM * m_phi->num_comp(); }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field* m_phi;
@@ -100,7 +100,7 @@ struct Divergence : public DerivedQty::Register<Divergence>
 
     int num_comp() const override { return 1; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field* m_phi;
@@ -117,7 +117,7 @@ struct Laplacian : public DerivedQty::Register<Laplacian>
 
     int num_comp() const override { return ncomp; }
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field* m_phi;
@@ -136,7 +136,7 @@ struct FieldComponents : public DerivedQty::Register<FieldComponents>
 
     void var_names(amrex::Vector<std::string>& plt_var_names) override;
 
-    void operator()(ScratchField& fld, int scomp = 0) override;
+    void operator()(ScratchField& fld, const int scomp = 0) override;
 
 private:
     const Field* m_fld;

--- a/amr-wind/utilities/DerivedQuantity.H
+++ b/amr-wind/utilities/DerivedQuantity.H
@@ -23,7 +23,7 @@ public:
 
     virtual int num_comp() const = 0;
 
-    virtual void operator()(ScratchField& fld, int scomp = 0) = 0;
+    virtual void operator()(ScratchField& fld, const int scomp = 0) = 0;
 
     virtual void var_names(amrex::Vector<std::string>& /*plt_var_names*/);
 };
@@ -37,7 +37,7 @@ public:
     explicit DerivedQtyMgr(const FieldRepo& repo);
     ~DerivedQtyMgr() = default;
 
-    void operator()(ScratchField& fld, int scomp = 0);
+    void operator()(ScratchField& fld, const int scomp = 0);
 
     void create(const amrex::Vector<std::string>& keys);
 

--- a/amr-wind/utilities/FieldPlaneAveraging.H
+++ b/amr-wind/utilities/FieldPlaneAveraging.H
@@ -153,8 +153,8 @@ public: // public for GPU
     template <typename IndexSelector>
     void compute_hvelmag_averages(
         const IndexSelector& idx_op,
-        int h1_idx,
-        int h2_idx,
+        const int h1_idx,
+        const int h2_idx,
         const amrex::MultiFab& mfab);
 
     /** return vector containing horizontal velocity magnitude average */

--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -45,7 +45,7 @@ public:
     void write_plot_file();
 
     //! Write all necessary fields for restart
-    void write_checkpoint_file(int start_level = 0);
+    void write_checkpoint_file(const int start_level = 0);
 
     //! Read all necessary fields for a restart
     void read_checkpoint_fields(
@@ -86,7 +86,7 @@ public:
     const amrex::Vector<Field*>& plot_fields() const { return m_plt_fields; }
 
 private:
-    void write_header(const std::string& /*chkname*/, int start_level);
+    void write_header(const std::string& /*chkname*/, const int start_level);
 
     void write_info_file(const std::string& /*path*/);
 

--- a/amr-wind/utilities/averaging/ReAveraging.H
+++ b/amr-wind/utilities/averaging/ReAveraging.H
@@ -24,8 +24,8 @@ public:
      */
     void operator()(
         const SimTime& /*unused*/,
-        amrex::Real /*unused*/,
-        amrex::Real /*unused*/) override;
+        const amrex::Real /*unused*/,
+        const amrex::Real /*unused*/) override;
 
     const std::string& average_field_name() override;
 

--- a/amr-wind/utilities/averaging/ReynoldsStress.H
+++ b/amr-wind/utilities/averaging/ReynoldsStress.H
@@ -28,8 +28,8 @@ public:
      */
     void operator()(
         const SimTime& /*time*/,
-        amrex::Real /*filter_width*/,
-        amrex::Real /*elapsed_time*/) override;
+        const amrex::Real /*filter_width*/,
+        const amrex::Real /*elapsed_time*/) override;
 
     const std::string& average_field_name() override;
 

--- a/amr-wind/utilities/averaging/TimeAveraging.H
+++ b/amr-wind/utilities/averaging/TimeAveraging.H
@@ -38,7 +38,8 @@ public:
      *
      *  \param elapsed_time Time elapsed since averaging was initiated
      */
-    virtual void operator()(const SimTime&, amrex::Real, amrex::Real) = 0;
+    virtual void
+    operator()(const SimTime&, const amrex::Real, const amrex::Real) = 0;
 
     virtual const std::string& average_field_name() = 0;
 };

--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.H
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.H
@@ -51,7 +51,8 @@ public:
     void
     populate_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
     void output_netcdf_data(
-        const ncutils::NCGroup& /*unused*/, size_t /*unused*/) const override;
+        const ncutils::NCGroup& /*unused*/,
+        const size_t /*unused*/) const override;
 
 private:
     int m_ns{1};

--- a/amr-wind/utilities/sampling/FieldNorms.H
+++ b/amr-wind/utilities/sampling/FieldNorms.H
@@ -38,7 +38,7 @@ public:
     void impl_write_native();
 
     //! calculate the L2 norm of a given field and component
-    static amrex::Real L2_norm(amr_wind::Field& field, int comp);
+    static amrex::Real L2_norm(amr_wind::Field& field, const int comp);
 
     const amrex::Vector<std::string>& var_names() const { return m_var_names; }
 

--- a/amr-wind/utilities/sampling/LidarSampler.H
+++ b/amr-wind/utilities/sampling/LidarSampler.H
@@ -40,7 +40,8 @@ public:
     void
     populate_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
     void output_netcdf_data(
-        const ncutils::NCGroup& /*unused*/, size_t /*unused*/) const override;
+        const ncutils::NCGroup& /*unused*/,
+        const size_t /*unused*/) const override;
 
 protected:
     amrex::Vector<amrex::Real> m_origin;

--- a/amr-wind/utilities/sampling/SamplingContainer.H
+++ b/amr-wind/utilities/sampling/SamplingContainer.H
@@ -74,7 +74,8 @@ public:
 
     /** Define the container and allocate memory for runtime components
      */
-    void setup_container(int num_real_components, int num_int_components = 0);
+    void setup_container(
+        const int num_real_components, const int num_int_components = 0);
 
     /** Create particle information for all the sampling locations
      */
@@ -82,7 +83,7 @@ public:
         const amrex::Vector<std::unique_ptr<SamplerBase>>& /*samplers*/);
 
     //! Perform field interpolation to sampling locations
-    void interpolate_fields(amrex::Vector<Field*> fields);
+    void interpolate_fields(const amrex::Vector<Field*> fields);
 
     //! Populate the buffer with data for all the particles
     void populate_buffer(std::vector<double>& buf);

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -31,12 +31,14 @@ class InletData
 public:
     InletData() = default;
 
-    void resize(int /*size*/);
+    void resize(const int /*size*/);
 
-    void define_plane(amrex::Orientation /*ori*/);
+    void define_plane(const amrex::Orientation /*ori*/);
 
     void define_level_data(
-        amrex::Orientation /*ori*/, const amrex::Box& /*bx*/, size_t /*nc*/);
+        const amrex::Orientation /*ori*/,
+        const amrex::Box& /*bx*/,
+        const size_t /*nc*/);
 
 #ifdef AMR_WIND_USE_NETCDF
     void read_data(
@@ -49,15 +51,15 @@ public:
 #endif
 
     void read_data_native(
-        amrex::OrientationIter oit,
+        const amrex::OrientationIter oit,
         amrex::BndryRegister& bndry_n,
         amrex::BndryRegister& bndry_np1,
-        int lev,
+        const int lev,
         const Field* /*fld*/,
-        amrex::Real time,
+        const amrex::Real time,
         const amrex::Vector<amrex::Real>& /*times*/);
 
-    void interpolate(amrex::Real /*time*/);
+    void interpolate(const amrex::Real /*time*/);
     bool is_populated(amrex::Orientation /*ori*/) const;
     const amrex::FArrayBox&
     interpolate_data(const amrex::Orientation ori, const int lev) const
@@ -129,8 +131,8 @@ public:
     void read_file();
 
     void populate_data(
-        int /*lev*/,
-        amrex::Real /*time*/,
+        const int /*lev*/,
+        const amrex::Real /*time*/,
         Field& /*fld*/,
         amrex::MultiFab& /*mfab*/) const;
 
@@ -149,8 +151,8 @@ public:
 
     bool box_intersects_boundary(
         const amrex::Box& /*bx*/,
-        int /*lev*/,
-        amrex::Orientation /*ori*/) const;
+        const int /*lev*/,
+        const amrex::Orientation /*ori*/) const;
 
 private:
     const amr_wind::SimTime& m_time;

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -35,7 +35,7 @@ public:
      *  pushes the field to device.
      */
     void perturb_temperature(
-        int lev, const amrex::Geometry& geom, Field& temperature) const;
+        const int lev, const amrex::Geometry& geom, Field& temperature) const;
 
     //! Flag indicating whether temperature field needs perturbations
     bool add_temperature_perturbations() const { return m_perturb_theta; }

--- a/amr-wind/wind_energy/ABLFillInflow.H
+++ b/amr-wind/wind_energy/ABLFillInflow.H
@@ -31,7 +31,7 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) override;
+        const FieldState fstate = FieldState::New) override;
 
     //! Implementation that handles filling patches from a coarse to fine level
     void fillpatch_from_coarse(
@@ -39,7 +39,7 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) override;
+        const FieldState fstate = FieldState::New) override;
 
     //! Implementation that handles filling physical boundary conditions
     void fillphysbc(
@@ -47,7 +47,7 @@ public:
         amrex::Real time,
         amrex::MultiFab& mfab,
         const amrex::IntVect& nghost,
-        FieldState fstate = FieldState::New) override;
+        const FieldState fstate = FieldState::New) override;
 
 protected:
     const ABLBoundaryPlane& m_bndry_plane;

--- a/amr-wind/wind_energy/ABLStats.H
+++ b/amr-wind/wind_energy/ABLStats.H
@@ -33,7 +33,9 @@ public:
     static std::string identifier() { return "precursor"; }
 
     ABLStats(
-        CFDSim& /*sim*/, const ABLWallFunction& /*abl_wall_func*/, int dir);
+        CFDSim& /*sim*/,
+        const ABLWallFunction& /*abl_wall_func*/,
+        const int dir);
 
     ~ABLStats() override;
 

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -70,11 +70,11 @@ class ABLVelWallFunc : public FieldBCIface
 public:
     ABLVelWallFunc(Field& velocity, const ABLWallFunction& wall_func);
 
-    void operator()(Field& velocity, FieldState rho_state) override;
+    void operator()(Field& velocity, const FieldState rho_state) override;
 
     template <typename ShearStress>
-    void
-    wall_model(Field& velocity, FieldState rho_state, const ShearStress& tau);
+    void wall_model(
+        Field& velocity, const FieldState rho_state, const ShearStress& tau);
 
 private:
     const ABLWallFunction& m_wall_func;
@@ -86,11 +86,11 @@ class ABLTempWallFunc : public FieldBCIface
 public:
     ABLTempWallFunc(Field& temperature, const ABLWallFunction& wall_fuc);
 
-    void operator()(Field& temperature, FieldState rho_state) override;
+    void operator()(Field& temperature, const FieldState rho_state) override;
 
     template <typename HeatFlux>
-    void
-    wall_model(Field& temperature, FieldState rho_state, const HeatFlux& tau);
+    void wall_model(
+        Field& temperature, const FieldState rho_state, const HeatFlux& tau);
 
 private:
     const ABLWallFunction& m_wall_func;

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -34,8 +34,8 @@ public:
 
     void setup_op() { copy_to_device(); }
 
-    void
-    operator()(int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
+    void operator()(
+        const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
 };
 
 template <typename ActTrait>

--- a/amr-wind/wind_energy/actuator/ActuatorContainer.H
+++ b/amr-wind/wind_energy/actuator/ActuatorContainer.H
@@ -37,7 +37,7 @@ struct ActuatorCloud
     //! Total number of turbines located on this MPI rank
     int num_objects;
 
-    explicit ActuatorCloud(int nobjects);
+    explicit ActuatorCloud(const int nobjects);
 };
 
 //! Number or real entries in Array of Structs (AOS)
@@ -63,7 +63,7 @@ class ActuatorContainer
 public:
     friend class Actuator;
 
-    explicit ActuatorContainer(amrex::AmrCore& mesh, int num_objects);
+    explicit ActuatorContainer(amrex::AmrCore& mesh, const int num_objects);
 
     void post_regrid_actions();
 
@@ -83,7 +83,7 @@ public:
 
     void populate_vel_buffer();
 
-    void initialize_particles(int total_pts);
+    void initialize_particles(const int total_pts);
 
 protected:
     void compute_local_coordinates();

--- a/amr-wind/wind_energy/actuator/ActuatorModel.H
+++ b/amr-wind/wind_energy/actuator/ActuatorModel.H
@@ -56,7 +56,9 @@ public:
     virtual void compute_forces() = 0;
 
     virtual void compute_source_term(
-        int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom) = 0;
+        const int lev,
+        const amrex::MFIter& mfi,
+        const amrex::Geometry& geom) = 0;
 
     virtual void prepare_outputs(const std::string&) = 0;
 

--- a/amr-wind/wind_energy/actuator/aero/AirfoilTable.H
+++ b/amr-wind/wind_energy/actuator/aero/AirfoilTable.H
@@ -17,10 +17,11 @@ public:
 
     ~AirfoilTable();
 
-    void operator()(amrex::Real aoa, amrex::Real& cl, amrex::Real& cd) const;
+    void
+    operator()(const amrex::Real aoa, amrex::Real& cl, amrex::Real& cd) const;
 
     void operator()(
-        amrex::Real aoa,
+        const amrex::Real aoa,
         amrex::Real& cl,
         amrex::Real& cd,
         amrex::Real& cm) const;
@@ -32,7 +33,7 @@ public:
     const VecList& polars() const { return m_polar; }
 
 protected:
-    explicit AirfoilTable(int num_entries);
+    explicit AirfoilTable(const int num_entries);
 
     void convert_aoa_to_radians();
 
@@ -46,7 +47,8 @@ protected:
 class ThinAirfoil
 {
 public:
-    void operator()(amrex::Real aoa, amrex::Real& cl, amrex::Real& cd) const;
+    void
+    operator()(const amrex::Real aoa, amrex::Real& cl, amrex::Real& cd) const;
 
     amrex::Real& cd_factor() { return m_cd_factor; }
 

--- a/amr-wind/wind_energy/actuator/disk/ActSrcDiskOp.H
+++ b/amr-wind/wind_energy/actuator/disk/ActSrcDiskOp.H
@@ -47,8 +47,8 @@ public:
 
     void setup_op() { copy_to_device(); }
 
-    void
-    operator()(int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
+    void operator()(
+        const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
 };
 
 template <typename ActTrait>

--- a/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
@@ -21,7 +21,7 @@ void write_netcdf(
     const UniformCtData& /*meta*/,
     const ActInfo& /*info*/,
     const ActGrid& /*unused*/,
-    amrex::Real /*time*/);
+    const amrex::Real /*time*/);
 } // namespace disk
 
 namespace ops {
@@ -55,8 +55,8 @@ void compute_disk_points(
     UniformCt::MetaType& meta,
     VecList& points,
     const vs::Vector& cylAxis,
-    int offset,
-    double dOffset);
+    const int offset,
+    const double dOffset);
 
 template <>
 struct ReadInputsOp<UniformCt, ActSrcDisk>

--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
@@ -37,8 +37,8 @@ public:
 
     void setup_op() { copy_to_device(); }
 
-    void
-    operator()(int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
+    void operator()(
+        const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom);
 };
 
 template <typename ActTrait>

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.H
@@ -31,13 +31,13 @@ public:
 
     int register_turbine(FastTurbine& data);
 
-    void init_turbine(int local_id);
+    void init_turbine(const int local_id);
 
-    void init_solution(int local_id);
+    void init_solution(const int local_id);
 
-    void advance_turbine(int local_id);
+    void advance_turbine(const int local_id);
 
-    void save_restart(int local_id);
+    void save_restart(const int local_id);
 
     int num_local_turbines() const { return m_turbine_data.size(); }
 
@@ -55,7 +55,9 @@ protected:
     void write_velocity_data(const FastTurbine& /*unused*/);
 
     void read_velocity_data(
-        FastTurbine& /*unused*/, const ncutils::NCFile& /*unused*/, size_t tid);
+        FastTurbine& /*unused*/,
+        const ncutils::NCFile& /*unused*/,
+        const size_t tid);
 
     //! Global to local index lookup map
     std::map<int, int> m_turbine_map;

--- a/amr-wind/wind_energy/actuator/turbine/turbine_utils.H
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_utils.H
@@ -21,7 +21,7 @@ void write_netcdf(
     const TurbineBaseData& /*meta*/,
     const TurbineInfo& /*info*/,
     const ActGrid& /*grid*/,
-    amrex::Real /*time*/);
+    const amrex::Real /*time*/);
 
 } // namespace utils
 } // namespace actuator

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -31,7 +31,7 @@ void write_netcdf(
     const WingBaseData& /*meta*/,
     const ActInfo& /*info*/,
     const ActGrid& /*grid*/,
-    amrex::Real /*time*/);
+    const amrex::Real /*time*/);
 
 } // namespace wing
 


### PR DESCRIPTION
Reverts Exawind/amr-wind#594

This appears to cause problem in some of the GPU kernels only at runtime. Since I don't understand why. I will just revert it.