### PR TITLE
Missing destruction of Omega

### DIFF
--- a/amr-wind/equation_systems/sdr/source_terms/SDRSrc.cpp
+++ b/amr-wind/equation_systems/sdr/source_terms/SDRSrc.cpp
@@ -23,7 +23,7 @@ void SDRSrc::operator()(
     const amrex::Array4<amrex::Real>& src_term) const
 {
     const auto& sdr_src_arr = (this->m_sdr_src)(lev).array(mfi);
-    const auto& sdr_diss_arr = (this->m_sdr_src)(lev).array(mfi);
+    const auto& sdr_diss_arr = (this->m_sdr_diss)(lev).array(mfi);
 
     const amrex::Real factor = (fstate == FieldState::NPH) ? 0.5 : 1.0;
 


### PR DESCRIPTION
Hi All! 

A couple fixes to RANS model here. Seems like there was a typo in the omega src term? 

Also, if I print out "wd_arr" during a kOmegaSST sim, I get only zeros, and I can't seem to find anywhere that we're computing wall distance. This is important to the blending behavior of k-Omega SST. Maybe we should try and fix that on this PR as well? 