### PR TITLE
Replace _OPENMP with AMREX_USE_OMP for OpenMP control of MFiter loops

### DIFF
--- a/amr-wind/boundary_conditions/FixedGradientBC.cpp
+++ b/amr-wind/boundary_conditions/FixedGradientBC.cpp
@@ -38,7 +38,7 @@ void FixedGradientBC::operator()(Field& field, const FieldState /*rho_state*/)
         if (amrex::Gpu::notInLaunchRegion()) {
             mfi_info.SetDynamic(true);
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(field(lev), mfi_info); mfi.isValid(); ++mfi) {

--- a/amr-wind/diffusion/incflo_diffusion.cpp
+++ b/amr-wind/diffusion/incflo_diffusion.cpp
@@ -132,7 +132,7 @@ void fixup_eta_on_domain_faces(
     if (Gpu::notInLaunchRegion()) {
         mfi_info.SetDynamic(true);
     }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cc, mfi_info); mfi.isValid(); ++mfi) {

--- a/amr-wind/equation_systems/AdvOp_Godunov.H
+++ b/amr-wind/equation_systems/AdvOp_Godunov.H
@@ -97,7 +97,7 @@ struct AdvectionOp<
                 mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
                     .SetDynamic(true);
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();
@@ -157,7 +157,7 @@ struct AdvectionOp<
         }
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU());

--- a/amr-wind/equation_systems/AdvOp_MOL.H
+++ b/amr-wind/equation_systems/AdvOp_MOL.H
@@ -59,7 +59,7 @@ struct AdvectionOp<
                 mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
                     .SetDynamic(true);
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(density(lev), mfi_info); mfi.isValid();

