### PR TITLE
Bug fix for constant, non-unity density simulations

### DIFF
--- a/amr-wind/equation_systems/icns/icns_advection.cpp
+++ b/amr-wind/equation_systems/icns/icns_advection.cpp
@@ -49,7 +49,7 @@ MacProjOp::MacProjOp(
     , m_mesh_mapping(mesh_mapping)
 {
     amrex::ParmParse pp("incflo");
-    pp.query("rho_0", m_rho_0);
+    pp.query("density", m_rho_0);
 }
 
 void MacProjOp::init_projector(const MacProjOp::FaceFabPtrVec& beta) noexcept


### PR DESCRIPTION
- changing parser query to match norm in input files, regression tests
- only effect is slight difference in convergence of MAC projection