### PR TITLE
Fix for FreeSurface routine on GPUs

### DIFF
--- a/amr-wind/utilities/sampling/FreeSurface.H
+++ b/amr-wind/utilities/sampling/FreeSurface.H
@@ -121,6 +121,9 @@ private:
 
     //! Frequency of data sampling and output
     int m_out_freq{100};
+
+    //! Max number of sample points found in a single cell
+    int m_ncomp{1};
 };
 
 } // namespace free_surface

--- a/amr-wind/utilities/sampling/FreeSurface.H
+++ b/amr-wind/utilities/sampling/FreeSurface.H
@@ -109,8 +109,8 @@ private:
     //! (this also determines the meaning of start and end points)
     int m_coorddir{2};
     //! Grid coordinates, determined as a function of m_coorddir
-    int m_gc1 = 0;
-    int m_gc2 = 1;
+    int m_gc0 = 0;
+    int m_gc1 = 1;
 
     //! Parameters to set up plane
     amrex::Vector<amrex::Real> m_start, m_end;

--- a/amr-wind/utilities/sampling/FreeSurface.H
+++ b/amr-wind/utilities/sampling/FreeSurface.H
@@ -124,6 +124,8 @@ private:
 
     //! Max number of sample points found in a single cell
     int m_ncomp{1};
+    //! Max number of sample points allowed in a single cell
+    int m_ncmax{8};
 };
 
 } // namespace free_surface

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -519,9 +519,8 @@ void FreeSurface::post_advance_work()
                                                  0.5 * dx[dir] * (1.0 + 1e-8)) {
                                         ht = xm[dir] + 0.5 * dx[dir];
                                     }
-                                    // Save interface location
-                                    dout_ptr[idx] =
-                                        amrex::max(dout_ptr[idx], ht);
+                                    // Save interface location by atomic max
+                                    amrex::Gpu::Atomic::Max(&dout_ptr[idx], ht);
                                 }
                             }
                         }

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -12,11 +12,7 @@ namespace free_surface {
 
 FreeSurface::FreeSurface(CFDSim& sim, std::string label)
     : m_sim(sim), m_label(std::move(label)), m_vof(sim.repo().get_field("vof"))
-{
-#ifdef AMREX_USE_GPU
-    amrex::Print() << "WARNING: FreeSurface: Running on GPUs..." << std::endl;
-#endif
-}
+{}
 
 FreeSurface::~FreeSurface() = default;
 

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -71,9 +71,8 @@ void FreeSurface::initialize()
     m_out.resize(m_npts * m_ninst);
 
     // Get size of sample grid spacing
-    amrex::Vector<amrex::Real> dxs = {0.0, 0.0};
-    dxs[0] = (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[0] - 1, 1);
-    dxs[1] = (m_end[m_gc2] - m_start[m_gc2]) / amrex::max(m_npts_dir[1] - 1, 1);
+    amrex::Real dxs1 = (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[0] - 1, 1);
+    amrex::Real dxs2 = (m_end[m_gc2] - m_start[m_gc2]) / amrex::max(m_npts_dir[1] - 1, 1);
 
     // Store locations
     int idx = 0;
@@ -84,9 +83,9 @@ void FreeSurface::initialize()
                 m_out[idx * m_ninst + ni] = m_start[m_coorddir];
             }
             // Grid direction 1
-            m_locs[idx][0] = m_start[m_gc1] + dxs[0] * i;
+            m_locs[idx][0] = m_start[m_gc1] + dxs1 * i;
             // Grid direction 2
-            m_locs[idx][1] = m_start[m_gc2] + dxs[1] * j;
+            m_locs[idx][1] = m_start[m_gc2] + dxs2 * j;
 
             ++idx;
         }
@@ -107,12 +106,17 @@ void FreeSurface::initialize()
         amrex::Gpu::hostToDevice, &locs[0], &locs[2 * m_npts - 1] + 1,
         dloc.begin());
 
+    // Capture variables for device
+    const amrex::Real s_gc1 = m_start[m_gc1];
+    const amrex::Real s_gc2 = m_start[m_gc2];
+    const int npts1 = m_npts_dir[0];
+    const int npts2 = m_npts_dir[1];
+    const int gc1 = m_gc1;
+    const int gc2 = m_gc2;
+
     // Determine number of components necessary for working fields
     int ncomp = 0;
     const int finest_level = m_vof.repo().num_active_levels() - 1;
-    const int npts = m_npts;
-    const int gc1 = m_gc1;
-    const int gc2 = m_gc2;
     for (int lev = 0; lev <= finest_level; lev++) {
         // Use level_mask to only count finest level present
         amrex::iMultiFab level_mask;
@@ -132,6 +136,8 @@ void FreeSurface::initialize()
             geom.CellSizeArray();
         const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
             geom.ProbLoArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> phi =
+            geom.ProbHiArray();
         ncomp = amrex::max(
             ncomp,
             amrex::ReduceMax(
@@ -146,24 +152,61 @@ void FreeSurface::initialize()
                         xm[0] = plo[0] + (i + 0.5) * dx[0];
                         xm[1] = plo[1] + (j + 0.5) * dx[1];
                         xm[2] = plo[2] + (k + 0.5) * dx[2];
-                        // Loop through sample locations to identify
-                        // how many are in current cell
-                        int ns = 0;
-                        for (int n = 0; n < npts; ++n) {
-                            int n0 = 2 * n;
-                            int n1 = 2 * n + 1;
-                            if (((plo[gc1] == dloc_ptr[n0] &&
-                                  xm[gc1] - dloc_ptr[n0] == 0.5 * dx[gc1]) ||
-                                 (xm[gc1] - dloc_ptr[n0] < 0.5 * dx[gc1] &&
-                                  dloc_ptr[n0] - xm[gc1] <= 0.5 * dx[gc1])) &&
-                                ((plo[gc2] == dloc_ptr[n1] &&
-                                  xm[gc2] - dloc_ptr[n1] == 0.5 * dx[gc2]) ||
-                                 (xm[gc2] - dloc_ptr[n1] < 0.5 * dx[gc2] &&
-                                  dloc_ptr[n1] - xm[gc2] <= 0.5 * dx[gc2]))) {
-                                ns += 1;
+                        int n0_f = 0; int n0_a = 0;
+                        int n1_f = 0; int n1_a = 0;
+                        // Get first and after sample indices for gc1
+                        if (npts1 == 1) {
+                            n0_a = ((phi[gc1] == s_gc1) ||
+                                    (xm[gc1] - s_gc1 <= 0.5 * dx[gc1] &&
+                                     s_gc1 - xm[gc1] < 0.5 * dx[gc1]))
+                                       ? 1
+                                       : 0;
+                        } else {
+                            n0_f = (int)amrex::Math::ceil(
+                                (xm[gc1] - 0.5 * dx[gc1] - s_gc1) / dxs1);
+                            n0_a = (int)amrex::Math::ceil(
+                                (xm[gc1] + 0.5 * dx[gc1] - s_gc1) / dxs1);
+                            // Edge case of phi
+                            if (xm[gc1] + 0.5 * dx[gc1] == phi[gc1] &&
+                                s_gc1 + n0_a * dxs1 == phi[gc1]) {
+                                ++n0_a;
                             }
-                            ns_fab = amrex::max(ns_fab, mask_arr(i, j, k) * ns);
+                            // Bounds
+                            n0_a = amrex::min(npts1, n0_a);
+                            n0_f = amrex::max(amrex::min(0, n0_a), n0_f);
+                            // Out of bounds indicates no sample point
+                            if (n0_f >= npts1 || n0_f < 0) {
+                                n0_a = n0_f;
+                            }
                         }
+                        // Get first and after sample indices for gc2
+                        if (npts2 == 1) {
+                            n1_a = ((phi[gc2] == s_gc2 ) ||
+                                    (xm[gc2] - s_gc2 <= 0.5 * dx[gc2] &&
+                                     s_gc2 - xm[gc2] < 0.5 * dx[gc2]))
+                                       ? 1
+                                       : 0;
+                        } else {
+                            n1_f = (int)amrex::Math::ceil(
+                                (xm[gc2] - 0.5 * dx[gc2] - s_gc2) / dxs2);
+                            n1_a = (int)amrex::Math::ceil(
+                                (xm[gc2] + 0.5 * dx[gc2] - s_gc2) / dxs2);
+                            // Edge case of phi
+                            if (xm[gc2] + 0.5 * dx[gc2] == phi[gc2] &&
+                                s_gc2 + n1_a * dxs2 == phi[gc2]) {
+                                ++n1_a;
+                            }
+                            // Bounds
+                            n1_a = amrex::min(npts2, n1_a);
+                            n1_f = amrex::max(amrex::min(0, n1_a), n1_f);
+                            // Out of bounds indicates no sample point
+                            if (n1_f >= npts2 || n1_f < 0) {
+                                n1_a = n1_f;
+                            }
+                        }
+                        // Get total number of possible samples in cell
+                        int ns = (n0_a - n0_f) * (n1_a - n1_f);
+                        ns_fab = amrex::max(ns_fab, mask_arr(i, j, k) * ns);
                     });
                     return ns_fab;
                 }));
