### PR TITLE
initializing a vector to avoid a compiler warning

### DIFF
--- a/unit_tests/utilities/test_free_surface.cpp
+++ b/unit_tests/utilities/test_free_surface.cpp
@@ -541,7 +541,7 @@ TEST_F(FreeSurfaceTest, sloped)
 
     // Calculate expected output values
     amrex::Vector<amrex::Real> out_vec;
-    out_vec.resize(npts * npts);
+    out_vec.resize(npts * npts, 0.0);
     // Step in x, then y
     // Most calcuations done by hand, not shown
     out_vec[0] = water_level2 + 2.0 * (0.5 - 0.375) / (0.375 - 1.0);


### PR DESCRIPTION
@tonyinme noticed a compiler warning in February that occurred in the FreeSurface unit test. this minor fix eliminates the warning.