### PR TITLE
Update and apply relaxation zones post-init

### DIFF
--- a/amr-wind/ocean_waves/OceanWaves.cpp
+++ b/amr-wind/ocean_waves/OceanWaves.cpp
@@ -59,7 +59,7 @@ void OceanWaves::initialize_fields(int level, const amrex::Geometry& geom)
 void OceanWaves::post_init_actions()
 {
     BL_PROFILE("amr-wind::ocean_waves::OceanWaves::post_init_actions");
-    m_owm->update_relax_zones();
+    relaxation_zones();
 }
 
 void OceanWaves::post_regrid_actions() {}


### PR DESCRIPTION
* initial velocity needs to be nonzero in order to use adaptive timestep
* will cause harmless diffs for ow cases