### PR TITLE
Post-ReGrid actions for FreeSurface tool

### DIFF
--- a/amr-wind/utilities/sampling/FreeSurface.H
+++ b/amr-wind/utilities/sampling/FreeSurface.H
@@ -44,7 +44,8 @@ public:
     //! Interpolate fields at a given timestep and output to disk
     void post_advance_work() override;
 
-    void post_regrid_actions() override {}
+    //! Redo some of the initialization work when the grid changes
+    void post_regrid_actions() override;
 
     //! Output functions for private variables
     //! Number of points

--- a/amr-wind/utilities/sampling/FreeSurface.cpp
+++ b/amr-wind/utilities/sampling/FreeSurface.cpp
@@ -534,6 +534,144 @@ void FreeSurface::post_advance_work()
     process_output();
 }
 
+void FreeSurface::post_regrid_actions()
+{
+    BL_PROFILE("amr-wind::FreeSurface::post_regrid_actions");
+    // Get working fields
+    auto& fidx = m_sim.repo().get_field("sample_idx_" + m_label);
+    auto& floc = m_sim.repo().get_field("sample_loc_" + m_label);
+    // Provide variables from class to device
+    const int ncomp = m_ncomp;
+    const int ntps0 = m_npts_dir[0];
+    const int ntps1 = m_npts_dir[1];
+    const int gc0 = m_gc0;
+    const int gc1 = m_gc1;
+    const amrex::Real s_gc0 = m_start[m_gc0];
+    const amrex::Real s_gc1 = m_start[m_gc1];
+    const amrex::Real dxs0 =
+        (m_end[m_gc0] - m_start[m_gc0]) / amrex::max(m_npts_dir[0] - 1, 1);
+    const amrex::Real dxs1 =
+        (m_end[m_gc1] - m_start[m_gc1]) / amrex::max(m_npts_dir[1] - 1, 1);
+
+    // Store locations and indices in fields
+    const int finest_level = m_vof.repo().num_active_levels() - 1;
+    for (int lev = 0; lev <= finest_level; lev++) {
+        // Use level_mask to only count finest level present
+        amrex::iMultiFab level_mask;
+        if (lev < finest_level) {
+            level_mask = makeFineMask(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                m_sim.mesh().boxArray(lev + 1), amrex::IntVect(2), 1, 0);
+        } else {
+            level_mask.define(
+                m_sim.mesh().boxArray(lev), m_sim.mesh().DistributionMap(lev),
+                1, 0, amrex::MFInfo());
+            level_mask.setVal(1);
+        }
+        // Get geometry information
+        const auto& geom = m_sim.mesh().Geom(lev);
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx =
+            geom.CellSizeArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> plo =
+            geom.ProbLoArray();
+        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> phi =
+            geom.ProbHiArray();
+        for (amrex::MFIter mfi(floc(lev)); mfi.isValid(); ++mfi) {
+            auto loc_arr = floc(lev).array(mfi);
+            auto idx_arr = fidx(lev).array(mfi);
+            auto mask_arr = level_mask.const_array(mfi);
+            const auto& vbx = mfi.validbox();
+            amrex::ParallelFor(
+                vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // Cell location
+                    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> xm;
+                    xm[0] = plo[0] + (i + 0.5) * dx[0];
+                    xm[1] = plo[1] + (j + 0.5) * dx[1];
+                    xm[2] = plo[2] + (k + 0.5) * dx[2];
+                    int n0_f = 0;
+                    int n0_a = 0;
+                    int n1_f = 0;
+                    int n1_a = 0;
+                    // Get first and after sample indices for gc0
+                    if (ntps0 == 1) {
+                        n0_a = ((phi[gc0] == s_gc0) ||
+                                (xm[gc0] - s_gc0 <= 0.5 * dx[gc0] &&
+                                 s_gc0 - xm[gc0] < 0.5 * dx[gc0]))
+                                   ? 1
+                                   : 0;
+                    } else {
+                        n0_f = (int)amrex::Math::ceil(
+                            (xm[gc0] - 0.5 * dx[gc0] - s_gc0) / dxs0);
+                        n0_a = (int)amrex::Math::ceil(
+                            (xm[gc0] + 0.5 * dx[gc0] - s_gc0) / dxs0);
+                        // Edge case of phi
+                        if (xm[gc0] + 0.5 * dx[gc0] == phi[gc0] &&
+                            s_gc0 + n0_a * dxs0 == phi[gc0]) {
+                            ++n0_a;
+                        }
+                        // Bounds
+                        n0_a = amrex::min(ntps0, n0_a);
+                        n0_f = amrex::max(amrex::min(0, n0_a), n0_f);
+                        // Out of bounds indicates no sample point
+                        if (n0_f >= ntps0 || n0_f < 0) {
+                            n0_a = n0_f;
+                        }
+                    }
+                    // Get first and after sample indices for gc1
+                    if (ntps1 == 1) {
+                        n1_a = ((phi[gc1] == s_gc1) ||
+                                (xm[gc1] - s_gc1 <= 0.5 * dx[gc1] &&
+                                 s_gc1 - xm[gc1] < 0.5 * dx[gc1]))
+                                   ? 1
+                                   : 0;
+                    } else {
+                        n1_f = (int)amrex::Math::ceil(
+                            (xm[gc1] - 0.5 * dx[gc1] - s_gc1) / dxs1);
+                        n1_a = (int)amrex::Math::ceil(
+                            (xm[gc1] + 0.5 * dx[gc1] - s_gc1) / dxs1);
+                        // Edge case of phi
+                        if (xm[gc1] + 0.5 * dx[gc1] == phi[gc1] &&
+                            s_gc1 + n1_a * dxs1 == phi[gc1]) {
+                            ++n1_a;
+                        }
+                        // Bounds
+                        n1_a = amrex::min(ntps1, n1_a);
+                        n1_f = amrex::max(amrex::min(0, n1_a), n1_f);
+                        // Out of bounds indicates no sample point
+                        if (n1_f >= ntps1 || n1_f < 0) {
+                            n1_a = n1_f;
+                        }
+                    }
+                    // Loop through local sample locations
+                    int ns = 0;
+                    for (int n0 = n0_f; n0 < n0_a; ++n0) {
+                        for (int n1 = n1_f; n1 < n1_a; ++n1) {
+                            // Save index and location
+                            idx_arr(i, j, k, ns) = (amrex::Real)n1 * ntps0 + n0;
+                            loc_arr(i, j, k, 2 * ns) = s_gc0 + n0 * dxs0;
+                            loc_arr(i, j, k, 2 * ns + 1) = s_gc1 + n1 * dxs1;
+                            // Advance to next point
+                            ++ns;
+                            // if ns gets to max components, break
+                            if (ns == ncomp) {
+                                break;
+                            }
+                        }
+                        if (ns == ncomp) {
+                            break;
+                        }
+                    }
+                    // Set remaining values to -1 to indicate no point
+                    // or set all values to -1 if not in fine mesh
+                    int nstart = (mask_arr(i, j, k) == 0) ? 0 : ns;
+                    for (int n = nstart; n < ncomp; ++n) {
+                        idx_arr(i, j, k, n) = -1.0;
+                    }
+                });
+        }
+    }
+}
+
 void FreeSurface::process_output()
 {
     if (m_out_fmt == "ascii") {

--- a/unit_tests/utilities/test_free_surface.cpp
+++ b/unit_tests/utilities/test_free_surface.cpp
@@ -360,9 +360,8 @@ protected:
         pp.add("labels", (std::string) "t1");
         amrex::ParmParse ppt1("tagging.t1");
         ppt1.add("type", (std::string) "FieldRefinement");
-        ppt1.add("field_name", (std::string) "flag");
-        ppt1.addarr(
-            "field_error", amrex::Vector<amrex::Real>{0.5, 0.5, 0.5, 0.5});
+        ppt1.add("field_name", fname);
+        ppt1.addarr("field_error", amrex::Vector<amrex::Real>{fref_val});
     }
     // Parameters to reuse
     const amrex::Real water_level0 = 64.0;
@@ -376,6 +375,8 @@ protected:
     const amrex::Vector<amrex::Real> plnarrow_s{{63.0, 63.0, 0.0}};
     const amrex::Vector<amrex::Real> plnarrow_e{{65.0, 65.0, 0.0}};
     const int npts = 3;
+    const amrex::Real fref_val = 0.5;
+    const std::string fname = "flag";
     int m_nlev = 0;
 };
 
@@ -533,10 +534,10 @@ TEST_F(FreeSurfaceTest, regrid)
     // Repo and fields
     auto& repo = rmesh.field_repo();
     auto& vof = repo.declare_field("vof", 1, 2);
-    auto& flag = repo.declare_field("flag", 1, 2);
+    auto& flag = repo.declare_field(fname, 1, 2);
 
     // Set up scalar for determining refinement - all fine level
-    flag.setVal(1.0);
+    flag.setVal(2.0 * fref_val);
 
     // Initialize mesh refiner and remesh
     rmesh.init_refiner();


### PR DESCRIPTION
- some of initialization needs to be performed again when mesh changes
- appeared to mainly occur when mesh coarsens, sample pt index gets lost
- (very involved) unit test to certify this improvement