### PR TITLE
Allowing initial CFL to be 0 for adaptive dt

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -95,7 +95,7 @@ void SimTime::set_current_cfl(
     const amrex::Real cd_cfl = conv_cfl + diff_cfl;
     const amrex::Real cfl_unit_time =
         cd_cfl + std::sqrt(cd_cfl * cd_cfl + 4.0 * src_cfl);
-    if ((m_adaptive) &&
+    if ((m_adaptive && !m_is_init) &&
         (cfl_unit_time < std::numeric_limits<amrex::Real>::epsilon())) {
         amrex::Abort(
             "CFL is below machine epsilon and the time step is adaptive. "


### PR DESCRIPTION
- the check for 0 CFL still applies for subsequent timesteps
- important for multiphase sims sloshing_tank and dam_break
- these start with 0 CFL and otherwise can't use adaptive dt