--- a/amr-wind/equation_systems/CompRHSOps.H
+++ b/amr-wind/equation_systems/CompRHSOps.H
@@ -76,7 +76,7 @@ struct ComputeRHSOp
                          : nullptr;
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
@@ -195,7 +195,7 @@ struct ComputeRHSOp
                          : nullptr;
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {

--- a/amr-wind/equation_systems/DiffusionOps.cpp
+++ b/amr-wind/equation_systems/DiffusionOps.cpp
@@ -126,7 +126,7 @@ void DiffSolverIface<LinOp>::linsys_solve_impl()
     for (int lev = 0; lev < nlevels; ++lev) {
         auto& rhs = (*rhs_ptr)(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(rhs, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/equation_systems/PDEOps.H
+++ b/amr-wind/equation_systems/PDEOps.H
@@ -100,7 +100,7 @@ struct SrcTermOpBase
         const int nlevels = fields.repo.num_active_levels();
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& src_term = fields.src_term(lev);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());
@@ -132,7 +132,7 @@ struct SrcTermOpBase
         const int nlevels = this->fields.repo.num_active_levels();
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& src_term = this->fields.src_term(lev);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());

--- a/amr-wind/equation_systems/density/density_ops.H
+++ b/amr-wind/equation_systems/density/density_ops.H
@@ -28,7 +28,7 @@ struct ComputeRHSOp<Density, Scheme>
         const auto& conv_term = fields.conv_term.state(fstate);
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
@@ -60,7 +60,7 @@ struct ComputeRHSOp<Density, Scheme>
         const auto& conv_term_old = fields.conv_term.state(FieldState::Old);
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -119,7 +119,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         // Predict
         //
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             {
@@ -281,7 +281,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
                 mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
                     .SetDynamic(true);
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();
@@ -322,7 +322,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), amrex::TilingIfNotGPU());
@@ -390,7 +390,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
         //
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             {
@@ -426,7 +426,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
                 mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
                     .SetDynamic(true);
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();

--- a/amr-wind/equation_systems/icns/icns_diffusion.H
+++ b/amr-wind/equation_systems/icns/icns_diffusion.H
@@ -48,7 +48,7 @@ public:
         const auto& density = m_density.state(fstate);
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(divtau(lev), amrex::TilingIfNotGPU());
@@ -178,7 +178,7 @@ public:
         mlmg.apply(divtau.vec_ptrs(), m_pdefields.field.vec_ptrs());
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(divtau(lev), amrex::TilingIfNotGPU());
@@ -248,7 +248,7 @@ public:
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& rhs = (*rhs_ptr)(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(rhs, amrex::TilingIfNotGPU()); mfi.isValid();
@@ -406,7 +406,7 @@ public:
         }
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(divtau(lev), amrex::TilingIfNotGPU());
@@ -487,7 +487,7 @@ public:
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& rhs = (*rhs_ptr)(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(rhs, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/equation_systems/icns/icns_ops.H
+++ b/amr-wind/equation_systems/icns/icns_ops.H
@@ -92,7 +92,7 @@ struct SrcTermOp<ICNS> : SrcTermOpBase<ICNS>
         const int nlevels = this->fields.repo.num_active_levels();
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& src_term = this->fields.src_term(lev);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(src_term, amrex::TilingIfNotGPU());

--- a/amr-wind/equation_systems/levelset/levelset_ops.H
+++ b/amr-wind/equation_systems/levelset/levelset_ops.H
@@ -68,7 +68,7 @@ struct ComputeRHSOp<Levelset, Scheme>
         const auto& conv_term = fields.conv_term.state(fstate);
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {
@@ -100,7 +100,7 @@ struct ComputeRHSOp<Levelset, Scheme>
         const auto& conv_term_old = fields.conv_term.state(FieldState::Old);
 
         for (int lev = 0; lev < nlevels; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(field(lev)); mfi.isValid(); ++mfi) {

--- a/amr-wind/equation_systems/vof/vof_advection.H
+++ b/amr-wind/equation_systems/vof/vof_advection.H
@@ -58,7 +58,7 @@ struct AdvectionOp<VOF, fvm::Godunov>
                 mfi_info.EnableTiling(amrex::IntVect(1024, 1024, 1024))
                     .SetDynamic(true);
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
             for (amrex::MFIter mfi(dof_field(lev), mfi_info); mfi.isValid();

--- a/amr-wind/fvm/fvm_utils.H
+++ b/amr-wind/fvm/fvm_utils.H
@@ -21,7 +21,7 @@ inline void apply(const FvmOp& fvmop, const FType& fld)
         const auto& domain = fld.repo().mesh().Geom(lev).Domain();
         const auto& mfab = fld(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -29,7 +29,7 @@ void iblank_to_mask(const IntField& iblank, IntField& maskf)
         const auto& ibl = iblank(lev);
         auto& mask = maskf(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(ibl); mfi.isValid(); ++mfi) {

--- a/amr-wind/physics/mms/MMS.cpp
+++ b/amr-wind/physics/mms/MMS.cpp
@@ -82,7 +82,7 @@ void MMS::fill_src()
         const auto& dx = m_mesh.Geom(lev).CellSizeArray();
         const auto& problo = m_mesh.Geom(lev).ProbLoArray();
         auto& mms_src_term = m_mms_vel_source(lev);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(mms_src_term, amrex::TilingIfNotGPU());

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -156,7 +156,7 @@ void incflo::ApplyProjection(
     if (!incremental) {
         for (int lev = 0; lev <= finest_level; lev++) {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(velocity(lev), TilingIfNotGPU()); mfi.isValid();
@@ -191,7 +191,7 @@ void incflo::ApplyProjection(
     if (add_surface_tension && !incremental) {
         // Create the Surface tension forcing term (Cell-centered)
         for (int lev = 0; lev <= finest_level; ++lev) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             {
@@ -247,7 +247,7 @@ void incflo::ApplyProjection(
         for (int lev = 0; lev <= finest_level; ++lev) {
             sigma[lev].define(
                 grids[lev], dmap[lev], ncomp, 0, MFInfo(), Factory(lev));
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(sigma[lev], TilingIfNotGPU()); mfi.isValid();
@@ -373,7 +373,7 @@ void incflo::ApplyProjection(
 
     for (int lev = 0; lev <= finest_level; lev++) {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(grad_p(lev), TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/amr-wind/utilities/FieldPlaneAveraging.cpp
+++ b/amr-wind/utilities/FieldPlaneAveraging.cpp
@@ -267,7 +267,7 @@ void FPlaneAveraging<FType>::compute_averages(
     amrex::Real* line_avg = lavg.data();
     const int captured_ncomp = m_ncomp;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();
@@ -374,7 +374,7 @@ void VelPlaneAveraging::compute_hvelmag_averages(
         m_line_hvelmag_average.data(), m_line_hvelmag_average.size());
     amrex::Real* line_avg = lavg.data();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/SecondMomentAveraging.cpp
+++ b/amr-wind/utilities/SecondMomentAveraging.cpp
@@ -146,7 +146,7 @@ void SecondMomentAveraging::compute_average(
     const int ncomp2 = m_plane_average2.ncomp();
     const int nmoments = m_num_moments;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab1, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/ThirdMomentAveraging.cpp
+++ b/amr-wind/utilities/ThirdMomentAveraging.cpp
@@ -169,7 +169,7 @@ void ThirdMomentAveraging::compute_average(
     const int ncomp3 = m_plane_average3.ncomp();
     const int nmoments = m_num_moments;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab1, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/averaging/ReAveraging.cpp
+++ b/amr-wind/utilities/averaging/ReAveraging.cpp
@@ -59,7 +59,7 @@ void ReAveraging::operator()(
         const auto& ffab = m_field(lev);
         auto& afab = m_average(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(ffab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/averaging/ReynoldsStress.cpp
+++ b/amr-wind/utilities/averaging/ReynoldsStress.cpp
@@ -76,7 +76,7 @@ void ReynoldsStress::operator()(
         auto& sfab = m_stress(lev);
         auto& rfab = m_re_stress(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(ffab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/console_io.cpp
+++ b/amr-wind/utilities/console_io.cpp
@@ -132,7 +132,7 @@ void print_banner(MPI_Comm comm, std::ostream& out)
         << "OFF" << std::endl
 #endif
         << "  OpenMP           :: "
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         << "ON    (Num. threads = " << omp_get_max_threads() << ")" << std::endl
 #else
         << "OFF" << std::endl

--- a/amr-wind/utilities/tagging/CurvatureRefinement.cpp
+++ b/amr-wind/utilities/tagging/CurvatureRefinement.cpp
@@ -51,7 +51,7 @@ void CurvatureRefinement::operator()(
     const auto& mfab = (*m_field)(level);
     const auto& idx = m_sim.repo().mesh().Geom(level).InvCellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/tagging/FieldRefinement.cpp
+++ b/amr-wind/utilities/tagging/FieldRefinement.cpp
@@ -63,7 +63,7 @@ void FieldRefinement::operator()(
     }
 
     const auto& mfab = (*m_field)(level);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -51,7 +51,7 @@ void GeometryRefinement::operator()(
     // We are always guaranteed to have at least one field
     const auto& field_fab = (*m_sim.repo().fields()[0])(level);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(field_fab); mfi.isValid(); ++mfi) {

--- a/amr-wind/utilities/tagging/GradientMagRefinement.cpp
+++ b/amr-wind/utilities/tagging/GradientMagRefinement.cpp
@@ -52,7 +52,7 @@ void GradientMagRefinement::operator()(
     const auto& mfab = (*m_field)(level);
     const auto& idx = m_sim.repo().mesh().Geom(level).InvCellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/tagging/OversetRefinement.cpp
+++ b/amr-wind/utilities/tagging/OversetRefinement.cpp
@@ -31,7 +31,7 @@ void OversetRefinement::operator()(
     const bool tag_fringe = m_tag_fringe;
     const bool tag_hole = m_tag_hole;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(ibfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/tagging/QCriterionRefinement.cpp
+++ b/amr-wind/utilities/tagging/QCriterionRefinement.cpp
@@ -59,7 +59,7 @@ void QCriterionRefinement::operator()(
 
     const auto nondim = m_nondim;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/utilities/tagging/VorticityMagRefinement.cpp
+++ b/amr-wind/utilities/tagging/VorticityMagRefinement.cpp
@@ -55,7 +55,7 @@ void VorticityMagRefinement::operator()(
     const auto& mfab = (*m_vel)(level);
     const auto& idx = m_sim.repo().mesh().Geom(level).InvCellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -912,7 +912,7 @@ void ABLBoundaryPlane::populate_data(
 
         const size_t nc = mfab.nComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();
@@ -974,7 +974,7 @@ void ABLBoundaryPlane::write_data(
     const int n_buffers = m_mesh.boxArray(lev).size();
     amrex::Vector<BufferData> buffers(n_buffers);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi((*fld)(lev), false); mfi.isValid(); ++mfi) {

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -131,7 +131,7 @@ void ABLFieldInit::perturb_temperature(
     const auto theta_gauss_var = m_theta_gauss_var;
     const auto deltaT = m_deltaT;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(theta_fab, amrex::TilingIfNotGPU()); mfi.isValid();

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -178,7 +178,7 @@ void ABLVelWallFunc::wall_model(
         if (amrex::Gpu::notInLaunchRegion()) {
             mfi_info.SetDynamic(true);
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(vel_lev, mfi_info); mfi.isValid(); ++mfi) {
@@ -306,7 +306,7 @@ void ABLTempWallFunc::wall_model(
         if (amrex::Gpu::notInLaunchRegion()) {
             mfi_info.SetDynamic(true);
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(theta, mfi_info); mfi.isValid(); ++mfi) {

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -189,7 +189,7 @@ void Actuator::compute_source_term()
         auto& sfab = m_act_source(lev);
         const auto& geom = m_sim.mesh().Geom(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::MFIter mfi(sfab); mfi.isValid(); ++mfi) {


### PR DESCRIPTION
This is necessary for Ascent which enables OpenMP for itself.