### PR TITLE
Perturbational pressure addressed: source terms and more

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
@@ -27,6 +27,12 @@ public:
 
 private:
     amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+
+    Field* m_rho{nullptr};
+    Field* m_rho0{nullptr};
+
+    // Presence of rho0 for perturbational form
+    bool is_rho0{false};
 };
 
 } // namespace amr_wind::pde::icns

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
@@ -31,8 +31,12 @@ private:
     Field* m_rho{nullptr};
     Field* m_rho0{nullptr};
 
+    // Input reference to perturbational form
+    bool is_pptb{false};
     // Presence of rho0 for perturbational form
     bool is_rho0{false};
+    // Constant reference density
+    amrex::Real m_rho0_const{1.0};
 };
 
 } // namespace amr_wind::pde::icns

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
@@ -25,9 +25,9 @@ GravityForcing::GravityForcing(const CFDSim& sim)
     amrex::ParmParse pp_icns("ICNS");
     pp_icns.query("use_perturb_pressure", is_pptb);
     // Determine if rho0 field exists
-    is_rho0 = sim.repo().field_exists("rho0");
+    is_rho0 = sim.repo().field_exists("reference_density");
     if (is_rho0) {
-        m_rho0 = &(sim.repo().get_field("rho0"));
+        m_rho0 = &(sim.repo().get_field("reference_density"));
     } else {
         // Point to existing field, won't be used
         m_rho0 = m_rho;

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
@@ -12,10 +12,22 @@ namespace amr_wind::pde::icns {
  *
  *  - `gravity` acceleration due to gravity (m/s)
  */
-GravityForcing::GravityForcing(const CFDSim& /*unused*/)
+GravityForcing::GravityForcing(const CFDSim& sim)
 {
     amrex::ParmParse pp("incflo");
     pp.queryarr("gravity", m_gravity);
+
+    // Get density fields
+    m_rho = &(sim.repo().get_field("density"));
+
+    // Determine if rho0 field exists
+    is_rho0 = sim.repo().field_exists("rho0");
+    if (is_rho0) {
+        m_rho0 = &(sim.repo().get_field("rho0"));
+    } else {
+        // Point to existing field, won't be used
+        m_rho0 = m_rho;
+    }
 }
 
 GravityForcing::~GravityForcing() = default;
@@ -29,19 +41,27 @@ GravityForcing::~GravityForcing() = default;
  *  @param vel_forces Forcing source term
  */
 void GravityForcing::operator()(
-    const int /*lev*/,
-    const amrex::MFIter& /*mfi*/,
+    const int lev,
+    const amrex::MFIter& mfi,
     const amrex::Box& bx,
-    const FieldState /*fstate*/,
+    const FieldState fstate,
     const amrex::Array4<amrex::Real>& vel_forces) const
 {
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
         {m_gravity[0], m_gravity[1], m_gravity[2]}};
 
+    const auto& rho_arr =
+        ((*m_rho).state(field_impl::phi_state(fstate)))(lev).const_array(mfi);
+    const auto& rho0_arr = (*m_rho0)(lev).const_array(mfi);
+    bool ir0 = is_rho0;
+
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        const amrex::Real factor =
+            (ir0 ? 1.0 - rho0_arr(i, j, k) / rho_arr(i, j, k) : 1.0);
+
         vel_forces(i, j, k, 0) += gravity[0];
         vel_forces(i, j, k, 1) += gravity[1];
-        vel_forces(i, j, k, 2) += gravity[2];
+        vel_forces(i, j, k, 2) += gravity[2] * factor;
     });
 }
 

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
@@ -66,8 +66,8 @@ void GravityForcing::operator()(
             (!ipt ? 1.0
                   : 1.0 - (ir0 ? rho0_arr(i, j, k) : mr0c) / rho_arr(i, j, k));
 
-        vel_forces(i, j, k, 0) += gravity[0];
-        vel_forces(i, j, k, 1) += gravity[1];
+        vel_forces(i, j, k, 0) += gravity[0] * factor;
+        vel_forces(i, j, k, 1) += gravity[1] * factor;
         vel_forces(i, j, k, 2) += gravity[2] * factor;
     });
 }

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -40,6 +40,9 @@ void read_inputs(
     if (wdata.has_ramp) {
         pp.query("timeramp_period", wdata.ramp_period);
     }
+
+    amrex::ParmParse pp_multiphase("MultiPhase");
+    pp_multiphase.add("water_level", wdata.zsl);
 }
 
 void init_data_structures(RelaxZonesBaseData& /*unused*/) {}

--- a/amr-wind/physics/RayleighTaylor.H
+++ b/amr-wind/physics/RayleighTaylor.H
@@ -29,7 +29,7 @@ public:
 
     void post_init_actions() override {}
 
-    void post_regrid_actions() override {}
+    void post_regrid_actions() override;
 
     void pre_advance_work() override {}
 
@@ -38,6 +38,11 @@ public:
 private:
     Field& m_velocity;
     Field& m_density;
+
+    // Density for perturbational form
+    Field& m_rho0;
+    // Default reference density
+    amrex::Real m_rho0_const{1.0};
 
     //! RayleighTaylor field initializer instance
     std::unique_ptr<RayleighTaylorFieldInit> m_field_init;

--- a/amr-wind/physics/RayleighTaylor.H
+++ b/amr-wind/physics/RayleighTaylor.H
@@ -29,7 +29,7 @@ public:
 
     void post_init_actions() override {}
 
-    void post_regrid_actions() override;
+    void post_regrid_actions() override {}
 
     void pre_advance_work() override {}
 
@@ -38,11 +38,6 @@ public:
 private:
     Field& m_velocity;
     Field& m_density;
-
-    // Density for perturbational form
-    Field& m_rho0;
-    // Default reference density
-    amrex::Real m_rho0_const{1.0};
 
     //! RayleighTaylor field initializer instance
     std::unique_ptr<RayleighTaylorFieldInit> m_field_init;

--- a/amr-wind/physics/RayleighTaylor.cpp
+++ b/amr-wind/physics/RayleighTaylor.cpp
@@ -3,20 +3,14 @@
 #include "amr-wind/physics/RayleighTaylor.H"
 #include "amr-wind/physics/RayleighTaylorFieldInit.H"
 #include "amr-wind/CFDSim.H"
