### PR TITLE
Actuators: Make density a sampled quantity

### DIFF
--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -161,9 +161,14 @@ void Actuator::update_velocities()
     auto& pinfo = m_container->m_data;
     for (int i = 0, ic = 0; i < pinfo.num_objects; ++i) {
         const auto ig = pinfo.global_id[i];
+
         const auto vel =
             ::amr_wind::utils::slice(pinfo.velocity, ic, pinfo.num_pts[i]);
-        m_actuators[ig]->update_velocities(vel);
+
+        const auto density =
+            ::amr_wind::utils::slice(pinfo.density, ic, pinfo.num_pts[i]);
+
+        m_actuators[ig]->update_fields(vel, density);
         ic += pinfo.num_pts[i];
     }
 }

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -147,7 +147,8 @@ void Actuator::update_positions()
 
     // Sample velocities at the new locations
     const auto& vel = m_sim.repo().get_field("velocity");
-    m_container->sample_velocities(vel);
+    const auto& density = m_sim.repo().get_field("density");
+    m_container->sample_fields(vel, density);
 }
 
 /** Provide updated velocities from container to actuator instances

--- a/amr-wind/wind_energy/actuator/ActuatorContainer.H
+++ b/amr-wind/wind_energy/actuator/ActuatorContainer.H
@@ -34,6 +34,9 @@ struct ActuatorCloud
     //! Velocity vectors of all actuator nodes belonging to this MPI rank
     amrex::Vector<vs::Vector> velocity;
 
+    //! Density of all actuator nodes belonging to this MPI rank
+    amrex::Vector<amrex::Real> density;
+
     //! Total number of turbines located on this MPI rank
     int num_objects;
 
@@ -41,7 +44,7 @@ struct ActuatorCloud
 };
 
 //! Number or real entries in Array of Structs (AOS)
-static constexpr int NumPStructReal = AMREX_SPACEDIM;
+static constexpr int NumPStructReal = AMREX_SPACEDIM + 1;
 //! Number of integer entries in Array of Structs (AOS)
 static constexpr int NumPStructInt = 1;
 //! Number of real entries in Struct of Arrays (SOA)
@@ -73,15 +76,15 @@ public:
 
     void update_positions();
 
-    void sample_velocities(const Field& vel);
+    void sample_fields(const Field& vel, const Field& density);
 
     int num_actuator_points() const { return m_data.position.size(); }
 
     // public for CUDA, not safe for general access
 
-    void interpolate_velocities(const Field& vel);
+    void interpolate_fields(const Field& vel, const Field& density);
 
-    void populate_vel_buffer();
+    void populate_field_buffers();
 
     void initialize_particles(const int total_pts);
 

--- a/amr-wind/wind_energy/actuator/ActuatorContainer.cpp
+++ b/amr-wind/wind_energy/actuator/ActuatorContainer.cpp
@@ -1,16 +1,11 @@
 #include "amr-wind/wind_energy/actuator/ActuatorContainer.H"
-#include "amr-wind/core/vs/vector.H"
 #include "amr-wind/wind_energy/actuator/Actuator.H"
 #include "amr-wind/core/gpu_utils.H"
 #include "amr-wind/core/Field.H"
 
 #include "AMReX_Scan.H"
 
-#include <AMReX_Config.H>
-#include <AMReX_Extension.H>
-#include <AMReX_GpuQualifiers.H>
 #include <algorithm>
-#include <cstddef>
 
 namespace amr_wind {
 namespace actuator {

--- a/amr-wind/wind_energy/actuator/ActuatorModel.H
+++ b/amr-wind/wind_energy/actuator/ActuatorModel.H
@@ -51,7 +51,7 @@ public:
 
     virtual void update_positions(VecSlice&) = 0;
 
-    virtual void update_velocities(const VecSlice&) = 0;
+    virtual void update_fields(const VecSlice&, const RealSlice&) = 0;
 
     virtual void compute_forces() = 0;
 
@@ -138,9 +138,11 @@ public:
         std::copy(vpos.begin(), vpos.end(), pos.begin());
     }
 
-    void update_velocities(const VecSlice& vel) override
+    void update_fields(const VecSlice& vel, const RealSlice& density) override
     {
         std::copy(vel.begin(), vel.end(), m_data.grid().vel.begin());
+        std::copy(
+            density.begin(), density.end(), m_data.grid().density.begin());
         ops::UpdateVelOp<ActTrait, SrcTrait>()(m_data);
     }
 

--- a/amr-wind/wind_energy/actuator/actuator_types.H
+++ b/amr-wind/wind_energy/actuator/actuator_types.H
@@ -90,6 +90,9 @@ struct ActGrid
     //! Velocity vector at the sampled locations
     VecList vel;
 
+    //! Density at the smapled locations
+    RealList density;
+
     /** Helper method to resize the data arrays defined on the grid
      *
      *  \params Number of nodes that contain forcing data
@@ -103,6 +106,7 @@ struct ActGrid
         orientation.resize(num_force_pts);
         vel_pos.resize(num_vel_pts);
         vel.resize(num_vel_pts);
+        density.resize(num_vel_pts);
     }
 
     /** Convenience function to resize both force/velocity data to same

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -125,7 +125,8 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
         const amrex::Real dTheta =
             amr_wind::utils::two_pi() / ddata.num_vel_pts_t;
 
-        const amrex::Real geometry_factor = ddata.dr * ddata.dr * dTheta * 0.5;
+        const ops::base::AreaComputer area(
+            ddata.radius(), ddata.num_vel_pts_r, ddata.num_vel_pts_t);
 
         const amrex::Real lambda =
             ddata.radius() * ddata.current_angular_velocity / U_ref;
@@ -195,6 +196,8 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
 
             ddata.f_normal[i] = f_z;
 
+            const auto dArea = area.area_section(i);
+
             for (int j = 0; j < ddata.num_vel_pts_t; j++, ip++) {
                 const auto point_current = grid.pos[ip];
 
@@ -209,9 +212,6 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
 
                 const amrex::Real f_theta = u_disk_ij / U_ref * q0 * g * F / x;
                 ddata.f_theta[ip] = f_theta;
-
-                const amrex::Real dArea =
-                    geometry_factor * (std::pow(i + 1.0, 2) - std::pow(i, 2));
 
                 // eq 18
                 moment += x * ddata.radius() * f_theta * dArea;

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -222,13 +222,12 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 grid.force[ip] =
                     (f_z * ddata.normal_vec + f_theta * theta_vec) *
                     ddata.density * uInfSqr * dArea;
-<<<<<<< HEAD
 
-=======
->>>>>>> 2f751a9d (Remove second theta division)
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }
+        // add missing R^3 factor for equation 18
+        moment *= std::pow(ddata.diameter * 0.5, 3);
 
         // equation 20
         const amrex::Real eq_20_denominator = std::max(

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -48,14 +48,11 @@ struct InitDataOp<Joukowsky, ActSrcDisk>
 {
     void operator()(typename Joukowsky::DataType& data)
     {
+        ops::base::allocate_basic_grid_quantities<Joukowsky>(data);
+
         auto& grid = data.grid();
         auto& meta = data.meta();
 
-        // only resize the members we are going to use
-        grid.pos.resize(meta.num_force_pts);
-        grid.force.resize(meta.num_force_pts);
-        grid.vel.resize(meta.num_vel_pts);
-        grid.vel_pos.resize(meta.num_vel_pts);
         meta.tip_correction.resize(meta.num_vel_pts_r);
         meta.root_correction.resize(meta.num_vel_pts_r);
         meta.f_normal.resize(meta.num_vel_pts_r);

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -226,8 +226,6 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }
-        // add missing R^3 factor for equation 18
-        moment *= std::pow(ddata.diameter * 0.5, 3);
 
         // equation 20
         const amrex::Real eq_20_denominator = std::max(

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -222,7 +222,10 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 grid.force[ip] =
                     (f_z * ddata.normal_vec + f_theta * theta_vec) *
                     ddata.density * uInfSqr * dArea;
+<<<<<<< HEAD
 
+=======
+>>>>>>> 2f751a9d (Remove second theta division)
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -122,8 +122,6 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
 
         const amrex::Real Ct = ddata.current_ct;
         const amrex::Real dx = ddata.dr / ddata.radius();
-        const amrex::Real dTheta =
-            amr_wind::utils::two_pi() / ddata.num_vel_pts_t;
 
         const ops::base::AreaComputer area(
             ddata.radius(), ddata.num_vel_pts_r, ddata.num_vel_pts_t);

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.H
@@ -59,6 +59,19 @@ void final_checks(const DiskBaseData& meta);
 amrex::RealBox compute_bounding_box(const DiskBaseData& meta);
 
 template <typename T>
+void allocate_basic_grid_quantities(typename T::DataType& data)
+{
+    auto& grid = data.grid();
+    auto& meta = data.meta();
+    // only resize the members we are going to use
+    grid.pos.resize(meta.num_force_pts);
+    grid.force.resize(meta.num_force_pts);
+    grid.vel.resize(meta.num_vel_pts);
+    grid.vel_pos.resize(meta.num_vel_pts);
+    grid.density.resize(meta.num_vel_pts);
+}
+
+template <typename T>
 void do_parse_based_computations(ActDataHolder<T>& data)
 {
     auto& meta = data.meta();
@@ -117,15 +130,20 @@ struct UpdateVelOp<
         const auto& grid = data.grid();
         meta.reference_velocity = {0.0, 0.0, 0.0};
         meta.mean_disk_velocity = {0.0, 0.0, 0.0};
+        meta.density = 0.0;
         auto& refVel = meta.reference_velocity;
         auto& diskVel = meta.mean_disk_velocity;
+        auto& density = meta.density;
         const int np = meta.num_vel_pts / 2;
+        assert(!grid.density.empty());
         for (int i = 0; i < np; i++) {
+            density += grid.density[i];
             refVel = refVel + grid.vel[i];
             diskVel = diskVel + grid.vel[i + np];
         }
         refVel /= np;
         diskVel /= np;
+        density /= np;
     }
 };
 

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.H
@@ -151,15 +151,19 @@ struct UpdateVelOp<
         auto& diskVel = meta.mean_disk_velocity;
         auto& density = meta.density;
         const int np = meta.num_vel_pts / 2;
+        const int num_r = meta.num_vel_pts_r;
+        const int num_t = meta.num_vel_pts_t;
 
-        for (int i = 0; i < np; i++) {
-            density += grid.density[i];
-            refVel = refVel + grid.vel[i];
-            diskVel = diskVel + grid.vel[i + np];
+        const base::AreaComputer area(meta.radius(), num_r, num_t);
+
+        for (int i = 0; i < num_r; i++) {
+            const auto weight = area.weight(i);
+            for (int j = 0; j < num_t; ++j) {
+                density += grid.density[j + i * num_t] * weight;
+                refVel = refVel + grid.vel[j + i * num_t] * weight;
+                diskVel = diskVel + grid.vel[j + i * num_t + np] * weight;
+            }
         }
-        refVel /= np;
-        diskVel /= np;
-        density /= np;
     }
 };
 

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.H
@@ -26,6 +26,22 @@ void write_netcdf(
 
 namespace ops {
 namespace base {
+
+class AreaComputer
+{
+public:
+    AreaComputer(
+        const amrex::Real radius, const int num_r, const int num_theta);
+
+    amrex::Real area_section(const int iRadius) const;
+
+    amrex::Real weight(const int iRadius) const;
+
+private:
+    const amrex::Real area;
+    const amrex::Real geometry_factor;
+};
+
 vs::Vector compute_coplanar_vector(const vs::Vector& normal);
 
 void collect_parse_conflicts(
@@ -135,7 +151,7 @@ struct UpdateVelOp<
         auto& diskVel = meta.mean_disk_velocity;
         auto& density = meta.density;
         const int np = meta.num_vel_pts / 2;
-        assert(!grid.density.empty());
+
         for (int i = 0; i < np; i++) {
             density += grid.density[i];
             refVel = refVel + grid.vel[i];

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
@@ -196,7 +196,6 @@ void optional_parameters(DiskBaseData& meta, const utils::ActParser& pp)
     }
     pp.query("disk_center", meta.center);
     pp.query("disk_normal", meta.normal_vec);
-    pp.query("density", meta.density);
     pp.query("diameters_to_sample", meta.diameters_to_sample);
     pp.query("num_points_t", meta.num_force_theta_pts);
 

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
@@ -96,6 +96,22 @@ void write_netcdf(
 namespace ops {
 namespace base {
 
+AreaComputer::AreaComputer(
+    const amrex::Real radius, const int num_r, const int num_theta)
+    : area(M_PI * radius * radius)
+    , geometry_factor(radius * radius / num_r / num_r * M_PI / num_theta)
+{}
+
+amrex::Real AreaComputer::area_section(const int iRadius) const
+{
+    return geometry_factor * (std::pow(iRadius + 1, 2) - std::pow(iRadius, 2));
+}
+
+amrex::Real AreaComputer::weight(const int iRadius) const
+{
+    return area_section(iRadius) / area;
+}
+
 vs::Vector get_east_orientation()
 {
     utils::ActParser pp("Coriolis.Forcing", "Coriolis");

--- a/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
@@ -17,7 +17,6 @@ struct ReadInputsOp<UniformCt, ActSrcDisk>
 {
     void operator()(UniformCt::DataType& data, const utils::ActParser& pp)
     {
-        // TODO get density at probe location
         auto& meta = data.meta();
         uniformct::parse_and_gather_params(pp, meta);
         base::do_parse_based_computations<UniformCt>(data);

--- a/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/uniform_ct_ops.H
@@ -59,14 +59,11 @@ struct InitDataOp<UniformCt, ActSrcDisk>
 {
     void operator()(typename UniformCt::DataType& data)
     {
+
+        ops::base::allocate_basic_grid_quantities<UniformCt>(data);
+
         auto& grid = data.grid();
         auto& meta = data.meta();
-
-        // only resize the members we are going to use
-        grid.pos.resize(meta.num_force_pts);
-        grid.force.resize(meta.num_force_pts);
-        grid.vel.resize(meta.num_vel_pts);
-        grid.vel_pos.resize(meta.num_vel_pts);
 
         const auto& cVec = meta.coplanar_vec;
         const auto& sVec = meta.sample_vec;

--- a/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_flat_plate.cpp
@@ -220,6 +220,8 @@ TEST_F(ActFlatPlateTest, actuator_init)
 {
     initialize_mesh();
     auto& vel = sim().repo().declare_field("velocity", 3, 3);
+    auto& density = sim().repo().declare_field("density", 1, 3);
+    density.setVal(1.0);
     init_field(vel);
     amr_wind::actuator::ActuatorContainer::ParticleType::NextID(1U);
 
@@ -253,6 +255,8 @@ TEST_F(ActFlatPlateTest, flat_plate_init)
 {
     initialize_mesh();
     auto& vel = sim().repo().declare_field("velocity", 3, 3);
+    auto& density = sim().repo().declare_field("density", 1, 3);
+    density.setVal(1.0);
     vel.setVal(10.0, 0, 1, 3);
     amr_wind::actuator::ActuatorContainer::ParticleType::NextID(1U);
 

--- a/unit_tests/wind_energy/actuator/test_actuator_joukowsky_disk.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_joukowsky_disk.cpp
@@ -46,7 +46,9 @@ protected:
         initialize_mesh();
         sim().repo().declare_field("actuator_src_term", 3, 0);
         auto& vel = sim().repo().declare_field("velocity", 3, 3);
+        auto& density = sim().repo().declare_field("density", 1, 3);
         vel.setVal(10.0, 0, 1, 3);
+        density.setVal(1.0);
         amr_wind::actuator::ActuatorContainer::ParticleType::NextID(1U);
     }
 

--- a/unit_tests/wind_energy/actuator/test_actuator_joukowsky_disk.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_joukowsky_disk.cpp
@@ -148,6 +148,7 @@ struct ComputeForceOp<::amr_wind_tests::Joukowsky, ActSrcDisk>
             // only x direction is guaranteed to be negative
             // y and z forces will vary based on azimuthal angle
             EXPECT_GE(0.0, grid.force[i][0]) << "i: " << i;
+            EXPECT_DOUBLE_EQ(1.0, grid.density[i]);
         }
     }
 };

--- a/unit_tests/wind_energy/actuator/test_actuator_sampling.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_sampling.cpp
@@ -60,7 +60,9 @@ TEST_F(ActuatorTest, act_container)
     const int iproc = amrex::ParallelDescriptor::MyProc();
     initialize_mesh();
     auto& vel = sim().repo().declare_field("velocity", 3, 3);
+    auto& density = sim().repo().declare_field("density", 1, 3);
     init_field(vel);
+    density.setVal(1.0);
 
     // Number of turbines in an MPI rank
     const int num_turbines = 2;
@@ -121,7 +123,7 @@ TEST_F(ActuatorTest, act_container)
         }
     }
 
-    ac.sample_velocities(vel);
+    ac.sample_fields(vel, density);
     ac.Redistribute();
 
     // Check to make sure that the velocity sampling gathered the particles back

--- a/unit_tests/wind_energy/actuator/test_disk_functions.cpp
+++ b/unit_tests/wind_energy/actuator/test_disk_functions.cpp
@@ -5,6 +5,68 @@ namespace amr_wind {
 namespace actuator {
 namespace disk {
 
+struct AreaComputerData
+{
+    amrex::Real radius;
+    int num_points_r;
+    int num_points_theta;
+};
+
+class TestAreaComputer : public ::testing::TestWithParam<AreaComputerData>
+{
+public:
+    struct PrintParamNamesToString
+    {
+        template <class ParamType>
+        std::string operator()(const testing::TestParamInfo<ParamType>& info)
+        {
+            std::stringstream name;
+            const auto data = static_cast<AreaComputerData>(info.param);
+            name << "R" << data.radius;
+            name << "nR" << data.num_points_r;
+            name << "nT" << data.num_points_theta;
+            return name.str();
+        }
+    };
+
+protected:
+    void SetUp() final
+    {
+        const auto params = GetParam();
+        computer = std::make_unique<ops::base::AreaComputer>(
+            params.radius, params.num_points_r, params.num_points_theta);
+        area = M_PI * params.radius * params.radius;
+    }
+    std::unique_ptr<ops::base::AreaComputer> computer;
+    amrex::Real area;
+};
+
+TEST_P(TestAreaComputer, area_matches)
+{
+    const auto params = GetParam();
+    amrex::Real area_computed = 0.0;
+
+    for (int i = 0; i < params.num_points_r; ++i) {
+        for (int j = 0; j < params.num_points_theta; ++j) {
+            area_computed += computer->area_section(i);
+        }
+    }
+    EXPECT_NEAR(area, area_computed, 1.e-12 * area);
+}
+
+TEST_P(TestAreaComputer, weight_sums_to_one)
+{
+    const auto params = GetParam();
+    amrex::Real weight_computed = 0.0;
+
+    for (int i = 0; i < params.num_points_r; ++i) {
+        for (int j = 0; j < params.num_points_theta; ++j) {
+            weight_computed += computer->weight(i);
+        }
+    }
+    EXPECT_DOUBLE_EQ(1.0, weight_computed);
+}
+
 class TestComputeDiskPoints : public ::testing::TestWithParam<vs::Vector>
 {};
 
@@ -46,6 +108,16 @@ INSTANTIATE_TEST_SUITE_P(
         vs::Vector{-1, 0, 0},
         vs::Vector{-1, -1, -1},
         vs::Vector{1000.0, 30.0, 5.0}));
+
+INSTANTIATE_TEST_SUITE_P(
+    ManyAreas,
+    TestAreaComputer,
+    testing::Values(
+        AreaComputerData{1.0, 3, 1},
+        AreaComputerData{1.0, 3, 2},
+        AreaComputerData{127.0, 10, 3},
+        AreaComputerData{30.0, 5, 30}),
+    TestAreaComputer::PrintParamNamesToString());
 } // namespace disk
 } // namespace actuator
 } // namespace amr_wind


### PR DESCRIPTION
Actuators require users to specify density again.  This makes density a sampled quantity, and a rotor averaged density can now be computed.

This will make it so that actuators don't need any inputs for density, and will allow for more flexibility in future research projects.