### PR TITLE
clean up channel flow parsing

### DIFF
--- a/amr-wind/physics/ChannelFlow.H
+++ b/amr-wind/physics/ChannelFlow.H
@@ -78,8 +78,6 @@ private:
 
     bool m_laminar{false};
 
-    bool m_dns{false};
-
     bool m_mesh_mapping{false};
 
     amrex::Real m_mean_vel;

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -16,11 +16,17 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
     , m_mesh_mapping(sim.has_mesh_mapping())
 {
     {
+        std::string turbulence_model;
+        amrex::ParmParse pp("turbulence");
+        pp.query("model", turbulence_model);
+        if(turbulence_model == "Laminar") {
+            m_laminar = true;
+        }
+    }
+    {
         amrex::ParmParse pp("ChannelFlow");
         pp.query("flow_direction", m_mean_vel_dir);
         pp.query("normal_direction", m_norm_dir);
-        pp.query("Laminar", m_laminar);
-        pp.query("Turbulent_DNS", m_dns);
         pp.query("error_log_file", m_output_fname);
 
         if (m_laminar) {
@@ -29,11 +35,8 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
         } else {
             pp.query("density", m_rho);
             pp.query("re_tau", m_re_tau);
-
-            if (!m_dns) {
-                pp.query("tke0", m_tke0);
-                pp.query("sdr0", m_sdr0);
-            }
+            pp.query("tke0", m_tke0);
+            pp.query("sdr0", m_sdr0);
         }
     }
     {
@@ -87,7 +90,7 @@ void ChannelFlow::initialize_fields(
     auto& density = m_repo.get_field("density")(level);
     density.setVal(m_rho);
 
-    if (!m_laminar && !m_dns) {
+    if (!m_laminar) {
         auto& tke = m_repo.get_field("tke")(level);
         auto& sdr = m_repo.get_field("sdr")(level);
         auto& walldist = m_repo.get_field("wall_dist")(level);
@@ -119,7 +122,7 @@ void ChannelFlow::initialize_fields(
                     vel(i, j, k, 2) = 0.0;
                 });
         }
-    } else if (m_laminar) {
+    } else {
         velocity.setVal(0.0);
         velocity.setVal(
             m_mean_vel, m_mean_vel_dir, 1,

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -19,7 +19,7 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
         std::string turbulence_model;
         amrex::ParmParse pp("turbulence");
         pp.query("model", turbulence_model);
-        if(turbulence_model == "Laminar") {
+        if (turbulence_model == "Laminar") {
             m_laminar = true;
         }
     }

--- a/test/test_files/channel_mol_mesh_map_x/channel_mol_mesh_map_x.i
+++ b/test/test_files/channel_mol_mesh_map_x/channel_mol_mesh_map_x.i
@@ -31,8 +31,6 @@ ICNS.source_terms = BodyForce
 BodyForce.magnitude = 6e-2 0 0
 incflo.physics = ChannelFlow
 ChannelFlow.density = 1.0
-ChannelFlow.Laminar = true
-ChannelFlow.Turbulent_DNS = false
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1
@@ -55,7 +53,7 @@ ChannelFlowMap.beta = 0 3 0
 
 velocity_diffusion.use_tensor_operator = false
 incflo.diffusion_type   = 2
-    
+
 # Boundary conditions
 ylo.type =   "no_slip_wall"
 yhi.type =   "no_slip_wall"

--- a/test/test_files/channel_mol_mesh_map_x_seg_vel_solve/channel_mol_mesh_map_x_seg_vel_solve.i
+++ b/test/test_files/channel_mol_mesh_map_x_seg_vel_solve/channel_mol_mesh_map_x_seg_vel_solve.i
@@ -31,8 +31,6 @@ ICNS.source_terms = BodyForce
 BodyForce.magnitude = 6e-2 0 0
 incflo.physics = ChannelFlow
 ChannelFlow.density = 1.0
-ChannelFlow.Laminar = true
-ChannelFlow.Turbulent_DNS = false
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1
@@ -56,7 +54,7 @@ ChannelFlowMap.beta = 0 3 0
 velocity_diffusion.use_tensor_operator = false
 velocity_diffusion.use_segregated_operator = true
 incflo.diffusion_type   = 2
-    
+
 # Boundary conditions
 ylo.type =   "no_slip_wall"
 yhi.type =   "no_slip_wall"

--- a/test/test_files/channel_mol_mesh_map_y/channel_mol_mesh_map_y.i
+++ b/test/test_files/channel_mol_mesh_map_y/channel_mol_mesh_map_y.i
@@ -31,10 +31,8 @@ ICNS.source_terms = BodyForce
 BodyForce.magnitude = 0.0 6e-2 0.0
 incflo.physics = ChannelFlow
 ChannelFlow.density = 1.0
-ChannelFlow.Laminar = true
 ChannelFlow.flow_direction = 1
 ChannelFlow.normal_direction = 2
-ChannelFlow.Turbulent_DNS = false
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1
@@ -57,7 +55,7 @@ ChannelFlowMap.beta = 0 0 3
 
 velocity_diffusion.use_tensor_operator = false
 incflo.diffusion_type   = 2
-    
+
 # Boundary conditions
 zlo.type =   "no_slip_wall"
 zhi.type =   "no_slip_wall"

--- a/test/test_files/channel_mol_mesh_map_z/channel_mol_mesh_map_z.i
+++ b/test/test_files/channel_mol_mesh_map_z/channel_mol_mesh_map_z.i
@@ -31,10 +31,8 @@ ICNS.source_terms = BodyForce
 BodyForce.magnitude = 0.0 0.0 6e-2
 incflo.physics = ChannelFlow
 ChannelFlow.density = 1.0
-ChannelFlow.Laminar = true
 ChannelFlow.flow_direction = 2
 ChannelFlow.normal_direction = 0
-ChannelFlow.Turbulent_DNS = false
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1
@@ -57,7 +55,7 @@ ChannelFlowMap.beta = 3 0 0
 
 velocity_diffusion.use_tensor_operator = false
 incflo.diffusion_type   = 2
-    
+
 # Boundary conditions
 xlo.type =   "no_slip_wall"
 xhi.type =   "no_slip_wall"


### PR DESCRIPTION
using `turbulence.model` to determine if flow is laminar. Remove `m_dns`.