-#include "AMReX_ParmParse.H"
 
 namespace amr_wind {
 
 RayleighTaylor::RayleighTaylor(const CFDSim& sim)
     : m_velocity(sim.repo().get_field("velocity"))
     , m_density(sim.repo().get_field("density"))
-    , m_rho0(sim.repo().declare_field("rho0", 1, 0, 1))
     , m_field_init(std::make_unique<RayleighTaylorFieldInit>())
-{
-    // Check for non-default reference density
-    amrex::ParmParse pp("incflo");
-    pp.query("density", m_rho0_const);
-}
+{}
 
 /** Initialize the velocity and density fields at the beginning of the
  *  simulation.
@@ -27,12 +21,8 @@ void RayleighTaylor::initialize_fields(int level, const amrex::Geometry& geom)
 {
     auto& velocity = m_velocity(level);
     auto& density = m_density(level);
-    auto& rho0 = m_rho0(level);
 
     velocity.setVal(0.0);
-
-    // Initialize reference density field
-    rho0.setVal(m_rho0_const);
 
     for (amrex::MFIter mfi(density); mfi.isValid(); ++mfi) {
         const auto& vbx = mfi.validbox();
@@ -40,7 +30,5 @@ void RayleighTaylor::initialize_fields(int level, const amrex::Geometry& geom)
         (*m_field_init)(vbx, geom, density.array(mfi));
     }
 }
-
-void RayleighTaylor::post_regrid_actions() { m_rho0.setVal(m_rho0_const); }
 
 } // namespace amr_wind

--- a/amr-wind/physics/RayleighTaylor.cpp
+++ b/amr-wind/physics/RayleighTaylor.cpp
@@ -3,14 +3,20 @@
 #include "amr-wind/physics/RayleighTaylor.H"
 #include "amr-wind/physics/RayleighTaylorFieldInit.H"
 #include "amr-wind/CFDSim.H"
+#include "AMReX_ParmParse.H"
 
 namespace amr_wind {
 
 RayleighTaylor::RayleighTaylor(const CFDSim& sim)
     : m_velocity(sim.repo().get_field("velocity"))
     , m_density(sim.repo().get_field("density"))
+    , m_rho0(sim.repo().declare_field("rho0", 1, 0, 1))
     , m_field_init(std::make_unique<RayleighTaylorFieldInit>())
-{}
+{
+    // Check for non-default reference density
+    amrex::ParmParse pp("incflo");
+    pp.query("density", m_rho0_const);
+}
 
 /** Initialize the velocity and density fields at the beginning of the
  *  simulation.
@@ -21,8 +27,12 @@ void RayleighTaylor::initialize_fields(int level, const amrex::Geometry& geom)
 {
     auto& velocity = m_velocity(level);
     auto& density = m_density(level);
+    auto& rho0 = m_rho0(level);
 
     velocity.setVal(0.0);
+
+    // Initialize reference density field
+    rho0.setVal(m_rho0_const);
 
     for (amrex::MFIter mfi(density); mfi.isValid(); ++mfi) {
         const auto& vbx = mfi.validbox();
@@ -30,5 +40,7 @@ void RayleighTaylor::initialize_fields(int level, const amrex::Geometry& geom)
         (*m_field_init)(vbx, geom, density.array(mfi));
     }
 }
+
+void RayleighTaylor::post_regrid_actions() { m_rho0.setVal(m_rho0_const); }
 
 } // namespace amr_wind

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -34,7 +34,7 @@ public:
 
     void post_init_actions() override;
 
-    void post_regrid_actions() override {}
+    void post_regrid_actions() override;
 
     void pre_advance_work() override;
 
@@ -79,6 +79,10 @@ private:
 
     // Density value for Fluid 2
     amrex::Real m_rho2{1.0};
+
+    // Info to create rho0
+    amrex::Real water_level0{0.0};
+    bool make_rho0{false};
 
     bool m_interface_smoothing{false};
 

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -80,9 +80,16 @@ private:
     // Density value for Fluid 2
     amrex::Real m_rho2{1.0};
 
+    // Bools according to ICNS settings
+    // Turning on perturbational density and pressure
+    bool is_pptb{false};
+    // Reconstructing true pressure field at end of timestep
+    bool is_ptrue{false};
+
     // Info to create rho0
     amrex::Real water_level0{0.0};
-    bool make_rho0{false};
+    // Info to reconstruct true pressure
+    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
 
     bool m_interface_smoothing{false};
 

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -106,9 +106,20 @@ void MultiPhase::post_init_actions()
 
     // Check if water level is specified (from case definition)
     amrex::ParmParse pp_multiphase("MultiPhase");
-    if (pp_multiphase.contains("water_level")) {
-        amrex::Real water_level0{0.0};
+    make_rho0 = pp_multiphase.contains("water_level");
+    if (make_rho0) {
         pp_multiphase.get("water_level", water_level0);
+        // Initialize rho_0 function for perturbational density, pressure
+        auto& rho0 = m_sim.repo().declare_field("rho0", 1, 0, 1);
+        initialize_rho0(
+            rho0, m_rho1, m_rho2, water_level0, m_sim.mesh().Geom());
+    }
+}
+
+void MultiPhase::post_regrid_actions()
+{
+    // Re-initialize rho0 if present
+    if (make_rho0) {
         // Initialize rho_0 function for perturbational density, pressure
         auto& rho0 = m_sim.repo().declare_field("rho0", 1, 0, 1);
         initialize_rho0(

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -62,7 +62,7 @@ void define_p0(
                         0.0, amrex::min(hliq - hnode, hliq - problo[2]));
                     // Integrated rho at pressure node
                     const amrex::Real irho = rho1 * ih_l + rho2 * ih_g;
-                    
+
                     // Add term to reference pressure
                     p0_arr(i, j, k) = -irho * grav_z;
                 });

--- a/amr-wind/physics/multiphase/hydrostatic_ops.H
+++ b/amr-wind/physics/multiphase/hydrostatic_ops.H
@@ -1,0 +1,70 @@
+#ifndef HYDROSTATIC_OPS_H
+#define HYDROSTATIC_OPS_H
+#include <AMReX_MultiFabUtil.H>
+#include "amr-wind/core/FieldRepo.H"
+
+namespace amr_wind::hydrostatic {
+
+static void define_rho0(
+    amr_wind::Field& rho0,
+    const amrex::Real rho1,
+    const amrex::Real rho2,
+    const amrex::Real wlev,
+    const amrex::Vector<amrex::Geometry> geom)
+{
+    for (int lev = 0; lev < rho0.repo().num_active_levels(); ++lev) {
+        const auto& dx = geom[lev].CellSizeArray();
+        const auto& problo = geom[lev].ProbLoArray();
+        for (amrex::MFIter mfi(rho0(lev)); mfi.isValid(); ++mfi) {
+            amrex::Box const& bx = mfi.validbox();
+            auto rho0_arr = rho0(lev).array(mfi);
+            amrex::ParallelFor(
+                bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    const amrex::Real zbtm = problo[2] + k * dx[2];
+                    const amrex::Real vof =
+                        amrex::max(amrex::min(1.0, (wlev - zbtm) / dx[2]), 0.0);
+                    rho0_arr(i, j, k) = vof * rho1 + (1.0 - vof) * rho2;
+                });
+        }
+    }
+}
+
+static void define_p0(
+    amr_wind::Field& p0,
+    const amrex::Real rho1,
+    const amrex::Real rho2,
+    const amrex::Real wlev,
+    const amrex::Real grav_z,
+    const amrex::Vector<amrex::Geometry> geom)
+{
+    for (int lev = 0; lev < p0.repo().num_active_levels(); ++lev) {
+        const auto& dx = geom[lev].CellSizeArray();
+        const auto& problo = geom[lev].ProbLoArray();
+        const auto& probhi = geom[lev].ProbHiArray();
+        for (amrex::MFIter mfi(p0(lev)); mfi.isValid(); ++mfi) {
+            amrex::Box const& nbx = mfi.grownnodaltilebox();
+            auto p0_arr = p0(lev).array(mfi);
+            amrex::ParallelFor(
+                nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // Height of pressure node
+                    const amrex::Real hnode = k * dx[2];
+                    // Liquid height
+                    const amrex::Real hliq = wlev - problo[2];
+                    // Integrated (top-down in z) phase heights to pressure node
+                    amrex::Real ih_g = amrex::max(
+                        0.0, amrex::min(probhi[2] - hliq, probhi[2] - hnode));
+                    amrex::Real ih_l = amrex::max(
+                        0.0, amrex::min(hliq - hnode, hliq - problo[2]));
+                    // Integrated rho at pressure node
+                    const amrex::Real irho = rho1 * ih_l + rho2 * ih_g;
+
+                    // Add term to reference pressure
+                    p0_arr(i, j, k) = -irho * grav_z;
+                });
+        }
+    }
+}
+
+} // namespace amr_wind::hydrostatic
+
+#endif

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -412,6 +412,15 @@ void incflo::ApplyProjection(
         }
     }
 
+    // Determine if reference pressure should be added back
+    if (m_repo.field_exists("p0") && time != 0.0) {
+        auto& p0 = m_repo.get_field("p0");
+        for (int lev = 0; lev <= finest_level; lev++) {
+            amrex::MultiFab::Add(
+                pressure(lev), p0(lev), 0, 0, 1, pressure.num_grow()[0]);
+        }
+    }
+
     for (int lev = finest_level - 1; lev >= 0; --lev) {
         amrex::average_down(
             grad_p(lev + 1), grad_p(lev), 0, AMREX_SPACEDIM, refRatio(lev));

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -413,8 +413,8 @@ void incflo::ApplyProjection(
     }
 
     // Determine if reference pressure should be added back
-    if (m_repo.field_exists("p0") && time != 0.0) {
-        auto& p0 = m_repo.get_field("p0");
+    if (m_repo.field_exists("reference_pressure") && time != 0.0) {
+        auto& p0 = m_repo.get_field("reference_pressure");
         for (int lev = 0; lev <= finest_level; lev++) {
             amrex::MultiFab::Add(
                 pressure(lev), p0(lev), 0, 0, 1, pressure.num_grow()[0]);

--- a/amr-wind/setup/init.cpp
+++ b/amr-wind/setup/init.cpp
@@ -127,9 +127,9 @@ void incflo::InitialIterations()
     }
 
     // Add mean pressure back if available
-    if (m_repo.field_exists("p0")) {
+    if (m_repo.field_exists("reference_pressure")) {
         auto& pressure = m_repo.get_field("p");
-        auto& p0 = m_repo.get_field("p0");
+        auto& p0 = m_repo.get_field("reference_pressure");
         for (int lev = 0; lev <= finest_level; lev++) {
             amrex::MultiFab::Add(
                 pressure(lev), p0(lev), 0, 0, 1, pressure.num_grow()[0]);

--- a/amr-wind/setup/init.cpp
+++ b/amr-wind/setup/init.cpp
@@ -125,6 +125,16 @@ void incflo::InitialIterations()
             }
         }
     }
+
+    // Add mean pressure back if available
+    if (m_repo.field_exists("p0")) {
+        auto& pressure = m_repo.get_field("p");
+        auto& p0 = m_repo.get_field("p0");
+        for (int lev = 0; lev <= finest_level; lev++) {
+            amrex::MultiFab::Add(
+                pressure(lev), p0(lev), 0, 0, 1, pressure.num_grow()[0]);
+        }
+    }
     amrex::Print() << "Completed initial pressure iterations" << std::endl
                    << std::endl;
 }

--- a/docs/sphinx/theory/theory.rst
+++ b/docs/sphinx/theory/theory.rst
@@ -160,6 +160,32 @@ Re-initialization of the level-set
 
 where :math:`\phi^0=\phi(x,0)` represents the location of the interface. 
 
+Source terms
+------------------------------------
+
+Gravity Forcing
+~~~~~~~~~~~~~~~~
+
+The implementation of this source term allows the user to choose the full gravity term (:math:`\rho g`) or a perturbational form (:math:`(\rho - \rho_0) g`). By default, the full term is used, but the perturbational form can be turned on by adding ``ICNS.use_perturb_pressure = true`` to the input file.
+
+The reference density (:math:`\rho_0`) is defined as ``1.0`` by default, can be defined as a constant through the input argument, ``incflo::density``, or can be defined as a spatially varying field within the flow setup (see physics/multiphase/Multiphase.cpp).
+
+Using the perturbational form implies that the hydrostatic pressure is removed from the pressure variable, including its output. This means that the solution to the Poisson equation is actually the perturbational pressure, :math:`p'`, not :math:`p`. If the full pressure, :math:`p`, is desired for analysis or postprocessing purposes, the hydrostatic pressure can be added back to the pressure field via the input argument ``ICNS.reconstruct_true_pressure = true``. In order for this to operate in the code, the reference pressure field must be defined for the specific flow case being run. 
+
+- An example of this is in physics/multiphase/Multiphase.cpp. To construct the reference pressure field, the reference gravity term must be integrated. This particular example assumes that the reference density only varies in z (or is constant), gravity acts only in z, and the hydrostatic pressure at zhi is equal to 0. 
+
+- In mathematical form, the derivation and calculation of the full pressure is as follows:
+
+.. math:: \nabla p = \nabla p + \rho_0 \boldsymbol{g}
+
+- assume :math:`\boldsymbol{g} = g\hat{k}` and :math:`\frac{dp_0}{dz} = g\hat{k}`
+
+.. math:: p = p' + \int_{z_{min}}^z \rho_0 g dz + p(z = z_{min}) 
+
+- reframe in reference to the top boundary, and assume :math:`p(z = z_{max}) = 0`
+   
+.. math:: p = p' - \int_z^{z_{max}} \rho_0 g dz + p(z = z_{max}) = p' - \int_z^{z_{max}} \rho_0 g dz
+
 Navigating source code
 ------------------------
 

--- a/docs/sphinx/theory/theory.rst
+++ b/docs/sphinx/theory/theory.rst
@@ -176,7 +176,7 @@ Using the perturbational form implies that the hydrostatic pressure is removed f
 
 - In mathematical form, the derivation and calculation of the full pressure is as follows:
 
-.. math:: \nabla p = \nabla p + \rho_0 \boldsymbol{g}
+.. math:: \nabla p = \nabla p' + \rho_0 \boldsymbol{g}
 
 - assume :math:`\boldsymbol{g} = g\hat{k}` and :math:`\frac{dp_0}{dz} = g\hat{k}`
 

--- a/test/test_files/ow_linear/ow_linear.inp
+++ b/test/test_files/ow_linear/ow_linear.inp
@@ -42,7 +42,9 @@ MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
 MultiPhase.interface_smoothing=0
 MultiPhase.interface_smoothing_frequency=1
-ICNS.source_terms = GravityForcing 
+ICNS.source_terms = GravityForcing
+ICNS.use_perturb_pressure = true
+ICNS.reconstruct_true_pressure = true
 MultiPhase.verbose=1
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
@@ -56,13 +58,13 @@ geometry.prob_lo        =     0.0   0.  -1   # Lo corner coordinates
 geometry.prob_hi        =     30.   1.   1  # Hi corner coordinates
 geometry.is_periodic    =     0     1     0   # Periodicity x y z (0/1)
 
-xlo.type =     "wave_generation"
-xhi.type =     "slip_wall"
+xlo.type =     "pressure_inflow"
+xhi.type =     "pressure_outflow"
 xlo.vof_type = "zero_gradient"
 xhi.vof_type = "zero_gradient"
 
 zlo.type =     "slip_wall"
-zhi.type =     "slip_wall"
+zhi.type =     "pressure_outflow"
 zlo.vof_type = "zero_gradient"
 zhi.vof_type = "zero_gradient"
 

--- a/test/test_files/ow_stokes/ow_stokes.inp
+++ b/test/test_files/ow_stokes/ow_stokes.inp
@@ -43,7 +43,8 @@ MultiPhase.density_fluid1=1000.
 MultiPhase.density_fluid2=1.
 MultiPhase.interface_smoothing=0
 MultiPhase.interface_smoothing_frequency=1
-ICNS.source_terms = GravityForcing 
+ICNS.source_terms = GravityForcing
+ICNS.use_perturb_pressure = true
 MultiPhase.verbose=1
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
@@ -57,13 +58,13 @@ geometry.prob_lo        =     0.0   0.  -1   # Lo corner coordinates
 geometry.prob_hi        =     30.   1.   1  # Hi corner coordinates
 geometry.is_periodic    =     0     1     0   # Periodicity x y z (0/1)
 
-xlo.type =     "wave_generation"
-xhi.type =     "slip_wall"
+xlo.type =     "pressure_inflow"
+xhi.type =     "pressure_outflow"
 xlo.vof_type = "zero_gradient"
 xhi.vof_type = "zero_gradient"
 
 zlo.type =     "slip_wall"
-zhi.type =     "slip_wall"
+zhi.type =     "pressure_outflow"
 zlo.vof_type = "zero_gradient"
 zhi.vof_type = "zero_gradient"
 

--- a/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.inp
+++ b/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.inp
@@ -29,7 +29,7 @@ zlo.type                = "sw"
 zhi.type                = "sw"
 
 incflo.physics = RayleighTaylor
-ICNS.source_terms = DensityBuoyancy
+ICNS.source_terms = GravityForcing
 RayleighTaylor.rho_lo = 0.5
 RayleighTaylor.rho_hi = 2.0
 

--- a/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.inp
+++ b/test/test_files/rayleigh_taylor_godunov/rayleigh_taylor_godunov.inp
@@ -30,6 +30,7 @@ zhi.type                = "sw"
 
 incflo.physics = RayleighTaylor
 ICNS.source_terms = GravityForcing
+ICNS.use_perturb_pressure = true
 RayleighTaylor.rho_lo = 0.5
 RayleighTaylor.rho_hi = 2.0
 

--- a/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
+++ b/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
@@ -28,7 +28,7 @@ zlo.type                = "sw"
 zhi.type                = "sw"
 
 incflo.physics = RayleighTaylor
-ICNS.source_terms = DensityBuoyancy
+ICNS.source_terms = GravityForcing
 RayleighTaylor.rho_lo = 0.5
 RayleighTaylor.rho_hi = 2.0
 

--- a/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
+++ b/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
@@ -29,6 +29,7 @@ zhi.type                = "sw"
 
 incflo.physics = RayleighTaylor
 ICNS.source_terms = GravityForcing
+ICNS.use_perturb_pressure = true
 RayleighTaylor.rho_lo = 0.5
 RayleighTaylor.rho_hi = 2.0
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(turbulence)
 add_subdirectory(fvm)
 add_subdirectory(multiphase)
 add_subdirectory(ocean_waves)
+add_subdirectory(projection)
 
 if(AMR_WIND_ENABLE_MASA)
   add_subdirectory(mms)

--- a/unit_tests/equation_systems/CMakeLists.txt
+++ b/unit_tests/equation_systems/CMakeLists.txt
@@ -1,6 +1,6 @@
 target_sources(${amr_wind_unit_test_exe_name}
   PRIVATE
-
   test_pde.cpp
   test_icns_cstdens.cpp
+  test_icns_gravityforcing.cpp
   )

--- a/unit_tests/equation_systems/test_icns_gravityforcing.cpp
+++ b/unit_tests/equation_systems/test_icns_gravityforcing.cpp
@@ -1,0 +1,217 @@
+#include "aw_test_utils/AmrexTest.H"
+#include "amr-wind/incflo.H"
+
+namespace amr_wind_tests {
+
+namespace {
+
+void init_density(amr_wind::Field& density, const int k_thresh = -3)
+{
+    const int nlevels = density.repo().num_active_levels();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+
+        for (amrex::MFIter mfi(density(lev)); mfi.isValid(); ++mfi) {
+            auto gbx = mfi.growntilebox();
+            const auto& darr = density(lev).array(mfi);
+
+            amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                darr(i, j, k) = (k > k_thresh) ? k + 4 : 0.0;
+            });
+        }
+    }
+}
+
+amrex::Real get_Fgz_sum(amr_wind::Field& src_term)
+{
+    amrex::Real Fgz_sum = 0.0;
+
+    for (int lev = 0; lev < src_term.repo().num_active_levels(); ++lev) {
+        Fgz_sum += amrex::ReduceSum(
+            src_term(lev), 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& bx,
+                amrex::Array4<amrex::Real const> const& Fg_arr) -> amrex::Real {
+                amrex::Real Fgz_sum_fab = 0.0;
+
+                amrex::Loop(
+                    bx, [=, &Fgz_sum_fab](int i, int j, int k) noexcept {
+                        Fgz_sum_fab += Fg_arr(i, j, k, 2);
+                    });
+
+                return Fgz_sum_fab;
+            });
+    }
+    amrex::ParallelDescriptor::ReduceRealSum(Fgz_sum);
+    return Fgz_sum;
+}
+
+void Fgtest_kernel(
+    const amrex::Real Fz_ref,
+    const int ncells,
+    const int nz,
+    const amr_wind::FieldState fstate,
+    const bool make_ref_dens = false)
+{
+    incflo my_incflo;
+    my_incflo.init_mesh();
+    if (make_ref_dens) {
+        // Create reference density field (only used if turned on via parser)
+        auto& ref_dens =
+            my_incflo.sim().repo().declare_field("reference_density", 1, 3, 1);
+        init_density(ref_dens, nz / 2);
+    }
+    my_incflo.init_amr_wind_modules();
+    auto& density = my_incflo.sim().repo().get_field("density").state(
+        amr_wind::FieldState::NPH);
+    auto& velocity = my_incflo.sim().repo().get_field("velocity");
+    auto& grad_p = my_incflo.sim().repo().get_field("gp");
+    auto& Fg_field = my_incflo.icns().fields().src_term;
+    // Set density field
+    init_density(density);
+    // Set old density to unity, avoid NaN
+    density.state(amr_wind::FieldState::Old).setVal(1.0);
+    // Set zero velocity
+    velocity.setVal(0.0);
+    // Set zero pressure gradient
+    grad_p.setVal(0.0);
+
+    // Calculate forcing terms
+    my_incflo.icns().compute_source_term(fstate);
+
+    // Check forcing average value
+    const amrex::Real Fz_avg = get_Fgz_sum(Fg_field) / ncells;
+    EXPECT_NEAR(Fz_ref, Fz_avg, 1e-8);
+}
+
+} // namespace
+
+class GravityForcingTest : public AmrexTest
+{
+protected:
+    void populate_parameters()
+    {
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{m_nx, m_ny, m_nz}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", m_nx);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{1.0, 1.0, 1.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+
+            amrex::Vector<int> periodic{{1, 1, 1}};
+            pp.addarr("is_periodic", periodic);
+        }
+        {
+            amrex::ParmParse pp("incflo");
+            pp.add("use_godunov", (int)1);
+        }
+        {
+            amrex::ParmParse pp("ICNS");
+            amrex::Vector<std::string> srcstr{"GravityForcing"};
+            pp.addarr("source_terms", srcstr);
+        }
+    }
+
+    const amrex::Real m_rho_0 = 2.0;
+    const amrex::Real m_Fg = -9.81;
+    const int m_nx = 2;
+    const int m_ny = 2;
+    const int m_nz = 16;
+};
+
+TEST_F(GravityForcingTest, full_term_u)
+{
+    // High-level setup
+    populate_parameters();
+    {
+        amrex::ParmParse pp("ICNS");
+        pp.add("use_perturb_pressure", (bool)false);
+    }
+    // Modify gravity to make sure it works
+    {
+        amrex::ParmParse pp("incflo");
+        amrex::Vector<amrex::Real> grav{0.0, 0.0, -5.0};
+        pp.addarr("gravity", grav);
+    }
+    // Expected average gravity term
+    amrex::Real Fg = -5.0;
+    // Test with ordinary gravity term (rho not included)
+    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
+}
+
+TEST_F(GravityForcingTest, full_term_rhou)
+{
+    // High-level setup
+    populate_parameters();
+    {
+        amrex::ParmParse pp("ICNS");
+        pp.add("use_perturb_pressure", (bool)false);
+    }
+    // Modify gravity to make sure it works
+    {
+        amrex::ParmParse pp("incflo");
+        amrex::Vector<amrex::Real> grav{0.0, 0.0, -5.0};
+        pp.addarr("gravity", grav);
+    }
+    // Expected average gravity term
+    amrex::Real Fg = -5.0;
+    amrex::Real fac = 0.0;
+    for (int k = 0; k < m_nz; ++k) {
+        fac += k + 4;
+    }
+    Fg *= fac / m_nz;
+    // Test with ordinary gravity term (rho included)
+    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::New);
+}
+
+TEST_F(GravityForcingTest, perturb_const)
+{
+    const amrex::Real rho_ref = 0.5;
+    const amrex::Real gz = -9.81;
+    // High-level setup
+    populate_parameters();
+    {
+        amrex::ParmParse pp("ICNS");
+        pp.add("use_perturb_pressure", (bool)true);
+    }
+    // Modify gravity to make sure it works
+    {
+        amrex::ParmParse pp("incflo");
+        pp.add("density", rho_ref);
+    }
+    // Expected average gravity term
+    amrex::Real Fg = (1.0 - rho_ref) * gz / 1.0;
+    // Test with ordinary gravity term (rho not multiplied)
+    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
+}
+
+TEST_F(GravityForcingTest, perturb_field)
+{
+    const amrex::Real gz = -9.81;
+    // High-level setup
+    populate_parameters();
+    {
+        amrex::ParmParse pp("ICNS");
+        pp.add("use_perturb_pressure", (bool)true);
+    }
+    // Expected average gravity term
+    amrex::Real Fg = gz;
+    amrex::Real fac = 0.0;
+    for (int k = 0; k < m_nz; ++k) {
+        fac += (k > m_nz / 2) ? 0.0 : k + 4;
+    }
+    Fg *= fac / m_nz;
+    // Test with ordinary gravity term (rho included)
+    Fgtest_kernel(
+        Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::New, true);
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/multiphase/CMakeLists.txt
+++ b/unit_tests/multiphase/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(
   test_momflux.cpp
   test_vof_BCs.cpp
   test_mflux_schemes.cpp
+  test_reference_fields.cpp
   )

--- a/unit_tests/multiphase/test_reference_fields.cpp
+++ b/unit_tests/multiphase/test_reference_fields.cpp
@@ -1,0 +1,162 @@
+#include "aw_test_utils/MeshTest.H"
+#include "amr-wind/physics/multiphase/hydrostatic_ops.H"
+
+namespace amr_wind_tests {
+namespace {
+
+amrex::Real density_test_impl(
+    amr_wind::Field& rho0,
+    const amrex::Vector<amrex::Geometry> geom,
+    const amrex::Real rho1,
+    const amrex::Real rho2,
+    const amrex::Real wlev)
+{
+    amrex::Real error_total = 0;
+
+    for (int lev = 0; lev < rho0.repo().num_active_levels(); ++lev) {
+
+        const auto& dx = geom[lev].CellSizeArray();
+        const auto& problo = geom[lev].ProbLoArray();
+
+        error_total += amrex::ReduceSum(
+            rho0(lev), 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& bx,
+                amrex::Array4<amrex::Real const> const& rho0_arr)
+                -> amrex::Real {
+                amrex::Real error = 0;
+
+                amrex::Loop(bx, [=, &error](int i, int j, int k) noexcept {
+                    const amrex::Real zbtm = problo[2] + k * dx[2];
+                    amrex::Real vof = (wlev - zbtm) / dx[2];
+                    vof = amrex::max(vof, 0.0);
+                    vof = amrex::min(vof, 1.0);
+                    amrex::Real dens = vof * rho1 + (1.0 - vof) * rho2;
+                    error += std::abs(rho0_arr(i, j, k) - dens);
+                });
+
+                return error;
+            });
+    }
+    return error_total;
+}
+
+amrex::Real pressure_test_impl(
+    amr_wind::Field& p0,
+    const amrex::Vector<amrex::Geometry> geom,
+    const amrex::Real rho1,
+    const amrex::Real rho2,
+    const amrex::Real wlev,
+    const amrex::Real gz,
+    const int ngrow)
+{
+    amrex::Real error_total = 0;
+
+    for (int lev = 0; lev < p0.repo().num_active_levels(); ++lev) {
+
+        const auto& dx = geom[lev].CellSizeArray();
+        const auto& problo = geom[lev].ProbLoArray();
+        const auto& probhi = geom[lev].ProbHiArray();
+
+        const amrex::Real ht_max = probhi[2] - problo[2];
+        const amrex::Real ht_min = 0.0;
+
+        error_total += amrex::ReduceSum(
+            p0(lev), ngrow,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& nbx,
+                amrex::Array4<amrex::Real const> const& p0_arr) -> amrex::Real {
+                amrex::Real error = 0;
+
+                amrex::Loop(nbx, [=, &error](int i, int j, int k) noexcept {
+                    const amrex::Real znode = problo[2] + k * dx[2];
+                    amrex::Real ht_g = probhi[2] - wlev;
+                    amrex::Real ht_l = wlev - problo[2];
+                    // Limit by location
+                    ht_g = amrex::min(ht_g, probhi[2] - znode);
+                    ht_l = amrex::min(ht_l, wlev - znode);
+                    // Limit by bounds
+                    ht_g = amrex::min(amrex::max(ht_g, ht_min), ht_max);
+                    ht_l = amrex::min(amrex::max(ht_l, ht_min), ht_max);
+                    // Integrated (-rho*g*z)
+                    const amrex::Real irhogz =
+                        -gz * (rho1 * ht_l + rho2 * ht_g);
+                    error += std::abs(p0_arr(i, j, k) - irhogz);
+                });
+
+                return error;
+            });
+    }
+    return error_total;
+}
+
+} // namespace
+
+class MultiPhaseHydroStatic : public MeshTest
+{
+protected:
+    void populate_parameters() override
+    {
+        MeshTest::populate_parameters();
+
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{m_nx, m_nx, m_nx}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", m_nx);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{1.0, 1.0, 1.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+        }
+    }
+
+    const amrex::Real m_rho1 = 1000.0;
+    const amrex::Real m_rho2 = 1.0;
+    const amrex::Real m_wlev = 0.5;
+    const amrex::Real m_gz = -9.81;
+    const int m_nx = 3;
+};
+
+TEST_F(MultiPhaseHydroStatic, reference_density)
+{
+    populate_parameters();
+    initialize_mesh();
+    auto& repo = sim().repo();
+    const int ncomp = 1;
+    const int nghost = 0;
+    auto& rho0 = repo.declare_field("reference_density", ncomp, nghost);
+
+    amr_wind::hydrostatic::define_rho0(
+        rho0, m_rho1, m_rho2, m_wlev, sim().mesh().Geom());
+
+    amrex::Real error_total =
+        density_test_impl(rho0, sim().mesh().Geom(), m_rho1, m_rho2, m_wlev);
+    amrex::ParallelDescriptor::ReduceRealSum(error_total);
+    EXPECT_EQ(error_total, 0.0);
+}
+
+TEST_F(MultiPhaseHydroStatic, reference_pressure)
+{
+    populate_parameters();
+    initialize_mesh();
+    auto& repo = sim().repo();
+    const int ncomp = 1;
+    const int nghost = 3;
+    auto& p0 = repo.declare_nd_field("reference_pressure", ncomp, nghost);
+
+    amr_wind::hydrostatic::define_p0(
+        p0, m_rho1, m_rho2, m_wlev, m_gz, sim().mesh().Geom());
+
+    amrex::Real error_total = pressure_test_impl(
+        p0, sim().mesh().Geom(), m_rho1, m_rho2, m_wlev, m_gz, nghost);
+    amrex::ParallelDescriptor::ReduceRealSum(error_total);
+    EXPECT_EQ(error_total, 0.0);
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/multiphase/test_reference_fields.cpp
+++ b/unit_tests/multiphase/test_reference_fields.cpp
@@ -138,7 +138,7 @@ TEST_F(MultiPhaseHydroStatic, reference_density)
     amrex::Real error_total =
         density_test_impl(rho0, sim().mesh().Geom(), m_rho1, m_rho2, m_wlev);
     amrex::ParallelDescriptor::ReduceRealSum(error_total);
-    EXPECT_EQ(error_total, 0.0);
+    EXPECT_NEAR(error_total, 0.0, 1e-8);
 }
 
 TEST_F(MultiPhaseHydroStatic, reference_pressure)
@@ -156,7 +156,7 @@ TEST_F(MultiPhaseHydroStatic, reference_pressure)
     amrex::Real error_total = pressure_test_impl(
         p0, sim().mesh().Geom(), m_rho1, m_rho2, m_wlev, m_gz, nghost);
     amrex::ParallelDescriptor::ReduceRealSum(error_total);
-    EXPECT_EQ(error_total, 0.0);
+    EXPECT_NEAR(error_total, 0.0, 1e-8);
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/projection/CMakeLists.txt
+++ b/unit_tests/projection/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(
+  ${amr_wind_unit_test_exe_name} PRIVATE
+  test_pressure_offset.cpp
+  )

--- a/unit_tests/projection/test_pressure_offset.cpp
+++ b/unit_tests/projection/test_pressure_offset.cpp
@@ -107,7 +107,7 @@ void ptest_kernel(
     auto& p = my_incflo.sim().repo().get_field("p");
     // Check result
     const amrex::Real pbottom = get_pbottom(p) / nbottom;
-    EXPECT_NEAR(p_0, pbottom, 1e-11);
+    EXPECT_NEAR(p_0, pbottom, 1e-8);
 }
 
 } // namespace

--- a/unit_tests/projection/test_pressure_offset.cpp
+++ b/unit_tests/projection/test_pressure_offset.cpp
@@ -62,9 +62,10 @@ amrex::Real get_pbottom(amr_wind::Field& pressure)
                 amrex::Array4<amrex::Real const> const& p_arr) -> amrex::Real {
                 amrex::Real pb_sum_fab = 0.0;
 
-                amrex::Loop(nbx, [=, &pb_sum_fab](int i, int j, int k) noexcept {
-                    pb_sum_fab += (k == 0) ? p_arr(i, j, k) : 0.0;
-                });
+                amrex::Loop(
+                    nbx, [=, &pb_sum_fab](int i, int j, int k) noexcept {
+                        pb_sum_fab += (k == 0) ? p_arr(i, j, k) : 0.0;
+                    });
 
                 return pb_sum_fab;
             });

--- a/unit_tests/projection/test_pressure_offset.cpp
+++ b/unit_tests/projection/test_pressure_offset.cpp
@@ -1,0 +1,186 @@
+#include "aw_test_utils/AmrexTest.H"
+#include "amr-wind/incflo.H"
+
+namespace amr_wind_tests {
+
+namespace {
+
+void init_vel_z(amr_wind::Field& vel, const amrex::Real w_const)
+{
+    const int nlevels = vel.repo().num_active_levels();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+
+        for (amrex::MFIter mfi(vel(lev)); mfi.isValid(); ++mfi) {
+            auto gbx = mfi.growntilebox();
+            const auto& varr = vel(lev).array(mfi);
+
+            amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                varr(i, j, k, 2) = w_const;
+            });
+        }
+    }
+}
+
+void init_ref_p(
+    amr_wind::Field& ref_p,
+    const amrex::Vector<amrex::Geometry> geom,
+    const amrex::Real F_g,
+    const amrex::Real rho_0)
+{
+    const int nlevels = ref_p.repo().num_active_levels();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        const auto& dx = geom[lev].CellSizeArray();
+        const auto& probhi = geom[lev].ProbHiArray();
+        for (amrex::MFIter mfi(ref_p(lev)); mfi.isValid(); ++mfi) {
+            auto nbx = mfi.nodaltilebox();
+            const auto& p0_arr = ref_p(lev).array(mfi);
+
+            amrex::ParallelFor(nbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                // Height of pressure node
+                const amrex::Real hnode = k * dx[2];
+                // Integrated density from top
+                const amrex::Real irho = rho_0 * (probhi[2] - hnode);
+
+                // Multiply with force to get hydrostatic pressure
+                p0_arr(i, j, k) = -irho * F_g;
+            });
+        }
+    }
+}
+
+amrex::Real get_pbottom(amr_wind::Field& pressure)
+{
+    amrex::Real pb_sum = 0.0;
+
+    for (int lev = 0; lev < pressure.repo().num_active_levels(); ++lev) {
+        pb_sum += amrex::ReduceSum(
+            pressure(lev), 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& bx,
+                amrex::Array4<amrex::Real const> const& p_arr) -> amrex::Real {
+                amrex::Real pb_sum_fab = 0.0;
+
+                amrex::Loop(bx, [=, &pb_sum_fab](int i, int j, int k) noexcept {
+                    pb_sum_fab += (k == 0) ? p_arr(i, j, k) : 0.0;
+                });
+
+                return pb_sum_fab;
+            });
+    }
+    amrex::ParallelDescriptor::ReduceRealSum(pb_sum);
+    return pb_sum;
+}
+
+void ptest_kernel(
+    const amrex::Real rho_0,
+    const amrex::Real w_0,
+    const amrex::Real p_0,
+    const int nbottom,
+    const amrex::Real Fg = 0.0)
+{
+    incflo my_incflo;
+    my_incflo.init_mesh();
+    auto& density = my_incflo.sim().repo().get_field("density");
+    auto& velocity = my_incflo.sim().repo().get_field("velocity");
+    // Set uniform density
+    density.setVal(rho_0);
+    // Set velocity as it would be with gravity forcing
+    init_vel_z(velocity, w_0);
+
+    // If requested, form reference_pressure field
+    if (Fg != 0.0) {
+        // Pressure has 3 ghost points
+        auto& p_ref_field = my_incflo.sim().repo().declare_nd_field(
+            "reference_pressure", 1, 3, 1);
+        init_ref_p(p_ref_field, my_incflo.sim().mesh().Geom(), Fg, rho_0);
+    }
+
+    // Time is set to non-zero: not testing initialization
+    // Delta t is set to non-zero for result to work
+    const amrex::Real time = 1.0;
+    const amrex::Real dt = 1.0;
+    // Apply projection
+    my_incflo.ApplyProjection((density).vec_const_ptrs(), time, dt, false);
+    // Get result
+    auto& p = my_incflo.sim().repo().get_field("p");
+    // Check result
+    const amrex::Real pbottom = get_pbottom(p) / nbottom;
+    EXPECT_NEAR(p_0, pbottom, 1e-11);
+}
+
+} // namespace
+
+class ProjPerturb : public AmrexTest
+{
+protected:
+    void populate_parameters()
+    {
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{m_nx, m_ny, m_nz}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", m_nx);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{1.0, 1.0, 1.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+        }
+        {
+            amrex::ParmParse pp("incflo");
+            pp.add("use_godunov", (int)1);
+        }
+
+        // Boundary conditions
+        amrex::ParmParse ppxlo("xlo");
+        ppxlo.add("type", (std::string) "slip_wall");
+        amrex::ParmParse ppylo("ylo");
+        ppylo.add("type", (std::string) "slip_wall");
+        amrex::ParmParse ppzlo("zlo");
+        ppzlo.add("type", (std::string) "slip_wall");
+        amrex::ParmParse ppxhi("xhi");
+        ppxhi.add("type", (std::string) "slip_wall");
+        amrex::ParmParse ppyhi("yhi");
+        ppyhi.add("type", (std::string) "slip_wall");
+        amrex::ParmParse ppzhi("zhi");
+        ppzhi.add("type", (std::string) "pressure_inflow");
+    }
+
+    const amrex::Real m_rho_0 = 1.0;
+    const amrex::Real m_Fg = -9.81;
+    const int m_nx = 2;
+    const int m_ny = 2;
+    const int m_nz = 16;
+};
+
+TEST_F(ProjPerturb, dynamic_only)
+{
+    // High-level setup
+    populate_parameters();
+    // Test with gravity term omitted
+    ptest_kernel(m_rho_0, 0.0, 0.0, m_nx * m_ny);
+}
+
+TEST_F(ProjPerturb, full_pressure)
+{
+    // High-level setup
+    populate_parameters();
+    // Test with gravity term included
+    ptest_kernel(m_rho_0, m_Fg, -m_Fg, (m_nx + 1) * (m_ny + 1));
+}
+
+TEST_F(ProjPerturb, full_p_perturb)
+{
+    // High-level setup
+    populate_parameters();
+    // Test with gravity term omitted, then added as reference pressure
+    ptest_kernel(m_rho_0, 0.0, -m_Fg, (m_nx + 1) * (m_ny + 1), m_Fg);
+}
+
+} // namespace amr_wind_tests

--- a/unit_tests/projection/test_pressure_offset.cpp
+++ b/unit_tests/projection/test_pressure_offset.cpp
@@ -58,11 +58,11 @@ amrex::Real get_pbottom(amr_wind::Field& pressure)
         pb_sum += amrex::ReduceSum(
             pressure(lev), 0,
             [=] AMREX_GPU_HOST_DEVICE(
-                amrex::Box const& bx,
+                amrex::Box const& nbx,
                 amrex::Array4<amrex::Real const> const& p_arr) -> amrex::Real {
                 amrex::Real pb_sum_fab = 0.0;
 
-                amrex::Loop(bx, [=, &pb_sum_fab](int i, int j, int k) noexcept {
+                amrex::Loop(nbx, [=, &pb_sum_fab](int i, int j, int k) noexcept {
                     pb_sum_fab += (k == 0) ? p_arr(i, j, k) : 0.0;
                 });
 
@@ -164,7 +164,7 @@ TEST_F(ProjPerturb, dynamic_only)
     // High-level setup
     populate_parameters();
     // Test with gravity term omitted
-    ptest_kernel(m_rho_0, 0.0, 0.0, m_nx * m_ny);
+    ptest_kernel(m_rho_0, 0.0, 0.0, (m_nx + 1) * (m_ny + 1));
 }
 
 TEST_F(ProjPerturb, full_pressure)


### PR DESCRIPTION
* Previously, GravityForcing and DensityBuoyancy both implemented the same terms, but the latter considered a perturbational form of density, implying a perturbational form of the pressure solution. 
* These perturb. forms enable better dirichlet BCs for the pressure equation without changing the way pressure is solved or implementing new BCs.
* A perturbational source term also implies a modification of the pressure solution from the Poisson solve
* This PR enables a perturbational form for these terms in a multiphase context, allows the true pressure to be reconstructed after being solved. This allows GravityForcing to have the same (and more) functionality as DensityBuoyancy, which can be removed in a future PR if desired.