### PR TITLE
Include AMReX_MLMG.H for an upcoming change in AMReX

### DIFF
--- a/amr-wind/core/MLMGOptions.H
+++ b/amr-wind/core/MLMGOptions.H
@@ -6,10 +6,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_MLLinOp.H"
-
-namespace amrex {
-class MLMG;
-} // namespace amrex
+#include "AMReX_MLMG.H"
 
 namespace Hydro {
 class NodalProjector;

--- a/amr-wind/core/MLMGOptions.cpp
+++ b/amr-wind/core/MLMGOptions.cpp
@@ -1,6 +1,5 @@
 #include "amr-wind/core/MLMGOptions.H"
 
-#include "AMReX_MLMG.H"
 #include "hydro_MacProjector.H"
 #include "hydro_NodalProjector.H"
 


### PR DESCRIPTION
In the future, amrex::MLMG will become an alias template.  So the forward declaration of class MLMG will cause a conflict.