@@ -176,6 +219,7 @@ void FreeSurface::initialize()
     auto& floc = m_sim.repo().declare_field("sample_loc", 2 * ncomp, 0, 1);
     auto& fidx = m_sim.repo().declare_field("sample_idx", ncomp, 0, 1);
 
+    const int npts = m_npts;
     // Store locations and indices in fields
     for (int lev = 0; lev <= finest_level; lev++) {
         // Use level_mask to only count finest level present
@@ -196,6 +240,8 @@ void FreeSurface::initialize()
             geom.CellSizeArray();
         const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
             geom.ProbLoArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> phi =
+            geom.ProbHiArray();
         for (amrex::MFIter mfi(floc(lev)); mfi.isValid(); ++mfi) {
             auto loc_arr = floc(lev).array(mfi);
             auto idx_arr = fidx(lev).array(mfi);
@@ -208,36 +254,75 @@ void FreeSurface::initialize()
                     xm[0] = plo[0] + (i + 0.5) * dx[0];
                     xm[1] = plo[1] + (j + 0.5) * dx[1];
                     xm[2] = plo[2] + (k + 0.5) * dx[2];
-                    // Loop through sample locations to identify
-                    // how many are in current cell
-                    int ns = 0;
-                    for (int n = 0; n < npts; ++n) {
-                        int n0 = 2 * n;
-                        int n1 = 2 * n + 1;
-                        bool pt_here = false;
-                        if (((plo[gc1] == dloc_ptr[n0] &&
-                              xm[gc1] - dloc_ptr[n0] == 0.5 * dx[gc1]) ||
-                             (xm[gc1] - dloc_ptr[n0] < 0.5 * dx[gc1] &&
-                              dloc_ptr[n0] - xm[gc1] <= 0.5 * dx[gc1])) &&
-                            ((plo[gc2] == dloc_ptr[n1] &&
-                              xm[gc2] - dloc_ptr[n1] == 0.5 * dx[gc2]) ||
-                             (xm[gc2] - dloc_ptr[n1] < 0.5 * dx[gc2] &&
-                              dloc_ptr[n1] - xm[gc2] <= 0.5 * dx[gc2]))) {
-                            ns += 1;
-                            pt_here = true;
+                    int n0_f = 0; int n0_a = 0;
+                    int n1_f = 0; int n1_a = 0;
+                    // Get first and after sample indices for gc1
+                    if (npts1 == 1) {
+                        n0_a = ((phi[gc1] == s_gc1) ||
+                                (xm[gc1] - s_gc1 <= 0.5 * dx[gc1] &&
+                                 s_gc1 - xm[gc1] < 0.5 * dx[gc1]))
+                                   ? 1
+                                   : 0;
+                    } else {
+                        n0_f = (int)amrex::Math::ceil(
+                            (xm[gc1] - 0.5 * dx[gc1] - s_gc1) / dxs1);
+                        n0_a = (int)amrex::Math::ceil(
+                            (xm[gc1] + 0.5 * dx[gc1] - s_gc1) / dxs1);
+                        // Edge case of phi
+                        if (xm[gc1] + 0.5 * dx[gc1] == phi[gc1] &&
+                            s_gc1 + n0_a * dxs1 == phi[gc1]) {
+                            ++n0_a;
                         }
-                        if (pt_here) {
+                        // Bounds
+                        n0_a = amrex::min(npts1, n0_a);
+                        n0_f = amrex::max(amrex::min(0, n0_a), n0_f);
+                        // Out of bounds indicates no sample point
+                        if (n0_f >= npts1 || n0_f < 0) {
+                            n0_a = n0_f;
+                        }
+                    }
+                    // Get first and after sample indices for gc2
+                    if (npts2 == 1) {
+                        n1_a = ((phi[gc2] == s_gc2 ) ||
+                                (xm[gc2] - s_gc2 <= 0.5 * dx[gc2] &&
+                                 s_gc2 - xm[gc2] < 0.5 * dx[gc2]))
+                                   ? 1
+                                   : 0;
+                    } else {
+                        n1_f = (int)amrex::Math::ceil(
+                            (xm[gc2] - 0.5 * dx[gc2] - s_gc2) / dxs2);
+                        n1_a = (int)amrex::Math::ceil(
+                            (xm[gc2] + 0.5 * dx[gc2] - s_gc2) / dxs2);
+                        // Edge case of phi
+                        if (xm[gc2] + 0.5 * dx[gc2] == phi[gc2] &&
+                            s_gc2 + n1_a * dxs2 == phi[gc2]) {
+                            ++n1_a;
+                        }
+                        // Bounds
+                        n1_a = amrex::min(npts2, n1_a);
+                        n1_f = amrex::max(amrex::min(0, n1_a), n1_f);
+                        // Out of bounds indicates no sample point
+                        if (n1_f >= npts2 || n1_f < 0) {
+                            n1_a = n1_f;
+                        }
+                    }
+                    // Loop through local sample locations
+                    int ns = 0;
+                    for (int n0 = n0_f; n0 < n0_a; ++n0) {
+                        for (int n1 = n1_f; n1 < n1_a; ++n1) {
                             // Save index and location
-                            idx_arr(i, j, k, ns - 1) = (amrex::Real)n;
-                            loc_arr(i, j, k, 2 * (ns - 1)) = dloc_ptr[n0];
-                            loc_arr(i, j, k, 2 * (ns - 1) + 1) = dloc_ptr[n1];
+                            idx_arr(i, j, k, ns) = (amrex::Real)n1 * npts1 + n0;
+                            loc_arr(i, j, k, 2 * ns) = s_gc1 + n0 * dxs1;
+                            loc_arr(i, j, k, 2 * ns + 1) = s_gc2 + n1 * dxs2;
+                            // Advance to next point
+                            ++ns;
                         }
                     }
                     // Set remaining values to -1 to indicate no point
                     // or set all values to -1 if not in fine mesh
                     int nstart = (mask_arr(i, j, k) == 0) ? 0 : ns;
                     for (int n = nstart; n < ncomp; ++n) {
-                        idx_arr(i, j, k, ns) = -1.0;
+                        idx_arr(i, j, k, n) = -1.0;
                     }
                 });
         }
@@ -316,145 +401,127 @@ void FreeSurface::post_advance_work()
                             const int idx =
                                 (int)amrex::Math::round(idx_arr(i, j, k, n));
                             // Proceed if there is sample point at this i,j,k,n
-                            if (idx >= 0) {
+                            // and that cell height is below previous instance
+                            if (idx >= 0 && dlst_ptr[amrex::max(0, idx)] >
+                                                xm[dir] + 0.5 * dx[dir]) {
                                 // Get sample locations from field loc
                                 amrex::Real loc0 = loc_arr(i, j, k, 2 * n);
                                 amrex::Real loc1 = loc_arr(i, j, k, 2 * n + 1);
 
-                                // (1) Check that cell height is below
-                                // previous instance. (2) Check if cell
-                                // contains 2D grid point: complicated
-                                // conditional is to avoid double-counting
-                                // and includes exception for lo boundary.
-                                // (3) Check if cell is obviously
-                                // multiphase, then check if cell might have
-                                // interface at top or bottom
-                                if ((dlst_ptr[idx] > xm[dir] + 0.5 * dx[dir]) &&
-                                    (((plo[gc1] == loc0 &&
-                                       xm[gc1] - loc0 == 0.5 * dx[gc1]) ||
-                                      (xm[gc1] - loc0 < 0.5 * dx[gc1] &&
-                                       loc0 - xm[gc1] <= 0.5 * dx[gc1])) &&
-                                     ((plo[gc2] == loc1 &&
-                                       xm[gc2] - loc1 == 0.5 * dx[gc2]) ||
-                                      (xm[gc2] - loc1 < 0.5 * dx[gc2] &&
-                                       loc1 - xm[gc2] <= 0.5 * dx[gc2])))) {
+                                // Indices and slope variables
+                                int ip = i;
+                                int jp = j;
+                                int kp = k;
+                                int im = i;
+                                int jm = j;
+                                int km = k;
+                                amrex::Real mx = 0.0;
+                                amrex::Real my = 0.0;
+                                amrex::Real mz = 0.0;
+                                amrex::Real alpha = 1.0;
+                                // Get modified indices for checking up
+                                // and down and orient normal in search
+                                // direction
+                                switch (dir) {
+                                case 0:
+                                    ip += 1;
+                                    im -= 1;
+                                    mx = 1.0;
+                                    break;
+                                case 1:
+                                    jp += 1;
+                                    jm -= 1;
+                                    my = 1.0;
+                                    break;
+                                case 2:
+                                    kp += 1;
+                                    km -= 1;
+                                    mz = 1.0;
+                                    break;
+                                }
+                                // If cell is full of single phase
+                                // (accounts for when interface is at
+                                // intersection of cells but lower one
+                                // is not single-phase)
+                                bool calc_flag = false;
+                                if ((ni % 2 == 0 &&
+                                     vof_arr(i, j, k) >= 1.0 - 1e-12) ||
+                                    (ni % 2 == 1 &&
+                                     vof_arr(i, j, k) <= 1e-12)) {
+                                    // put bdy at top
+                                    alpha = 1.0;
+                                    if (ni % 2 == 1) {
+                                        mx *= -1.0;
+                                        my *= -1.0;
+                                        mz *= -1.0;
+                                        alpha *= -1.0;
+                                    }
+                                    calc_flag = true;
+                                }
+                                // Multiphase cell case
+                                if (vof_arr(i, j, k) < (1.0 - 1e-12) &&
+                                    vof_arr(i, j, k) > 1e-12) {
+                                    // Get interface reconstruction
+                                    multiphase::fit_plane(
+                                        i, j, k, vof_arr, mx, my, mz, alpha);
+                                    calc_flag = true;
+                                }
 
-                                    int ip = i;
-                                    int jp = j;
-                                    int kp = k;
-                                    int im = i;
-                                    int jm = j;
-                                    int km = k;
-                                    amrex::Real mx = 0.0;
-                                    amrex::Real my = 0.0;
-                                    amrex::Real mz = 0.0;
-                                    amrex::Real alpha = 1.0;
-                                    // Get modified indices for checking up
-                                    // and down and orient normal in search
-                                    // direction
+                                if (calc_flag) {
+                                    // Initialize height measurement
+                                    amrex::Real ht = plo[dir];
+                                    // Reassign slope coefficients
+                                    amrex::Real mdr = 0.0;
+                                    amrex::Real mg1 = 0.0;
+                                    amrex::Real mg2 = 0.0;
                                     switch (dir) {
                                     case 0:
-                                        ip += 1;
-                                        im -= 1;
-                                        mx = 1.0;
+                                        mdr = mx;
+                                        mg1 = my;
+                                        mg2 = mz;
                                         break;
                                     case 1:
-                                        jp += 1;
-                                        jm -= 1;
-                                        my = 1.0;
+                                        mdr = my;
+                                        mg1 = mx;
+                                        mg2 = mz;
                                         break;
                                     case 2:
-                                        kp += 1;
-                                        km -= 1;
-                                        mz = 1.0;
+                                        mdr = mz;
+                                        mg1 = mx;
+                                        mg2 = my;
                                         break;
                                     }
-                                    // If cell is full of single phase
-                                    // (accounts for when interface is at
-                                    // intersection of cells but lower one
-                                    // is not single-phase)
-                                    bool calc_flag = false;
-                                    if ((ni % 2 == 0 &&
-                                         vof_arr(i, j, k) >= 1.0 - 1e-12) ||
-                                        (ni % 2 == 1 &&
-                                         vof_arr(i, j, k) <= 1e-12)) {
-                                        // put bdy at top
-                                        alpha = 1.0;
-                                        if (ni % 2 == 1) {
-                                            mx *= -1.0;
-                                            my *= -1.0;
-                                            mz *= -1.0;
-                                            alpha *= -1.0;
-                                        }
-                                        calc_flag = true;
+                                    // Get height of interface
+                                    if (mdr == 0) {
+                                        // If slope is undefined in z,
+                                        // use middle of cell
+                                        ht = xm[dir];
+                                    } else {
+                                        // Intersect 2D point with plane
+                                        ht = (xm[dir] - 0.5 * dx[dir]) +
+                                             (alpha -
+                                              mg1 * dxi[gc1] *
+                                                  (loc0 -
+                                                   (xm[gc1] - 0.5 * dx[gc1])) -
+                                              mg2 * dxi[gc2] *
+                                                  (loc1 -
+                                                   (xm[gc2] - 0.5 * dx[gc2]))) /
+                                                 (mdr * dxi[dir]);
                                     }
-                                    // Multiphase cell case
-                                    if (vof_arr(i, j, k) < (1.0 - 1e-12) &&
-                                        vof_arr(i, j, k) > 1e-12) {
-                                        // Get interface reconstruction
-                                        multiphase::fit_plane(
-                                            i, j, k, vof_arr, mx, my, mz,
-                                            alpha);
-                                        calc_flag = true;
+                                    // If interface is below lower
+                                    // bound, continue to look
+                                    if (ht < xm[dir] - 0.5 * dx[dir]) {
+                                        ht = plo[dir];
                                     }
-
-                                    if (calc_flag) {
-                                        // Initialize height measurement
-                                        amrex::Real ht = plo[dir];
-                                        // Reassign slope coefficients
-                                        amrex::Real mdr = 0.0;
-                                        amrex::Real mg1 = 0.0;
-                                        amrex::Real mg2 = 0.0;
-                                        switch (dir) {
-                                        case 0:
-                                            mdr = mx;
-                                            mg1 = my;
-                                            mg2 = mz;
-                                            break;
-                                        case 1:
-                                            mdr = my;
-                                            mg1 = mx;
-                                            mg2 = mz;
-                                            break;
-                                        case 2:
-                                            mdr = mz;
-                                            mg1 = mx;
-                                            mg2 = my;
-                                            break;
-                                        }
-                                        // Get height of interface
-                                        if (mdr == 0) {
-                                            // If slope is undefined in z,
-                                            // use middle of cell
-                                            ht = xm[dir];
-                                        } else {
-                                            // Intersect 2D point with plane
-                                            ht =
-                                                (xm[dir] - 0.5 * dx[dir]) +
-                                                (alpha -
-                                                 mg1 * dxi[gc1] *
-                                                     (loc0 - (xm[gc1] -
-                                                              0.5 * dx[gc1])) -
-                                                 mg2 * dxi[gc2] *
-                                                     (loc1 - (xm[gc2] -
-                                                              0.5 * dx[gc2]))) /
-                                                    (mdr * dxi[dir]);
-                                        }
-                                        // If interface is below lower
-                                        // bound, continue to look
-                                        if (ht < xm[dir] - 0.5 * dx[dir]) {
-                                            ht = plo[dir];
-                                        }
-                                        // If interface is above upper
-                                        // bound, limit it
-                                        if (ht > xm[dir] + 0.5 * dx[dir] *
-                                                               (1.0 + 1e-8)) {
-                                            ht = xm[dir] + 0.5 * dx[dir];
-                                        }
-                                        // Save interface location
-                                        dout_ptr[idx] =
-                                            amrex::max(dout_ptr[idx], ht);
+                                    // If interface is above upper
+                                    // bound, limit it
+                                    if (ht > xm[dir] +
+                                                 0.5 * dx[dir] * (1.0 + 1e-8)) {
+                                        ht = xm[dir] + 0.5 * dx[dir];
                                     }
+                                    // Save interface location
+                                    dout_ptr[idx] =
+                                        amrex::max(dout_ptr[idx], ht);
                                 }
                             }
                         }
@@ -521,6 +588,8 @@ void FreeSurface::write_ascii()
         if (!File.good()) {
             amrex::FileOpenFailed(fname);
         }
+
+        // WRITE TIME
 
         std::string str1 = "x";
         std::string str2 = "y";

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -593,7 +593,7 @@ void FreeSurface::write_ascii()
         if (!File.good()) {
             amrex::FileOpenFailed(fname);
         }
-        
+
         std::string str1 = "x";
         std::string str2 = "y";
         switch (m_coorddir) {

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -94,15 +94,6 @@ void FreeSurface::initialize()
         }
     }
 
-    // Create 1D vector of locations
-    amrex::Vector<amrex::Real> locs;
-    locs.resize(2 * m_npts);
-    for (int n = 0; n < m_npts; ++n) {
-        for (int d = 0; d < 2; ++d) {
-            locs[2 * n + d] = m_locs[n][d];
-        }
-    }
-
     // Capture variables for device
     const amrex::Real s_gc0 = m_start[m_gc0];
     const amrex::Real s_gc1 = m_start[m_gc1];
@@ -319,9 +310,13 @@ void FreeSurface::initialize()
                             // Advance to next point
                             ++ns;
                             // if ns gets to max components, break
-                            if (ns == ncomp) break;
+                            if (ns == ncomp) {
+                                break;
+                            }
                         }
-                        if (ns == ncomp) break;
+                        if (ns == ncomp) {
+                            break;
+                        }
                     }
                     // Set remaining values to -1 to indicate no point
                     // or set all values to -1 if not in fine mesh

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -71,8 +71,10 @@ void FreeSurface::initialize()
     m_out.resize(m_npts * m_ninst);
 
     // Get size of sample grid spacing
-    amrex::Real dxs0 = (m_end[m_gc0] - m_start[m_gc0]) / amrex::max(m_npts_dir[0] - 1, 1);
-    amrex::Real dxs1 = (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[1] - 1, 1);
+    amrex::Real dxs0 =
+        (m_end[m_gc0] - m_start[m_gc0]) / amrex::max(m_npts_dir[0] - 1, 1);
+    amrex::Real dxs1 =
+        (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[1] - 1, 1);
 
     // Store locations
     int idx = 0;
@@ -146,8 +148,10 @@ void FreeSurface::initialize()
                         xm[0] = plo[0] + (i + 0.5) * dx[0];
                         xm[1] = plo[1] + (j + 0.5) * dx[1];
                         xm[2] = plo[2] + (k + 0.5) * dx[2];
-                        int n0_f = 0; int n0_a = 0;
-                        int n1_f = 0; int n1_a = 0;
+                        int n0_f = 0;
+                        int n0_a = 0;
+                        int n1_f = 0;
+                        int n1_a = 0;
                         // Get first and after sample indices for gc0
                         if (ntps0 == 1) {
                             n0_a = ((phi[gc0] == s_gc0) ||
@@ -175,7 +179,7 @@ void FreeSurface::initialize()
                         }
                         // Get first and after sample indices for gc1
                         if (ntps1 == 1) {
-                            n1_a = ((phi[gc1] == s_gc1 ) ||
+                            n1_a = ((phi[gc1] == s_gc1) ||
                                     (xm[gc1] - s_gc1 <= 0.5 * dx[gc1] &&
                                      s_gc1 - xm[gc1] < 0.5 * dx[gc1]))
                                        ? 1
@@ -247,8 +251,10 @@ void FreeSurface::initialize()
                     xm[0] = plo[0] + (i + 0.5) * dx[0];
                     xm[1] = plo[1] + (j + 0.5) * dx[1];
                     xm[2] = plo[2] + (k + 0.5) * dx[2];
-                    int n0_f = 0; int n0_a = 0;
-                    int n1_f = 0; int n1_a = 0;
+                    int n0_f = 0;
+                    int n0_a = 0;
+                    int n1_f = 0;
+                    int n1_a = 0;
                     // Get first and after sample indices for gc0
                     if (ntps0 == 1) {
                         n0_a = ((phi[gc0] == s_gc0) ||
@@ -276,7 +282,7 @@ void FreeSurface::initialize()
                     }
                     // Get first and after sample indices for gc1
                     if (ntps1 == 1) {
-                        n1_a = ((phi[gc1] == s_gc1 ) ||
+                        n1_a = ((phi[gc1] == s_gc1) ||
                                 (xm[gc1] - s_gc1 <= 0.5 * dx[gc1] &&
                                  s_gc1 - xm[gc1] < 0.5 * dx[gc1]))
                                    ? 1

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -34,6 +34,7 @@ void FreeSurface::initialize()
         pp.getarr("num_points", m_npts_dir);
         pp.getarr("start", m_start);
         pp.getarr("end", m_end);
+        pp.query("max_sample_points_per_cell", m_ncmax);
         AMREX_ALWAYS_ASSERT(static_cast<int>(m_start.size()) == AMREX_SPACEDIM);
         AMREX_ALWAYS_ASSERT(static_cast<int>(m_end.size()) == AMREX_SPACEDIM);
         AMREX_ALWAYS_ASSERT(static_cast<int>(m_npts_dir.size()) == 2);
@@ -210,6 +211,8 @@ void FreeSurface::initialize()
                 }));
     }
     amrex::ParallelDescriptor::ReduceIntMax(ncomp);
+    // Limit number of components
+    ncomp = amrex::min(ncomp, m_ncmax);
     // Save number of components
     m_ncomp = ncomp;
 
@@ -315,7 +318,10 @@ void FreeSurface::initialize()
                             loc_arr(i, j, k, 2 * ns + 1) = s_gc1 + n1 * dxs1;
                             // Advance to next point
                             ++ns;
+                            // if ns gets to max components, break
+                            if (ns == ncomp) break;
                         }
+                        if (ns == ncomp) break;
                     }
                     // Set remaining values to -1 to indicate no point
                     // or set all values to -1 if not in fine mesh

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -71,9 +71,9 @@ void FreeSurface::initialize()
     m_out.resize(m_npts * m_ninst);
 
     // Get size of sample grid spacing
-    amrex::Vector<amrex::Real> dx = {0.0, 0.0};
-    dx[0] = (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[0] - 1, 1);
-    dx[1] = (m_end[m_gc2] - m_start[m_gc2]) / amrex::max(m_npts_dir[1] - 1, 1);
+    amrex::Vector<amrex::Real> dxs = {0.0, 0.0};
+    dxs[0] = (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[0] - 1, 1);
+    dxs[1] = (m_end[m_gc2] - m_start[m_gc2]) / amrex::max(m_npts_dir[1] - 1, 1);
 
     // Store locations
     int idx = 0;
@@ -84,11 +84,162 @@ void FreeSurface::initialize()
                 m_out[idx * m_ninst + ni] = m_start[m_coorddir];
             }
             // Grid direction 1
-            m_locs[idx][0] = m_start[m_gc1] + dx[0] * i;
+            m_locs[idx][0] = m_start[m_gc1] + dxs[0] * i;
             // Grid direction 2
-            m_locs[idx][1] = m_start[m_gc2] + dx[1] * j;
+            m_locs[idx][1] = m_start[m_gc2] + dxs[1] * j;
 
             ++idx;
+        }
+    }
+
+    // Create 1D vector of locations
+    amrex::Vector<amrex::Real> locs;
+    locs.resize(2 * m_npts);
+    for (int n = 0; n < m_npts; ++n) {
+        for (int d = 0; d < 2; ++d) {
+            locs[2 * n + d] = m_locs[n][d];
+        }
+    }
+    // Copy locations to device
+    amrex::Gpu::DeviceVector<amrex::Real> dloc(2 * m_npts);
+    auto* dloc_ptr = dloc.data();
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, &locs[0], &locs[2 * m_npts - 1] + 1,
+        dloc.begin());
+
+    // Determine number of components necessary for working fields
+    int ncomp = 0;
+    const int finest_level = m_vof.repo().num_active_levels() - 1;
+    const int npts = m_npts;
+    const int gc1 = m_gc1;
+    const int gc2 = m_gc2;
+    for (int lev = 0; lev <= finest_level; lev++) {
+        // Use level_mask to only count finest level present
+        amrex::iMultiFab level_mask;
+        if (lev < finest_level) {
+            level_mask = makeFineMask(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                m_sim.mesh().boxArray(lev + 1), amrex::IntVect(2), 1, 0);
+        } else {
+            level_mask.define(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                1, 0, amrex::MFInfo());
+            level_mask.setVal(1);
+        }
+        // Get geometry information
+        const auto& geom = m_sim.mesh().Geom(lev);
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
+            geom.CellSizeArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
+            geom.ProbLoArray();
+        ncomp = amrex::max(
+            ncomp,
+            amrex::ReduceMax(
+                level_mask, 0,
+                [=] AMREX_GPU_HOST_DEVICE(
+                    amrex::Box const& bx,
+                    amrex::Array4<int const> const& mask_arr) -> int {
+                    int ns_fab = 0;
+                    amrex::Loop(bx, [=, &ns_fab](int i, int j, int k) noexcept {
+                        // Cell location
+                        amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> xm;
+                        xm[0] = plo[0] + (i + 0.5) * dx[0];
+                        xm[1] = plo[1] + (j + 0.5) * dx[1];
+                        xm[2] = plo[2] + (k + 0.5) * dx[2];
+                        // Loop through sample locations to identify
+                        // how many are in current cell
+                        int ns = 0;
+                        for (int n = 0; n < npts; ++n) {
+                            int n0 = 2 * n;
+                            int n1 = 2 * n + 1;
+                            if (((plo[gc1] == dloc_ptr[n0] &&
+                                  xm[gc1] - dloc_ptr[n0] == 0.5 * dx[gc1]) ||
+                                 (xm[gc1] - dloc_ptr[n0] < 0.5 * dx[gc1] &&
+                                  dloc_ptr[n0] - xm[gc1] <= 0.5 * dx[gc1])) &&
+                                ((plo[gc2] == dloc_ptr[n1] &&
+                                  xm[gc2] - dloc_ptr[n1] == 0.5 * dx[gc2]) ||
+                                 (xm[gc2] - dloc_ptr[n1] < 0.5 * dx[gc2] &&
+                                  dloc_ptr[n1] - xm[gc2] <= 0.5 * dx[gc2]))) {
+                                ns += 1;
+                            }
+                            ns_fab = amrex::max(ns_fab, mask_arr(i, j, k) * ns);
+                        }
+                    });
+                    return ns_fab;
+                }));
+    }
+    amrex::ParallelDescriptor::ReduceIntMax(ncomp);
+    // Save number of components
+    m_ncomp = ncomp;
+
+    // Declare fields for search
+    auto& floc = m_sim.repo().declare_field("sample_loc", 2 * ncomp, 0, 1);
+    auto& fidx = m_sim.repo().declare_field("sample_idx", ncomp, 0, 1);
+
+    // Store locations and indices in fields
+    for (int lev = 0; lev <= finest_level; lev++) {
+        // Use level_mask to only count finest level present
+        amrex::iMultiFab level_mask;
+        if (lev < finest_level) {
+            level_mask = makeFineMask(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                m_sim.mesh().boxArray(lev + 1), amrex::IntVect(2), 1, 0);
+        } else {
+            level_mask.define(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                1, 0, amrex::MFInfo());
+            level_mask.setVal(1);
+        }
+        // Get geometry information
+        const auto& geom = m_sim.mesh().Geom(lev);
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
+            geom.CellSizeArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
+            geom.ProbLoArray();
+        for (amrex::MFIter mfi(floc(lev)); mfi.isValid(); ++mfi) {
+            auto loc_arr = floc(lev).array(mfi);
+            auto idx_arr = fidx(lev).array(mfi);
+            auto mask_arr = level_mask.const_array(mfi);
+            const auto& vbx = mfi.validbox();
+            amrex::ParallelFor(
+                vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // Cell location
+                    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> xm;
+                    xm[0] = plo[0] + (i + 0.5) * dx[0];
+                    xm[1] = plo[1] + (j + 0.5) * dx[1];
+                    xm[2] = plo[2] + (k + 0.5) * dx[2];
+                    // Loop through sample locations to identify
+                    // how many are in current cell
+                    int ns = 0;
+                    for (int n = 0; n < npts; ++n) {
+                        int n0 = 2 * n;
+                        int n1 = 2 * n + 1;
+                        bool pt_here = false;
+                        if (((plo[gc1] == dloc_ptr[n0] &&
+                              xm[gc1] - dloc_ptr[n0] == 0.5 * dx[gc1]) ||
+                             (xm[gc1] - dloc_ptr[n0] < 0.5 * dx[gc1] &&
+                              dloc_ptr[n0] - xm[gc1] <= 0.5 * dx[gc1])) &&
+                            ((plo[gc2] == dloc_ptr[n1] &&
+                              xm[gc2] - dloc_ptr[n1] == 0.5 * dx[gc2]) ||
+                             (xm[gc2] - dloc_ptr[n1] < 0.5 * dx[gc2] &&
+                              dloc_ptr[n1] - xm[gc2] <= 0.5 * dx[gc2]))) {
+                            ns += 1;
+                            pt_here = true;
+                        }
+                        if (pt_here) {
+                            // Save index and location
+                            idx_arr(i, j, k, ns - 1) = (amrex::Real)n;
+                            loc_arr(i, j, k, 2 * (ns - 1)) = dloc_ptr[n0];
+                            loc_arr(i, j, k, 2 * (ns - 1) + 1) = dloc_ptr[n1];
+                        }
+                    }
+                    // Set remaining values to -1 to indicate no point
+                    // or set all values to -1 if not in fine mesh
+                    int nstart = (mask_arr(i, j, k) == 0) ? 0 : ns;
+                    for (int n = nstart; n < ncomp; ++n) {
+                        idx_arr(i, j, k, ns) = -1.0;
+                    }
+                });
         }
     }
 
