### PR TITLE
cmake: Only install unit tests if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,12 +207,18 @@ endif()
 
 #Define what we want to be installed during a make install
 install(
-  TARGETS ${amr_wind_exe_name} ${amr_wind_unit_test_exe_name}
+  TARGETS ${amr_wind_exe_name}
   ${aw_api_lib} ${amr_wind_lib_name} buildInfo${amr_wind_lib_name}
   EXPORT ${PROJECT_NAME}Targets
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib)
+
+if(AMR_WIND_ENABLE_UNIT_TESTS OR AMR_WIND_ENABLE_TESTS)
+  install(
+    TARGETS ${amr_wind_unit_test_exe_name}
+    RUNTIME DESTINATION bin)
+endif()
 
 install(
   DIRECTORY ${PROJECT_SOURCE_DIR}/amr-wind


### PR DESCRIPTION
  * Unit tests are build if either AMR_WIND_ENABLE_UNIT_TESTS or AMR_WIND_ENABLE_TESTS is defined. 
  * If both are unset, unit test executable is not build but install expects binary.