### PR TITLE
fch uses finest level

### DIFF
--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -93,7 +93,7 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
 void ABLWallFunction::init_log_law_height()
 {
     if (m_use_fch) {
-        const auto& geom = m_mesh.Geom(0);
+        const auto& geom = m_mesh.Geom(m_mesh.finestLevel());
         m_mo.zref =
             (geom.ProbLo(m_direction) + 0.5 * geom.CellSize(m_direction));
     }


### PR DESCRIPTION
This could be risky if the fine level is not on the ground... an alternative could be to make ABL.log_law_height a required input from now on?