### PR TITLE
abl_bndry_input requires abl_bndry_output to generate chk0004

### DIFF
--- a/test/test_files/abl_bndry_output/abl_bndry_output.i
+++ b/test/test_files/abl_bndry_output/abl_bndry_output.i
@@ -12,7 +12,7 @@ time.cfl              =   0.95         # CFL factor
 #            INPUT AND OUTPUT           #
 #.......................................#
 time.plot_interval            =  10       # Steps between plot files
-time.checkpoint_interval      =  5       # Steps between checkpoint files
+time.checkpoint_interval      =  4       # Steps between checkpoint files
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #               PHYSICS                 #
 #.......................................#


### PR DESCRIPTION
This fixes errors in `abl_bndry_input` which depends on `abl_bndry_output` due to changes in https://github.com/Exawind/amr-wind/pull/613