### PR TITLE
Update docs to mention constant lidar position

### DIFF
--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -83,7 +83,8 @@ with ``num_points`` equidistant nodes.
 Location of the line is given by the time histories 
 ``azimuth_table`` and ``elevation_table``.
 Angles are given in degrees with 0 azimuth and 0 elevation being the 
-x direction.
+x direction. Lidar measurements may also be collected at a constant location
+by specifying only one entry to the tables.
 
 Example::
 


### PR DESCRIPTION
I was uncertain if we could keep the lidar at a constant location or if it needed to move around. I confirmed that we can keep the lidar in one location and updated the docs to clarify.