### PR TITLE
Fix VOF BC unit tests for GPUs

### DIFF
--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -203,7 +203,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void mixed_youngs_central_normal(
         t0 = t2;
     }
 
-    if (amrex::Math::abs(m[cn][cn]) > t0) {
+    if (amrex::Math::abs(m[cn][cn]) > t0 && t0 > 0.0) {
+        // second t0 condition is to ensure nonzero normal magnitude
         cn = 3;
     }
 
@@ -346,7 +347,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real cut_volume(
     // amrex::Real bm = amrex::min(b12, b3);
     // amrex::Real pr = amrex::max(6.0 * m1 * m2 * m3, const_tiny);
 
-    // Compute volume fraction using Aoki Kawano (Computer & Fluids 2016) method
+    // Compute volume fraction using PLIC from Scardovelli & Zaleski (JCP 2000),
+    // adapted from code in paper by Akio Kawano (Computer & Fluids 2016)
     amrex::Real vm1 = b1;
     amrex::Real vm3 = b3;
     amrex::Real vm2 = b2;

--- a/unit_tests/multiphase/test_vof_BCs.cpp
+++ b/unit_tests/multiphase/test_vof_BCs.cpp
@@ -62,15 +62,23 @@ protected:
 
         // Get string version of direction
         std::string sdir = "d";
+        std::string odir0 = "d";
+        std::string odir1 = "d";
         switch (dir) {
         case 0:
             sdir = "x";
+            odir0 = "y";
+            odir1 = "z";
             break;
         case 1:
             sdir = "y";
+            odir0 = "x";
+            odir1 = "z";
             break;
         case 2:
             sdir = "z";
+            odir0 = "x";
+            odir1 = "y";
             break;
         }
 
@@ -108,8 +116,7 @@ protected:
         populate_parameters();
         {
             amrex::ParmParse pp("geometry");
-            amrex::Vector<int> periodic{
-                {dir == 0 ? 0 : 1, dir == 1 ? 0 : 1, dir == 2 ? 0 : 1}};
+            amrex::Vector<int> periodic{{0, 0, 0}};
             pp.addarr("is_periodic", periodic);
         }
         {
@@ -135,6 +142,22 @@ protected:
                 pp.addarr(
                     "velocity", amrex::Vector<amrex::Real>{0.0, 0.0, 0.0});
             }
+        }
+        {
+            amrex::ParmParse pp(odir0 + "lo");
+            pp.add("type", (std::string) "slip_wall");
+        }
+        {
+            amrex::ParmParse pp(odir0 + "hi");
+            pp.add("type", (std::string) "slip_wall");
+        }
+        {
+            amrex::ParmParse pp(odir1 + "lo");
+            pp.add("type", (std::string) "slip_wall");
+        }
+        {
+            amrex::ParmParse pp(odir1 + "hi");
+            pp.add("type", (std::string) "slip_wall");
         }
 
         initialize_mesh();


### PR DESCRIPTION
* updated transverse BCs of unit test prevent getting 0 -> NaN normals  in important boundary cells
* conditional in volume_fractions prevents getting 0 magnitude normals  ever, which would only happen with a weird VOF field or at corner cells  in bdy (e.g., (-1,-1))
* comment in volume_fractions clarifies which method is used and  corrects spelling error