@@ -112,34 +263,34 @@ void FreeSurface::post_advance_work()
     for (int n = 0; n < m_npts * m_ninst; n++) {
         m_out[n] = 0.0;
     }
-    // Set up device vector of outputs, initialize to above phi0
+    // Set up device vector of current outputs, initialize to plo
     const auto& plo0 = m_sim.mesh().Geom(0).ProbLoArray();
-    const auto& phi0 = m_sim.mesh().Geom(0).ProbHiArray();
-    amrex::Gpu::DeviceVector<amrex::Real> dout(m_npts, phi0[2] + 1.0);
+    amrex::Gpu::DeviceVector<amrex::Real> dout(m_npts, plo0[m_coorddir]);
     auto* dout_ptr = dout.data();
+    // Set up device vector of last outputs, initialize to above phi0
+    const auto& phi0 = m_sim.mesh().Geom(0).ProbHiArray();
+    amrex::Gpu::DeviceVector<amrex::Real> dout_last(
+        m_npts, phi0[m_coorddir] + 1.0);
+    auto* dlst_ptr = dout_last.data();
 
-    // Sum of interface locations at each point (assumes one interface only)
+    // Get working fields
+    auto& fidx = m_sim.repo().get_field("sample_idx");
+    auto& floc = m_sim.repo().get_field("sample_loc");
+
     const int finest_level = m_vof.repo().num_active_levels() - 1;
