### PR TITLE
Conservative ICNS (velocity equation)

### DIFF
--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -96,7 +96,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         }
 
         // TODO: Need iconserv flag to be adjusted???
-        iconserv.resize(ICNS::ndim, 0);
+        iconserv.resize(ICNS::ndim, 1);
     }
 
     void preadvect(const FieldState fstate, const amrex::Real dt)

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -95,8 +95,10 @@ struct AdvectionOp<ICNS, fvm::Godunov>
             godunov_scheme = godunov::scheme::PPM;
         }
 
-        // TODO: Need iconserv flag to be adjusted???
-        iconserv.resize(ICNS::ndim, 1);
+        // Formulation of discrete ICNS equation
+        // 1 = conservative (default), 0 = nonconservative
+        pp.query("icns_conserv", m_cons);
+        iconserv.resize(ICNS::ndim, m_cons);
     }
 
     void preadvect(const FieldState fstate, const amrex::Real dt)
@@ -350,6 +352,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
     godunov::scheme godunov_scheme = godunov::scheme::PPM;
     std::string godunov_type;
     bool godunov_use_forces_in_trans{false};
+    int m_cons{1};
 };
 
 /** MOL scheme for ICNS


### PR DESCRIPTION
changing the icns formulation to be conservative. will cause reg test diffs, but has been evaluated in a variety of ABL simulations and is necessary for going forward with multiphase.