### PR TITLE
Added power output to Joukowsky disk

### DIFF
--- a/amr-wind/wind_energy/actuator/disk/Joukowsky.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky.H
@@ -19,6 +19,7 @@ struct JoukowskyData : public DiskBaseData
     amrex::Real current_tip_speed_ratio{0.0};
     amrex::Real vortex_core_size;
     amrex::Real current_cp;
+    amrex::Real current_power;
     // --- Sorenson 2020 equation 10 constants ----
     amrex::Real root_correction_coefficient{2.335};
     amrex::Real root_correction_exponent{4.0};

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -230,6 +230,9 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 std::pow(U_ref, 3),
             machine_eps);
 
+        ddata.current_power = ddata.density * uInfSqr * moment *
+                              ddata.current_angular_velocity;
+
         ddata.current_cp = ddata.density * uInfSqr * moment *
                            ddata.current_angular_velocity / eq_20_denominator;
     }

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -231,7 +231,7 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
             machine_eps);
 
         ddata.current_power = ddata.density * uInfSqr * moment *
-                              ddata.current_angular_velocity;
+            ddata.current_angular_velocity;
 
         ddata.current_cp = ddata.density * uInfSqr * moment *
                            ddata.current_angular_velocity / eq_20_denominator;

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -230,8 +230,8 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 std::pow(U_ref, 3),
             machine_eps);
 
-        ddata.current_power = ddata.density * uInfSqr * moment *
-            ddata.current_angular_velocity;
+        ddata.current_power =
+            ddata.density * uInfSqr * moment * ddata.current_angular_velocity;
 
         ddata.current_cp = ddata.density * uInfSqr * moment *
                            ddata.current_angular_velocity / eq_20_denominator;

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
@@ -120,6 +120,7 @@ void prepare_netcdf_file(
     grp.def_var("tsr", NC_DOUBLE, {nt_name});
     grp.def_var("ct", NC_DOUBLE, {nt_name});
     grp.def_var("cp", NC_DOUBLE, {nt_name});
+    grp.def_var("power", NC_DOUBLE, {nt_name});
     grp.def_var("density", NC_DOUBLE, {nt_name});
     grp.def_var("total_disk_force", NC_DOUBLE, {nt_name, "ndim"});
     grp.def_var("angular_velocity", NC_DOUBLE, {nt_name});
@@ -171,6 +172,7 @@ void write_netcdf(
     grp.var("tsr").put(&data.current_tip_speed_ratio, {nt}, {1});
     grp.var("ct").put(&data.current_ct, {nt}, {1});
     grp.var("cp").put(&data.current_cp, {nt}, {1});
+    grp.var("power").put(&data.current_power, {nt}, {1});
     grp.var("density").put(&data.density, {nt}, {1});
     grp.var("total_disk_force")
         .put(&data.disk_force[0], {nt}, {1, AMREX_SPACEDIM});


### PR DESCRIPTION
For the Joukowsky actuator disk, I added the power output (in kW) to the netcdf output file.  Could be useful when we compute wind turbine and wind farm performance metrics.

Lawrence