### PR TITLE
Initial condition input

### DIFF
--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -65,12 +65,19 @@ void ABL::initialize_fields(int level, const amrex::Geometry& geom)
         temp.setVal(0.0);
     }
 
+    bool interp_fine_levels = false;
     for (amrex::MFIter mfi(density); mfi.isValid(); ++mfi) {
         const auto& vbx = mfi.validbox();
 
-        (*m_field_init)(
-            vbx, geom, velocity.array(mfi), density.array(mfi),
-            temp.array(mfi));
+        interp_fine_levels = (*m_field_init)(
+            vbx, geom, velocity.array(mfi), density.array(mfi), temp.array(mfi),
+            level);
+    }
+
+    if (interp_fine_levels) {
+        // Fill the finer levels with coarse data
+        m_velocity.fillpatch_from_coarse(level, 0.0, velocity, 0);
+        m_density.fillpatch_from_coarse(level, 0.0, density, 0);
     }
 
     if (m_sim.repo().field_exists("tke")) {

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -105,6 +105,9 @@ private:
 
     //! Perturb temperature field with random fluctuations
     bool m_perturb_theta{false};
+
+    //! Input file with initial condition from Machine Learning
+    std::string m_ic_input{""};
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -107,7 +107,7 @@ private:
     bool m_perturb_theta{false};
 
     //! Input file with initial condition from Machine Learning
-    std::string m_ic_input{""};
+    std::string m_ic_input;
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -22,12 +22,13 @@ class ABLFieldInit
 public:
     ABLFieldInit();
 
-    void operator()(
+    bool operator()(
         const amrex::Box& vbx,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::Real>& velocity,
         const amrex::Array4<amrex::Real>& density,
-        const amrex::Array4<amrex::Real>& temperature) const;
+        const amrex::Array4<amrex::Real>& temperature,
+        const int lev = 0) const;
 
     /** Add temperature perturbations
      *

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -184,7 +184,7 @@ void ABLFieldInit::operator()(
         // Read the velocity components u and v
         uvel.get(uvel2.data(), start, count);
         vvel.get(vvel2.data(), start, count);
-        wvel.get(vvel2.data(), start, count);
+        wvel.get(wvel2.data(), start, count);
 
         // Amrex parallel for to assign the velocity at each point
         amrex::ParallelFor(

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -157,6 +157,7 @@ void ABLFieldInit::operator()(
         // The x, y and z velocity components (u, v, w)
         auto uvel = ncf.var("uvel");
         auto vvel = ncf.var("vvel");
+        auto wvel = ncf.var("wvel");
 
         // Loop through all points in the domain and set velocities to values
         // from the input file
@@ -172,15 +173,18 @@ void ABLFieldInit::operator()(
         // Vector to store the 3d data into a single array
         amrex::Vector<double> uvel2;
         amrex::Vector<double> vvel2;
+        amrex::Vector<double> wvel2;
 
         // Set the size of the arrays to the total number of points in this
         // processor
         uvel2.resize(count[0] * count[1] * count[2]);
         vvel2.resize(count[0] * count[1] * count[2]);
+        wvel2.resize(count[0] * count[1] * count[2]);
 
         // Read the velocity components u and v
         uvel.get(uvel2.data(), start, count);
         vvel.get(vvel2.data(), start, count);
+        wvel.get(vvel2.data(), start, count);
 
         // Amrex parallel for to assign the velocity at each point
         amrex::ParallelFor(
@@ -191,6 +195,7 @@ void ABLFieldInit::operator()(
                 // Pass values from temporary array to the velocity field
                 velocity(i, j, k, 0) = uvel2.data()[idx];
                 velocity(i, j, k, 1) = vvel2.data()[idx];
+                velocity(i, j, k, 3) = wvel2.data()[idx];
             });
         // Close the netcdf file
         ncf.close();

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -82,8 +82,8 @@ bool ABLFieldInit::operator()(
     const int lev) const
 {
     // Initialized using lev to prevent compiler warnings when netcdf is not
-    // used cppcheck-suppress constVariable
-    bool interp_fine_levels = (lev >= 0) ? false : true;
+    // used. Will always initialize to false. cppcheck-suppress constVariable
+    bool interp_fine_levels = (lev < 0);
 
     const amrex::Real pi = M_PI;
     const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -81,8 +81,9 @@ bool ABLFieldInit::operator()(
     const amrex::Array4<amrex::Real>& temperature,
     const int lev) const
 {
-    // cppcheck-suppress constVariable
-    bool interp_fine_levels = false;
+    // Initialized using lev to prevent compiler warnings when netcdf is not
+    // used cppcheck-suppress constVariable
+    bool interp_fine_levels = (lev >= 0) ? false : true;
 
     const amrex::Real pi = M_PI;
     const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -153,7 +153,7 @@ void ABLFieldInit::operator()(
 
         auto k0 = std::max(vbx.smallEnd(2), domain.smallEnd(2));
         auto k1 = std::min(vbx.bigEnd(2), domain.bigEnd(2));
-        // std::cout << "k vals" <<  k0 << " " << k1 << std::endl;
+
         // The x, y and z velocity components (u, v, w)
         auto uvel = ncf.var("uvel");
         auto vvel = ncf.var("vvel");
@@ -186,21 +186,15 @@ void ABLFieldInit::operator()(
         amrex::ParallelFor(
             vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 // The counter to go from 3d to 1d vector
-                // auto idx = i + j * count[1] + k * count[2] * count[1];
-                // auto idx = (i - i0) + (j - j0) * count[1] + (k - k0) *
-                // count[2] * count[1];
-                // auto idx = i * count[0] * count[1] +  j * count[1]  + k;
                 auto idx = (i - i0) * count[2] * count[1] +
                            (j - j0) * count[2] + (k - k0);
-                // auto idx = (i-i0) +  (j-j0) * count[0]  + (k-k0) * count[0] *
-                // count[1];
+                // Pass values from temporary array to the velocity field
                 velocity(i, j, k, 0) = uvel2.data()[idx];
                 velocity(i, j, k, 1) = vvel2.data()[idx];
             });
         // Close the netcdf file
         ncf.close();
     }
-// Make sure to call fill patch *******
 #endif
 }
 

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -186,8 +186,14 @@ void ABLFieldInit::operator()(
         amrex::ParallelFor(
             vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 // The counter to go from 3d to 1d vector
-                auto idx = i + j * count[1] + k * count[2] * count[1];
+                // auto idx = i + j * count[1] + k * count[2] * count[1];
+                // auto idx = (i - i0) + (j - j0) * count[1] + (k - k0) *
+                // count[2] * count[1];
                 // auto idx = i * count[0] * count[1] +  j * count[1]  + k;
+                auto idx = (i - i0) * count[2] * count[1] +
+                           (j - j0) * count[2] + (k - k0);
+                // auto idx = (i-i0) +  (j-j0) * count[0]  + (k-k0) * count[0] *
+                // count[1];
                 velocity(i, j, k, 0) = uvel2.data()[idx];
                 velocity(i, j, k, 1) = vvel2.data()[idx];
             });

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -36,6 +36,12 @@ ABLFieldInit::ABLFieldInit()
 
     // Use input from netcdf file
     pp_abl.query("initial_condition_input_file", m_ic_input);
+#ifndef AMR_WIND_USE_NETCDF
+    // Ensure that if netcdf is not used, the initial condition
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_ic_input.empty(),
+        "NETCDF is needed for initial_condition_input_file");
+#endif
 
     // TODO: Modify this to accept velocity as a function of height
     amrex::ParmParse pp_incflo("incflo");

--- a/docs/sphinx/user/inputs_ABL.rst
+++ b/docs/sphinx/user/inputs_ABL.rst
@@ -157,8 +157,17 @@ This section is for setting atmospheric boundary layer parameters.
    
 .. input_param:: ABL.wall_shear_stress_type
 
-    **type:** String, optional, default = "Moeng"
+   **type:** String, optional, default = "Moeng"
 
    Wall shear stress model: options include 
    "constant", "local", "Schumann", and "Moeng"
 
+.. input_param:: ABL.initial_condition_input_file
+
+   **type:** String, optional, default= ""
+    
+   File that contains initial conditions for the
+   velocity field in netcdf file format.
+   This file is expected to have the same dimensions as the simulation.
+   Values are passed directly from the file to the velocity field inside the code.
+   Only spanwise velocity components are supported. 


### PR DESCRIPTION
This is a feature to read in a netcdf file with initial conditions for velocity generated outside of amr-wind.
The feature lives within the ABL section and it is designed for it.
The number of points in the netcdf file (nx, ny, nz) needs to be the same as in the simulation.

The current implementation works when using one processor, but it doesn't work correctly with more than one processor (reads in the wrong ordering). 
This is because the netcdf reading is still missing something (need help here).
Once this feature is fixed, the PR should become ready for review.

I am tagging the group that has been helping with this development.
@michaeljbrazell @gantech @mbkuhn @rybchuk 