### PR TITLE
Multiphase CFL calc

### DIFF
--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -430,6 +430,29 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void fit_plane(
         alpha + amrex::min(0.0, mx) + amrex::min(0.0, my) + amrex::min(0.0, mz);
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
+    int i,
+    int j,
+    int k,
+    amrex::Array4<amrex::Real const> const& volfrac) noexcept
+{
+    // Check if near interface
+    amrex::Real VOF_max = 0.0;
+    amrex::Real VOF_min = 1.0;
+    bool VOF_mid = false;
+    for (int ii = -1; ii < 2; ++ii) {
+        for (int jj = -1; jj < 2; ++jj) {
+            for (int kk = -1; kk < 2; ++kk) {
+                amrex::Real VOF = volfrac(i + ii, j + jj, k + kk);
+                VOF_max = amrex::max(VOF_max, VOF);
+                VOF_min = amrex::min(VOF_min, VOF);
+                if (VOF < 1.0 && VOF > 0.0) VOF_mid = true;
+            }
+        }
+    }
+    return (VOF_max != VOF_min || VOF_mid);
+}
+
 } // namespace multiphase
 } // namespace amr_wind
 

--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -447,7 +447,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
                 amrex::Real VOF = volfrac(i + ii, j + jj, k + kk);
                 VOF_max = amrex::max(VOF_max, VOF);
                 VOF_min = amrex::min(VOF_min, VOF);
-                if (VOF - 1.0 < tiny && VOF > tiny) VOF_mid = true;
+                if (VOF - 1.0 < tiny && VOF > tiny) {
+                    VOF_mid = true;
+                }
             }
         }
     }

--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -436,6 +436,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
     int k,
     amrex::Array4<amrex::Real const> const& volfrac) noexcept
 {
+    constexpr amrex::Real tiny = 1e-12;
     // Check if near interface
     amrex::Real VOF_max = 0.0;
     amrex::Real VOF_min = 1.0;
@@ -446,7 +447,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
                 amrex::Real VOF = volfrac(i + ii, j + jj, k + kk);
                 VOF_max = amrex::max(VOF_max, VOF);
                 VOF_min = amrex::min(VOF_min, VOF);
-                if (VOF < 1.0 && VOF > 0.0) VOF_mid = true;
+                if (VOF - 1.0 < tiny && VOF > tiny) VOF_mid = true;
             }
         }
     }

--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -1,4 +1,5 @@
 #include "amr-wind/incflo.H"
+#include "amr-wind/equation_systems/vof/volume_fractions.H"
 
 #include <cmath>
 #include <limits>
@@ -39,6 +40,7 @@ void incflo::ComputeDt(bool explicit_diffusion)
     Real diff_cfl = 0.0;
     Real force_cfl = 0.0;
     const bool mesh_mapping = m_sim.has_mesh_mapping();
+    const bool yes_vof = m_repo.field_exists("vof");
 
     const auto& den = density();
     amr_wind::Field const* mesh_fac =
@@ -59,6 +61,7 @@ void incflo::ComputeDt(bool explicit_diffusion)
                          : MultiArray4<Real const>();
 
         Real conv_lev = 0.0;
+        Real mphase_conv_lev = 0.0;
         Real diff_lev = 0.0;
         Real force_lev = 0.0;
 
@@ -81,6 +84,43 @@ void incflo::ComputeDt(bool explicit_diffusion)
                     amrex::Math::abs(v_bx(i, j, k, 2)) * dxinv[2] / fac_z,
                     -1.0);
             });
+
+        if (yes_vof) {
+            MultiFab const& vof = m_repo.get_field("vof")(lev);
+            auto const& vof_arr = vof.const_arrays();
+            mphase_conv_lev += amrex::ParReduce(
+                TypeList<ReduceOpMax>{}, TypeList<Real>{}, vel, IntVect(0),
+                [=] AMREX_GPU_HOST_DEVICE(
+                    int box_no, int i, int j, int k) -> GpuTuple<Real> {
+                    auto const& v_bx = vel_arr[box_no];
+                    auto const& vof_bx = vof_arr[box_no];
+
+                    // Check for interface
+                    auto is_near =
+                        amr_wind::multiphase::interface_band(i, j, k, vof_bx);
+
+                    // CFL calculation is not needed away from interface
+                    amrex::Real result = 0.0;
+                    if (is_near) {
+                        // Near interface, evaluate CFL by sum of velocities
+                        amrex::Real fac_x =
+                            mesh_mapping ? (fac_arr[box_no](i, j, k, 0)) : 1.0;
+                        amrex::Real fac_y =
+                            mesh_mapping ? (fac_arr[box_no](i, j, k, 1)) : 1.0;
+                        amrex::Real fac_z =
+                            mesh_mapping ? (fac_arr[box_no](i, j, k, 2)) : 1.0;
+
+                        result = amrex::Math::abs(v_bx(i, j, k, 0)) * dxinv[0] /
+                                     fac_x +
+                                 amrex::Math::abs(v_bx(i, j, k, 1)) * dxinv[1] /
+                                     fac_y +
+                                 amrex::Math::abs(v_bx(i, j, k, 2)) * dxinv[2] /
+                                     fac_z;
+                    }
+                    return result;
+                });
+        }
+        conv_lev = amrex::max(conv_lev,mphase_conv_lev);
 
         if (explicit_diffusion) {
             auto const& mu_arr = mu.const_arrays();

--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -120,7 +120,7 @@ void incflo::ComputeDt(bool explicit_diffusion)
                     return result;
                 });
         }
-        conv_lev = amrex::max(conv_lev,mphase_conv_lev);
+        conv_lev = amrex::max(conv_lev, mphase_conv_lev);
 
         if (explicit_diffusion) {
             auto const& mu_arr = mu.const_arrays();

--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -40,7 +40,6 @@ void incflo::ComputeDt(bool explicit_diffusion)
     Real diff_cfl = 0.0;
     Real force_cfl = 0.0;
     const bool mesh_mapping = m_sim.has_mesh_mapping();
-    const bool yes_vof = m_repo.field_exists("vof");
 
     const auto& den = density();
     amr_wind::Field const* mesh_fac =
@@ -85,7 +84,7 @@ void incflo::ComputeDt(bool explicit_diffusion)
                     -1.0);
             });
 
-        if (yes_vof) {
+        if (m_sim.pde_manager().has_pde("VOF")) {
             MultiFab const& vof = m_repo.get_field("vof")(lev);
             auto const& vof_arr = vof.const_arrays();
             mphase_conv_lev += amrex::ParReduce(


### PR DESCRIPTION
PR provides new way to calculate CFL, which adds the contribution of the velocities in each direction. This only turns on when the VOF variable is present, and it is the CFL that is used to guarantee conservation of VOF according to the Weymouth and Yue advection scheme.