### PR TITLE
Improvements to Wave Energy routine

### DIFF
--- a/amr-wind/utilities/sampling/WaveEnergy.H
+++ b/amr-wind/utilities/sampling/WaveEnergy.H
@@ -13,13 +13,19 @@ namespace wave_energy {
  *  A concrete implementation of the post-processing interface that deals with
  *  integrating total wave energy. This routine calculates the kinetic energy
  *  (KE) and potential energy (PE) according to the following definitions. It
- *  allows for a user-defined potential energy offset, as well (PE_0), intended
- *  to give the result PE = 0 for an undisturbed interface.
+ *  caclulates the correct potential energy offset, assuming an equilibrium
+ *  water level of 0 unless specified otherwise by an input parameter. It also
+ *  assumes the traditional coordinate system, where interface height/depth is
+ *  in z.
  *
- *  KE = 0.5 * (Integral over liquid phase) \rho * u^2 dV
- *  PE = (Integral over liquid phase) \rho * g * z_liq dV + PE_0
+ *  Integral definitions (not output)
+ *  KE_i = 0.5 * (Integral over liquid phase) \rho * u^2 dV
+ *  PE_i = (Integral over liquid phase) \rho * g * z_liq dV
+ *  (offset for PE would be 1/2 * Lx * Ly * \rho_liq * g * depth^2)
  *
- *  Note: the output quantities are not normalized.
+ *  Normalized definitions (which are output) in form of avg kinematic energy
+ *  KE = KE_i / (d * \rho_liq * Lx * Ly)
+ *  PE = PE_i / (d * \rho_liq * Lx * Ly) + 1/2 * g * depth
  */
 class WaveEnergy : public PostProcessBase::Register<WaveEnergy>
 {
@@ -83,9 +89,8 @@ private:
 
     //! offset for potential energy calculation
     amrex::Real m_pe_off = 0.0;
-
-    //! density of liquid phase
-    amrex::Real m_rho1 = 10.0;
+    //! volumetric scaling for each energy
+    amrex::Real m_escl = 1.0;
 
     //! filename for ASCII output
     std::string m_out_fname;

--- a/amr-wind/utilities/sampling/WaveEnergy.cpp
+++ b/amr-wind/utilities/sampling/WaveEnergy.cpp
@@ -22,18 +22,25 @@ WaveEnergy::~WaveEnergy() = default;
 void WaveEnergy::initialize()
 {
     BL_PROFILE("amr-wind::WaveEnergy::initialize");
+    // Default water level is 0
+    amrex::Real w_lev = 0.0;
     {
         amrex::ParmParse pp(m_label);
         pp.query("output_frequency", m_out_freq);
-        pp.query("potential_energy_offset", m_pe_off);
+        pp.query("water_level", w_lev);
     }
     // Get gravity and density
     {
         amrex::ParmParse pp("incflo");
         pp.queryarr("gravity", m_gravity);
     }
-    auto& mphase = m_sim.physics_manager().get<amr_wind::MultiPhase>();
-    m_rho1 = mphase.rho1();
+    // Calculate depth
+    const auto& geom = m_sim.repo().mesh().Geom();
+    amrex::Real depth = w_lev - geom[0].ProbLo()[2];
+    // Calculate volume scaling and PE offset
+    m_escl = (geom[0].ProbHi()[0] - geom[0].ProbLo()[0]) *
+             (geom[0].ProbHi()[1] - geom[0].ProbLo()[1]) * depth;
+    m_pe_off = -0.5 * m_gravity[2] * depth;
 
     prepare_ascii_file();
 }
@@ -44,9 +51,6 @@ amrex::Real WaveEnergy::calculate_kinetic_energy()
 
     // integrated total wave Energy
     amrex::Real wave_ke = 0.0;
-
-    // Liquid density
-    const amrex::Real rho_liq = m_rho1;
 
     const int finest_level = m_velocity.repo().num_active_levels() - 1;
     const auto& geom = m_velocity.repo().mesh().Geom();
@@ -81,7 +85,7 @@ amrex::Real WaveEnergy::calculate_kinetic_energy()
                 amrex::Loop(
                     bx, [=, &Wave_Energy_Fab](int i, int j, int k) noexcept {
                         Wave_Energy_Fab +=
-                            cell_vol * mask_arr(i, j, k) * 0.5 * rho_liq *
+                            cell_vol * mask_arr(i, j, k) * 0.5 *
                             vof_arr(i, j, k) *
                             (vel_arr(i, j, k, 0) * vel_arr(i, j, k, 0) +
                              vel_arr(i, j, k, 1) * vel_arr(i, j, k, 1) +
@@ -102,8 +106,6 @@ amrex::Real WaveEnergy::calculate_potential_energy()
 
     // integrated total wave Energy
     amrex::Real wave_pe = 0.0;
-    // Liquid density
-    const amrex::Real rho_liq = m_rho1;
     // gravity constant
     const amrex::Real g = -m_gravity[2];
 
@@ -150,7 +152,7 @@ amrex::Real WaveEnergy::calculate_potential_energy()
                         const amrex::Real zl =
                             probloz + (kk + dir * 0.5 * vof_arr(i, j, k)) * dz;
                         Wave_Energy_Fab += cell_vol * mask_arr(i, j, k) *
-                                           rho_liq * vof_arr(i, j, k) * g * zl;
+                                           vof_arr(i, j, k) * g * zl;
                     });
                 return Wave_Energy_Fab;
             });
@@ -171,8 +173,8 @@ void WaveEnergy::post_advance_work()
         return;
     }
 
