### PR TITLE
Freesurface fix for GPUs

### DIFF
--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -519,9 +519,8 @@ void FreeSurface::post_advance_work()
                                                  0.5 * dx[dir] * (1.0 + 1e-8)) {
                                         ht = xm[dir] + 0.5 * dx[dir];
                                     }
-                                    // Save interface location
-                                    dout_ptr[idx] =
-                                        amrex::max(dout_ptr[idx], ht);
+                                    // Save interface location by atomic max
+                                    amrex::Gpu::Atomic::Max(&dout_ptr[idx], ht);
                                 }
                             }
                         }

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -12,11 +12,7 @@ namespace free_surface {
 
 FreeSurface::FreeSurface(CFDSim& sim, std::string label)
     : m_sim(sim), m_label(std::move(label)), m_vof(sim.repo().get_field("vof"))
-{
-#ifdef AMREX_USE_GPU
-    amrex::Print() << "WARNING: FreeSurface: Running on GPUs..." << std::endl;
-#endif
-}
+{}
 
 FreeSurface::~FreeSurface() = default;
 

--- a/amr-wind/utilities/sampling/WaveEnergy.H
+++ b/amr-wind/utilities/sampling/WaveEnergy.H
@@ -60,7 +60,7 @@ public:
 
 private:
     //! prepare ASCII file and directory
-    void prepare_ascii_file();
+    virtual void prepare_ascii_file();
 
     //! Output sampled data in ASCII format
     virtual void write_ascii();

--- a/unit_tests/utilities/test_wave_energy.cpp
+++ b/unit_tests/utilities/test_wave_energy.cpp
@@ -66,6 +66,7 @@ public:
 
 protected:
     // No file output during test
+    void prepare_ascii_file() override {}
     void write_ascii() override {}
 };
 


### PR DESCRIPTION
- uses atomic operation to ensure it always gets the same answer on GPUs
- removes an obsolete print statement
- removes an unnecessary file write from unit tests (wave energy)

