### PR TITLE
compute l2 error over both fringe and field points

### DIFF
--- a/amr-wind/physics/ConvectingTaylorVortex.cpp
+++ b/amr-wind/physics/ConvectingTaylorVortex.cpp
@@ -248,7 +248,7 @@ amrex::Real ConvectingTaylorVortex::compute_error(const Field& field)
                 const auto& imask_arr = level_mask.array(mfi);
                 amrex::ParallelFor(
                     vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        if (std::abs(iblank_arr(i, j, k)) < 1) {
+                        if (amrex::Math::abs(iblank_arr(i, j, k)) < 1) {
                             imask_arr(i, j, k) = 0;
                         }
                     });

--- a/amr-wind/physics/ConvectingTaylorVortex.cpp
+++ b/amr-wind/physics/ConvectingTaylorVortex.cpp
@@ -248,7 +248,7 @@ amrex::Real ConvectingTaylorVortex::compute_error(const Field& field)
                 const auto& imask_arr = level_mask.array(mfi);
                 amrex::ParallelFor(
                     vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        if (iblank_arr(i, j, k) < 1) {
+                        if (std::abs(iblank_arr(i, j, k)) < 1) {
                             imask_arr(i, j, k) = 0;
                         }
                     });

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
@@ -242,7 +242,7 @@ amrex::Real ZalesakDiskScalarVel::compute_error(const Field& field)
                 const auto& imask_arr = level_mask.array(mfi);
                 amrex::ParallelFor(
                     vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        if (iblank_arr(i, j, k) < 1) {
+                        if (std::abs(iblank_arr(i, j, k)) < 1) {
                             imask_arr(i, j, k) = 0;
                         }
                     });

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
@@ -242,7 +242,7 @@ amrex::Real ZalesakDiskScalarVel::compute_error(const Field& field)
                 const auto& imask_arr = level_mask.array(mfi);
                 amrex::ParallelFor(
                     vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        if (std::abs(iblank_arr(i, j, k)) < 1) {
+                        if (amrex::Math::abs(iblank_arr(i, j, k)) < 1) {
                             imask_arr(i, j, k) = 0;
                         }
                     });


### PR DESCRIPTION
Currently l2 error is compute over only field points. This is inconsistent with nalu-wind which computes l2 errors over both field and fringe points. Additionally, the l2 error slope over field points may not always be representative of the l2 error slope over fringe points. 