### PR TITLE
Bug fix central difference and change var names

### DIFF
--- a/amr-wind/wind_energy/actuator/FLLC.H
+++ b/amr-wind/wind_energy/actuator/FLLC.H
@@ -10,7 +10,7 @@ struct FLLCData
     // constants
     amrex::Real epsilon;
     amrex::Real relaxation_factor{0.1};
-    RealList dx;
+    RealList dr;
     RealList optimal_epsilon;
 
     // computed values

--- a/amr-wind/wind_energy/actuator/FLLC.cpp
+++ b/amr-wind/wind_energy/actuator/FLLC.cpp
@@ -17,7 +17,7 @@ void FLLCInit(
             data.span_distance_vel[i] = vs::mag(view.vel_pos[i]);
         }
     }
-    data.dx.resize(npts);
+    data.dr.resize(npts);
     data.optimal_epsilon.resize(npts);
     data.les_velocity.assign(npts, vs::Vector::zero());
     data.optimal_velocity.assign(npts, vs::Vector::zero());
@@ -26,12 +26,18 @@ void FLLCInit(
     data.grad_lift.assign(npts, vs::Vector::zero());
     data.force_point_velocity.assign(npts, vs::Vector::zero());
 
-    for (int i = 0; i < npts - 1; ++i) {
-        data.dx[i] = vs::mag(view.pos[i + 1] - view.pos[i]);
+    for (int i = 0; i < npts; ++i) {
+
         data.optimal_epsilon[i] = view.chord[i] * eps_chord;
     }
-    data.dx[npts - 1] = vs::mag(view.pos[npts - 1] - view.pos[npts - 2]);
-    data.optimal_epsilon[npts - 1] = view.chord[npts - 1] * eps_chord;
+
+    // Central difference
+    for (int i = 1; i < npts - 1; ++i) {
+        data.dr[i] = vs::mag(view.pos[i + 1] - view.pos[i - 1]) / 2.;
+    }
+    data.dr[0] = vs::mag(view.pos[1] - view.pos[0]) / 2.;
+    data.dr[npts - 1] = vs::mag(view.pos[npts - 1] - view.pos[npts - 2]) / 2.;
+
     data.initialized = true;
 }
 

--- a/amr-wind/wind_energy/actuator/FLLCOp.H
+++ b/amr-wind/wind_energy/actuator/FLLCOp.H
@@ -53,14 +53,14 @@ struct FLLCOp
             const auto& tmat = data.orientation[ip];
             const auto force = data.force[ip];
             const auto vel = data.vel_rel[ip] & tmat;
-            const auto dx = fllc.dx[ip];
+            const auto dr = fllc.dr[ip];
             const auto vmag =
                 std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
             const auto vmag2 = vmag * vmag;
 
             const auto fv = force & vel;
 
-            G[ip] = (force - vel * fv / vmag2) / dx;
+            G[ip] = (force - vel * fv / vmag2) / dr;
         }
 
         /**
@@ -90,17 +90,17 @@ struct FLLCOp
                     continue;
                 }
 
-                const auto dr = vs::mag(data.vel_pos[ip] - data.vel_pos[jp]);
+                const auto r_dis = vs::mag(data.vel_pos[ip] - data.vel_pos[jp]);
                 const auto& vel = data.vel_rel[jp];
                 const auto vmag =
                     std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
 
                 auto coefficient =
-                    1.0 / (-4.0 * amr_wind::utils::pi() * dr * vmag);
+                    1.0 / (-4.0 * amr_wind::utils::pi() * r_dis * vmag);
                 const auto cLes =
-                    1.0 - std::exp(-dr * dr / (eps_les * eps_les));
+                    1.0 - std::exp(-r_dis * r_dis / (eps_les * eps_les));
                 const auto cOpt =
-                    1.0 - std::exp(-dr * dr / (eps_opt * eps_opt));
+                    1.0 - std::exp(-r_dis * r_dis / (eps_opt * eps_opt));
 
                 // The sign of the induced velocity depends on which side of the
                 // blade we are on


### PR DESCRIPTION
Co-developed with @psakievich 

This fixes a small bug when computing the central different of spacing `dr`.
`dx` was changed to `dr` (differential along the blade) for clarity and consistency.
The variable `dr` that was used before to indicate spacing between points was changed to `r_dis`.