+
+    // Capture integers for device
+    const int dir = m_coorddir;
+    const int gc1 = m_gc1;
+    const int gc2 = m_gc2;
+    const int ncomp = m_ncomp;
 
     // Loop instances
     for (int ni = 0; ni < m_ninst; ++ni) {
         for (int lev = 0; lev <= finest_level; lev++) {
+            // Level mask info is built into idx info
 
-            // Use level_mask to identify smallest volume
-            amrex::iMultiFab level_mask;
-            if (lev < finest_level) {
-                level_mask = makeFineMask(
-                    m_sim.mesh().boxArray(lev),
-                    m_sim.mesh().DistributionMap(lev),
-                    m_sim.mesh().boxArray(lev + 1), amrex::IntVect(2), 1, 0);
-            } else {
-                level_mask.define(
-                    m_sim.mesh().boxArray(lev),
-                    m_sim.mesh().DistributionMap(lev), 1, 0, amrex::MFInfo());
-                level_mask.setVal(1);
-            }
-
-            const auto& vof = m_vof(lev);
+            // Get geometry information
             const auto& geom = m_sim.mesh().Geom(lev);
             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
                 geom.CellSizeArray();
@@ -147,199 +298,186 @@ void FreeSurface::post_advance_work()
                 geom.InvCellSizeArray();
             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
                 geom.ProbLoArray();
+            for (amrex::MFIter mfi(floc(lev)); mfi.isValid(); ++mfi) {
+                auto loc_arr = floc(lev).const_array(mfi);
+                auto idx_arr = fidx(lev).const_array(mfi);
+                auto vof_arr = m_vof(lev).const_array(mfi);
+                const auto& vbx = mfi.validbox();
+                amrex::ParallelFor(
+                    vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        // Cell location
+                        amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> xm;
+                        xm[0] = plo[0] + (i + 0.5) * dx[0];
+                        xm[1] = plo[1] + (j + 0.5) * dx[1];
+                        xm[2] = plo[2] + (k + 0.5) * dx[2];
+                        // Loop number of components
+                        for (int n = 0; n < ncomp; ++n) {
+                            // Get index of current component and cell
+                            const int idx =
+                                (int)amrex::Math::round(idx_arr(i, j, k, n));
+                            // Proceed if there is sample point at this i,j,k,n
+                            if (idx >= 0) {
+                                // Get sample locations from field loc
+                                amrex::Real loc0 = loc_arr(i, j, k, 2 * n);
+                                amrex::Real loc1 = loc_arr(i, j, k, 2 * n + 1);
 
-            // c = captured
-            const int dir = m_coorddir;
-            const int gc1 = m_gc1;
-            const int gc2 = m_gc2;
+                                // (1) Check that cell height is below
+                                // previous instance. (2) Check if cell
+                                // contains 2D grid point: complicated
+                                // conditional is to avoid double-counting
+                                // and includes exception for lo boundary.
+                                // (3) Check if cell is obviously
+                                // multiphase, then check if cell might have
+                                // interface at top or bottom
+                                if ((dlst_ptr[idx] > xm[dir] + 0.5 * dx[dir]) &&
+                                    (((plo[gc1] == loc0 &&
+                                       xm[gc1] - loc0 == 0.5 * dx[gc1]) ||
+                                      (xm[gc1] - loc0 < 0.5 * dx[gc1] &&
+                                       loc0 - xm[gc1] <= 0.5 * dx[gc1])) &&
+                                     ((plo[gc2] == loc1 &&
+                                       xm[gc2] - loc1 == 0.5 * dx[gc2]) ||
+                                      (xm[gc2] - loc1 < 0.5 * dx[gc2] &&
+                                       loc1 - xm[gc2] <= 0.5 * dx[gc2])))) {
 
-            // Loop points in 2D grid
-            for (int n = 0; n < m_npts; ++n) {
-                amrex::GpuArray<amrex::Real, 2> loc;
-                for (int d = 0; d < 2; ++d) {
-                    loc[d] = m_locs[n][d];
-                }
+                                    int ip = i;
+                                    int jp = j;
+                                    int kp = k;
+                                    int im = i;
+                                    int jm = j;
+                                    int km = k;
+                                    amrex::Real mx = 0.0;
+                                    amrex::Real my = 0.0;
+                                    amrex::Real mz = 0.0;
+                                    amrex::Real alpha = 1.0;
+                                    // Get modified indices for checking up
+                                    // and down and orient normal in search
+                                    // direction
+                                    switch (dir) {
+                                    case 0:
+                                        ip += 1;
+                                        im -= 1;
+                                        mx = 1.0;
+                                        break;
+                                    case 1:
+                                        jp += 1;
+                                        jm -= 1;
+                                        my = 1.0;
+                                        break;
+                                    case 2:
+                                        kp += 1;
+                                        km -= 1;
+                                        mz = 1.0;
+                                        break;
+                                    }
+                                    // If cell is full of single phase
+                                    // (accounts for when interface is at
+                                    // intersection of cells but lower one
+                                    // is not single-phase)
+                                    bool calc_flag = false;
+                                    if ((ni % 2 == 0 &&
+                                         vof_arr(i, j, k) >= 1.0 - 1e-12) ||
+                                        (ni % 2 == 1 &&
+                                         vof_arr(i, j, k) <= 1e-12)) {
+                                        // put bdy at top
+                                        alpha = 1.0;
+                                        if (ni % 2 == 1) {
+                                            mx *= -1.0;
+                                            my *= -1.0;
+                                            mz *= -1.0;
+                                            alpha *= -1.0;
+                                        }
+                                        calc_flag = true;
+                                    }
+                                    // Multiphase cell case
+                                    if (vof_arr(i, j, k) < (1.0 - 1e-12) &&
+                                        vof_arr(i, j, k) > 1e-12) {
+                                        // Get interface reconstruction
+                                        multiphase::fit_plane(
+                                            i, j, k, vof_arr, mx, my, mz,
+                                            alpha);
+                                        calc_flag = true;
+                                    }
 
-                m_out[ni * m_npts + n] = amrex::max(
-                    m_out[ni * m_npts + n],
-                    amrex::ReduceMax(
-                        vof, level_mask, 0,
-                        [=] AMREX_GPU_HOST_DEVICE(
-                            amrex::Box const& bx,
-                            amrex::Array4<amrex::Real const> const& vof_arr,
-                            amrex::Array4<int const> const& mask_arr)
-                            -> amrex::Real {
-                            amrex::Real height_fab = 0.0;
-
-                            amrex::Loop(
-                                bx,
-                                [=, &height_fab](int i, int j, int k) noexcept {
-                                    // Initialize height measurement
-                                    amrex::Real ht = plo[dir];
-                                    // Cell location
-                                    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>
-                                        xm;
-                                    xm[0] = plo[0] + (i + 0.5) * dx[0];
-                                    xm[1] = plo[1] + (j + 0.5) * dx[1];
-                                    xm[2] = plo[2] + (k + 0.5) * dx[2];
-                                    // (1) Check that cell height is below
-                                    // previous instance. (2) Check if cell
-                                    // contains 2D grid point: complicated
-                                    // conditional is to avoid double-counting
-                                    // and includes exception for lo boundary.
-                                    // (3) Check if cell is obviously
-                                    // multiphase, then check if cell might have
-                                    // interface at top or bottom
-                                    if ((dout_ptr[n] >
-                                         xm[dir] + 0.5 * dx[dir]) &&
-                                        (((plo[gc1] == loc[0] &&
-                                           xm[gc1] - loc[0] == 0.5 * dx[gc1]) ||
-                                          (xm[gc1] - loc[0] < 0.5 * dx[gc1] &&
-                                           loc[0] - xm[gc1] <=
-                                               0.5 * dx[gc1])) &&
-                                         ((plo[gc2] == loc[1] &&
-                                           xm[gc2] - loc[1] == 0.5 * dx[gc2]) ||
-                                          (xm[gc2] - loc[1] < 0.5 * dx[gc2] &&
-                                           loc[1] - xm[gc2] <=
-                                               0.5 * dx[gc2])))) {
-
-                                        int ip = i;
-                                        int jp = j;
-                                        int kp = k;
-                                        int im = i;
-                                        int jm = j;
-                                        int km = k;
-                                        amrex::Real mx = 0.0;
-                                        amrex::Real my = 0.0;
-                                        amrex::Real mz = 0.0;
-                                        amrex::Real alpha = 1.0;
-                                        // Get modified indices for checking up
-                                        // and down and orient normal in search
-                                        // direction
+                                    if (calc_flag) {
+                                        // Initialize height measurement
+                                        amrex::Real ht = plo[dir];
+                                        // Reassign slope coefficients
+                                        amrex::Real mdr = 0.0;
+                                        amrex::Real mg1 = 0.0;
+                                        amrex::Real mg2 = 0.0;
                                         switch (dir) {
                                         case 0:
-                                            ip += 1;
-                                            im -= 1;
-                                            mx = 1.0;
+                                            mdr = mx;
+                                            mg1 = my;
+                                            mg2 = mz;
                                             break;
                                         case 1:
-                                            jp += 1;
-                                            jm -= 1;
-                                            my = 1.0;
+                                            mdr = my;
+                                            mg1 = mx;
+                                            mg2 = mz;
                                             break;
                                         case 2:
-                                            kp += 1;
-                                            km -= 1;
-                                            mz = 1.0;
+                                            mdr = mz;
+                                            mg1 = mx;
+                                            mg2 = my;
                                             break;
                                         }
-                                        // If cell is full of single phase
-                                        // (accounts for when interface is at
-                                        // intersection of cells but lower one
-                                        // is not single-phase)
-                                        bool calc_flag = false;
-                                        if ((ni % 2 == 0 &&
-                                             vof_arr(i, j, k) >= 1.0 - 1e-12) ||
-                                            (ni % 2 == 1 &&
-                                             vof_arr(i, j, k) <= 1e-12)) {
-                                            // put bdy at top
-                                            alpha = 1.0;
-                                            if (ni % 2 == 1) {
-                                                mx *= -1.0;
-                                                my *= -1.0;
-                                                mz *= -1.0;
-                                                alpha *= -1.0;
-                                            }
-                                            calc_flag = true;
+                                        // Get height of interface
+                                        if (mdr == 0) {
+                                            // If slope is undefined in z,
+                                            // use middle of cell
+                                            ht = xm[dir];
+                                        } else {
+                                            // Intersect 2D point with plane
+                                            ht =
+                                                (xm[dir] - 0.5 * dx[dir]) +
+                                                (alpha -
+                                                 mg1 * dxi[gc1] *
+                                                     (loc0 - (xm[gc1] -
+                                                              0.5 * dx[gc1])) -
+                                                 mg2 * dxi[gc2] *
+                                                     (loc1 - (xm[gc2] -
+                                                              0.5 * dx[gc2]))) /
+                                                    (mdr * dxi[dir]);
                                         }
-                                        // Multiphase cell case
-                                        if ((vof_arr(i, j, k) < (1.0 - 1e-12) &&
-                                             vof_arr(i, j, k) > 1e-12)) {
-                                            // Get interface reconstruction
-                                            multiphase::fit_plane(
-                                                i, j, k, vof_arr, mx, my, mz,
-                                                alpha);
-                                            calc_flag = true;
+                                        // If interface is below lower
+                                        // bound, continue to look
+                                        if (ht < xm[dir] - 0.5 * dx[dir]) {
+                                            ht = plo[dir];
                                         }
-
-                                        if (calc_flag) {
-                                            // Reassign slope coefficients
-                                            amrex::Real mdr = 0.0;
-                                            amrex::Real mg1 = 0.0;
-                                            amrex::Real mg2 = 0.0;
-                                            switch (dir) {
-                                            case 0:
-                                                mdr = mx;
-                                                mg1 = my;
-                                                mg2 = mz;
-                                                break;
-                                            case 1:
-                                                mdr = my;
-                                                mg1 = mx;
-                                                mg2 = mz;
-                                                break;
-                                            case 2:
-                                                mdr = mz;
-                                                mg1 = mx;
-                                                mg2 = my;
-                                                break;
-                                            }
-                                            // Get height of interface
-                                            if (mdr == 0) {
-                                                // If slope is undefined in z,
-                                                // use middle of cell
-                                                ht = xm[dir];
-                                            } else {
-                                                // Intersect 2D point with plane
-                                                ht = (xm[dir] - 0.5 * dx[dir]) +
-                                                     (alpha -
-                                                      mg1 * dxi[gc1] *
-                                                          (loc[0] -
-                                                           (xm[gc1] -
-                                                            0.5 * dx[gc1])) -
-                                                      mg2 * dxi[gc2] *
-                                                          (loc[1] -
-                                                           (xm[gc2] -
-                                                            0.5 * dx[gc2]))) /
-                                                         (mdr * dxi[dir]);
-                                            }
-                                            // If interface is below lower
-                                            // bound, continue to look
-                                            if (ht < xm[dir] - 0.5 * dx[dir]) {
-                                                ht = plo[dir];
-                                            }
-                                            // If interface is above upper
-                                            // bound, limit it
-                                            if (ht >
-                                                xm[dir] + 0.5 * dx[dir] *
-                                                              (1.0 + 1e-8)) {
-                                                ht = xm[dir] + 0.5 * dx[dir];
-                                            }
+                                        // If interface is above upper
+                                        // bound, limit it
+                                        if (ht > xm[dir] + 0.5 * dx[dir] *
+                                                               (1.0 + 1e-8)) {
+                                            ht = xm[dir] + 0.5 * dx[dir];
                                         }
+                                        // Save interface location
+                                        dout_ptr[idx] =
+                                            amrex::max(dout_ptr[idx], ht);
                                     }
-                                    // Offset by removing lo and contribute to
-                                    // whole
-                                    height_fab = amrex::max(
-                                        height_fab,
-                                        mask_arr(i, j, k) * (ht - plo[dir]));
-                                });
-                            return height_fab;
-                        }));
+                                }
+                            }
+                        }
+                    });
             }
         }
 
-        // Loop points in 2D grid
+        // Copy information back from device
+        amrex::Gpu::copy(
+            amrex::Gpu::deviceToHost, dout.begin(), dout.end(),
+            &m_out[ni * m_npts]);
+        // Make consistent across parallelization
         for (int n = 0; n < m_npts; n++) {
             amrex::ParallelDescriptor::ReduceRealMax(m_out[ni * m_npts + n]);
         }
-        // Add problo back to heights, making them absolute, not relative
-        for (int n = 0; n < m_npts; n++) {
-            m_out[ni * m_npts + n] += plo0[m_coorddir];
-        }
-        // Copy last m_out to device vector
+        // Copy last m_out to device vector of results of last instance
         amrex::Gpu::copy(
             amrex::Gpu::hostToDevice, &m_out[ni * m_npts],
-            &m_out[(ni + 1) * m_npts - 1] + 1, dout.begin());
+            &m_out[(ni + 1) * m_npts - 1] + 1, dout_last.begin());
+        // Reset current output device vector
+        for (int n = 0; n < m_npts; n++) {
+            dout_ptr[n] = plo0[m_coorddir];
+        }
     }
 
     process_output();

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -593,9 +593,7 @@ void FreeSurface::write_ascii()
         if (!File.good()) {
             amrex::FileOpenFailed(fname);
         }
-
-        // WRITE TIME
-
+        
         std::string str1 = "x";
         std::string str2 = "y";
         switch (m_coorddir) {
@@ -616,6 +614,7 @@ void FreeSurface::write_ascii()
         }
 
         // Metadata
+        File << m_sim.time().new_time() << '\n';
         File << m_npts << '\n';
         File << str1 << ' ' << m_npts_dir[0] << ' ' << str2 << ' '
              << m_npts_dir[1] << '\n';

--- a/amr-wind/utilities/sampling/WaveEnergy.H
+++ b/amr-wind/utilities/sampling/WaveEnergy.H
@@ -54,7 +54,7 @@ public:
 
 private:
     //! prepare ASCII file and directory
-    void prepare_ascii_file();
+    virtual void prepare_ascii_file();
 
     //! Output sampled data in ASCII format
     virtual void write_ascii();

--- a/unit_tests/utilities/test_wave_energy.cpp
+++ b/unit_tests/utilities/test_wave_energy.cpp
@@ -66,6 +66,7 @@ public:
 
 protected:
     // No file output during test
+    void prepare_ascii_file() override {}
     void write_ascii() override {}
 };
 


### PR DESCRIPTION
- uses atomic operation to ensure it always gets the same answer on GPUs
- removes an obsolete print statement
- removes an unnecessary file write from unit tests (wave energy)