-    m_wave_kinetic_energy = calculate_kinetic_energy();
-    m_wave_potential_energy = calculate_potential_energy() + m_pe_off;
+    m_wave_kinetic_energy = calculate_kinetic_energy() / m_escl;
+    m_wave_potential_energy = calculate_potential_energy() / m_escl + m_pe_off;
 
     write_ascii();
 }

--- a/unit_tests/utilities/test_wave_energy.cpp
+++ b/unit_tests/utilities/test_wave_energy.cpp
@@ -93,7 +93,7 @@ protected:
         {
             amrex::ParmParse pp("waveenergy");
             pp.add("output_frequency", 1);
-            pp.add("potential_energy_offset", pe_off);
+            pp.add("water_level", wlev);
         }
         {
             amrex::ParmParse pp("incflo");
@@ -109,9 +109,9 @@ protected:
     }
     // Parameters
     const amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
-    const amrex::Vector<amrex::Real> probhi{{1.0, 1.0, 1.0}};
-    const amrex::Real pe_off = 0.25;
+    const amrex::Vector<amrex::Real> probhi{{2.0, 2.0, 1.0}};
     const int nx = 5;
+    const amrex::Real wlev = 0.25;
     const amrex::Real g = -9;
     const amrex::Real rho1 = 888;
     const amrex::Real tol = 1e-12;
@@ -144,26 +144,21 @@ TEST_F(WaveEnergyTest, checkoutput)
     tool.wave_energy(ke, pe);
 
     // Check answers
-    const amrex::Real dx = 1.0 / (amrex::Real)nx;
-    const amrex::Real cell_vol = std::pow(dx, 3);
+    const amrex::Real dx = 2.0 / (amrex::Real)nx;
+    const amrex::Real dz = 1.0 / (amrex::Real)nx;
+    const amrex::Real cell_vol = dx * dx * dz;
     amrex::Real ke_ref =
-        0.5 * rho1 * cell_vol *
+        0.5 * cell_vol / (wlev * 2.0 * 2.0) *
         (4.0 * 5.0 * (1.0 + 4.0 + 9.0 + 16.0) + 25.0 +
          0.5 * (4.0 * 15.0 + 5.0 * (4.0 + 16.0) +
                 3.0 * (1.0 + 4.0 + 9.0 + 16.0)) +
          (4.0 * 10.0 + 5.0 * (1.0 + 9.0) + 2.0 * (1.0 + 4.0 + 9.0 + 16.0)));
     EXPECT_NEAR(ke, ke_ref, tol);
-    /* // How the routine is expected to find the potential energy
-    amrex::Real pe_ref = rho1 * cell_vol * (-g) *
-                             (25.0 * (0.5 * dx + 1.5 * dx) +
-                              0.5 * 15.0 * (2.25 * dx) + 10.0 * (2.5 * dx)) +
-                         pe_off;
-                         */
     // Formula has been integrated in z, and uses exact interface locations
     amrex::Real pe_exact =
-        rho1 * dx * dx * (-g) * 0.5 *
-            (15.0 * std::pow(2.5 * dx, 2) + 10.0 * std::pow(3.0 * dx, 2)) +
-        pe_off;
+        dx * dx * (-g) * 0.5 / (wlev * 2.0 * 2.0) *
+            (15.0 * std::pow(2.5 * dz, 2) + 10.0 * std::pow(3.0 * dz, 2)) +
+        0.5 * (-g) * wlev;
     EXPECT_NEAR(pe, pe_exact, tol);
 }
 


### PR DESCRIPTION
* outputs average kinematic quantities, so numbers are smaller and  easier to manage
* automatically calculates the correct PE offset when user provides  water level, assumes water level at z = 0 otherwise