### PR TITLE
Unified memory removed from TiogaInterface

### DIFF
--- a/amr-wind/core/CMakeLists.txt
+++ b/amr-wind/core/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${amr_wind_lib_name}
   IntField.cpp
   FieldRepo.cpp
   ScratchField.cpp
+  IntScratchField.cpp
   ViewField.cpp
   MLMGOptions.cpp
   MeshMap.cpp

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -276,13 +276,6 @@ public:
         const int nstates = 1,
         const FieldLoc floc = FieldLoc::CELL);
 
-    IntField& declare_int_field_on_host(
-        const std::string& name,
-        const int ncomp = 1,
-        const int ngrow = 0,
-        const int nstates = 1,
-        const FieldLoc floc = FieldLoc::CELL);
-
     //! Return a reference to an integer field
     IntField& get_int_field(
         const std::string& name,

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -9,6 +9,7 @@
 #include "amr-wind/core/Field.H"
 #include "amr-wind/core/IntField.H"
 #include "amr-wind/core/ScratchField.H"
+#include "amr-wind/core/IntScratchField.H"
 
 #include "AMReX_AmrCore.H"
 #include "AMReX_MultiFab.H"
@@ -343,6 +344,18 @@ public:
         const int nghost = 0,
         const FieldLoc floc = FieldLoc::CELL) const;
 
+
+    std::unique_ptr<IntScratchField> create_int_scratch_field_on_host(
+        const std::string& name,
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
+
+
+    std::unique_ptr<IntScratchField> create_int_scratch_field_on_host(
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
     //! Advance all fields with more than one timestate to the new timestep
     void advance_states() noexcept;
 

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -275,6 +275,13 @@ public:
         const int nstates = 1,
         const FieldLoc floc = FieldLoc::CELL);
 
+    IntField& declare_int_field_on_host(
+        const std::string& name,
+        const int ncomp = 1,
+        const int ngrow = 0,
+        const int nstates = 1,
+        const FieldLoc floc = FieldLoc::CELL);
+
     //! Return a reference to an integer field
     IntField& get_int_field(
         const std::string& name,

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -344,7 +344,6 @@ public:
         const int nghost = 0,
         const FieldLoc floc = FieldLoc::CELL) const;
 
-
     std::unique_ptr<IntScratchField> create_int_scratch_field_on_host(
         const std::string& name,
         const int ncomp = 1,
@@ -356,6 +355,7 @@ public:
         const int ncomp = 1,
         const int nghost = 0,
         const FieldLoc floc = FieldLoc::CELL) const;
+
     //! Advance all fields with more than one timestate to the new timestep
     void advance_states() noexcept;
 

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -324,7 +324,6 @@ public:
         const int nghost = 0,
         const FieldLoc floc = FieldLoc::CELL) const;
 
-	// IXT, added function definitions
     std::unique_ptr<ScratchField> create_scratch_field_on_host(
         const std::string& name,
         const int ncomp = 1,

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -324,6 +324,19 @@ public:
         const int nghost = 0,
         const FieldLoc floc = FieldLoc::CELL) const;
 
+	// IXT, added function definitions
+    std::unique_ptr<ScratchField> create_scratch_field_on_host(
+        const std::string& name,
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
+
+
+    std::unique_ptr<ScratchField> create_scratch_field_on_host(
+        const int ncomp = 1,
+        const int nghost = 0,
+        const FieldLoc floc = FieldLoc::CELL) const;
+
     //! Advance all fields with more than one timestate to the new timestep
     void advance_states() noexcept;
 

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -24,6 +24,7 @@ void FieldRepo::make_new_level_from_scratch(
         ba, dm, *m_leveldata[lev], *(m_leveldata[lev]->m_int_fact));
 
     m_is_initialized = true;
+    amrex::Print()<<"m_is_initialized in make_new_level_from_scratch "<<m_is_initialized<<std::endl;
 }
 
 void FieldRepo::make_new_level_from_coarse(
@@ -48,6 +49,7 @@ void FieldRepo::make_new_level_from_coarse(
 
     m_leveldata[lev] = std::move(ldata);
     m_is_initialized = true;
+    amrex::Print()<<"m_is_initialized in make_new_level_from_coarse "<<m_is_initialized<<std::endl;
 }
 
 void FieldRepo::remake_level(
@@ -72,6 +74,7 @@ void FieldRepo::remake_level(
 
     m_leveldata[lev] = std::move(ldata);
     m_is_initialized = true;
+    amrex::Print()<<"m_is_initialized in remake_level "<<m_is_initialized<<std::endl;
 }
 
 void FieldRepo::clear_level(int lev)
@@ -440,14 +443,13 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
 {
     return create_scratch_field_on_host("scratch_field_host", ncomp, nghost, floc);
 }
-
 std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
     const std::string& name,
     const int ncomp,
     const int nghost,
     const FieldLoc floc) const
 {
-    BL_PROFILE("amr-wind::FieldRepo::create_scratch_field_on_host");
+    BL_PROFILE("amr-wind::FieldRepo::create_int_scratch_field_on_host");
     if (!m_is_initialized) {
         amrex::Abort(
             "Scratch field creation is not permitted before mesh is "
@@ -468,13 +470,11 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
     }
     return field;
 }
-
 std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
     const int ncomp, const int nghost, const FieldLoc floc) const
 {
     return create_int_scratch_field_on_host("int_scratch_field_host", ncomp, nghost, floc);
 }
-
 void FieldRepo::advance_states() noexcept
 {
     for (auto& it : m_field_vec) {

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -466,7 +466,7 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
         field->m_data.emplace_back(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
 	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
-            *(m_leveldata[lev]->m_factory));
+            *(m_leveldata[lev]->m_int_fact));
     }
     return field;
 }

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -334,9 +334,13 @@ IntField& FieldRepo::declare_int_field_on_host(
 		    const auto ba = amrex::convert(
 			m_mesh.boxArray(lev), field_impl::index_type((*field).field_location()));
 
+		    //fab_vec.emplace_back(
+			//ba, m_mesh.DistributionMap(lev), (*field).num_comp(), (*field).num_grow(),
+			//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()), *level_data.m_int_fact);
+
 		    fab_vec.emplace_back(
 			ba, m_mesh.DistributionMap(lev), (*field).num_comp(), (*field).num_grow(),
-			amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()), *level_data.m_int_fact);
+			amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()), *level_data.m_int_fact);
 		}
 	    }
         }
@@ -433,7 +437,9 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
 
         field->m_data.emplace_back(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
-	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
+	//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
+        //    *(m_leveldata[lev]->m_factory));
+	amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
             *(m_leveldata[lev]->m_factory));
     }
     return field;
@@ -467,7 +473,9 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
 
         field->m_data.emplace_back(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
-	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
+	//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
+        //    *(m_leveldata[lev]->m_int_fact));
+	amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
             *(m_leveldata[lev]->m_int_fact));
     }
     return field;

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -387,7 +387,7 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
             "Scratch field creation is not permitted before mesh is "
             "initialized");
     }
-
+	amrex::Print()<<"ncomp in create_scratch_field"<<ncomp<<std::endl;
     std::unique_ptr<ScratchField> field(
         new ScratchField(*this, name, ncomp, nghost, floc));
 
@@ -423,6 +423,7 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
             "initialized");
     }
 
+	amrex::Print()<<"ncomp in create_scratch_field_on_host"<<ncomp<<std::endl;
     std::unique_ptr<ScratchField> field(
         new ScratchField(*this, name, ncomp, nghost, floc));
 
@@ -456,6 +457,7 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
             "initialized");
     }
 
+	amrex::Print()<<"ncomp in create_int_scratch_field"<<ncomp<<std::endl;
     std::unique_ptr<IntScratchField> field(
         new IntScratchField(*this, name, ncomp, nghost, floc));
 

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -458,7 +458,7 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
     BL_PROFILE("amr-wind::FieldRepo::create_int_scratch_field_on_host");
     if (!m_is_initialized) {
         amrex::Abort(
-            "Scratch field creation is not permitted before mesh is "
+            "Integer scratch field creation is not permitted before mesh is "
             "initialized");
     }
 

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -334,7 +334,6 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
 }
 
 
-// IXT function
 std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
     const std::string& name,
     const int ncomp,

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -334,13 +334,13 @@ IntField& FieldRepo::declare_int_field_on_host(
 		    const auto ba = amrex::convert(
 			m_mesh.boxArray(lev), field_impl::index_type((*field).field_location()));
 
-		    //fab_vec.emplace_back(
-			//ba, m_mesh.DistributionMap(lev), (*field).num_comp(), (*field).num_grow(),
-			//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()), *level_data.m_int_fact);
-
 		    fab_vec.emplace_back(
 			ba, m_mesh.DistributionMap(lev), (*field).num_comp(), (*field).num_grow(),
-			amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()), *level_data.m_int_fact);
+			amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()), *level_data.m_int_fact);
+
+		    //fab_vec.emplace_back(
+		//	ba, m_mesh.DistributionMap(lev), (*field).num_comp(), (*field).num_grow(),
+		//	amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()), *level_data.m_int_fact);
 		}
 	    }
         }
@@ -436,10 +436,10 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
 
         field->m_data.emplace_back(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
-	//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
-        //    *(m_leveldata[lev]->m_factory));
-	amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
+	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
             *(m_leveldata[lev]->m_factory));
+	//amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
+        //    *(m_leveldata[lev]->m_factory));
     }
     return field;
 }
@@ -471,10 +471,10 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
 
         field->m_data.emplace_back(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
-	//amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
-        //    *(m_leveldata[lev]->m_int_fact));
-	amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
+	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
             *(m_leveldata[lev]->m_int_fact));
+	//amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
+        //    *(m_leveldata[lev]->m_int_fact));
     }
     return field;
 }

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -326,6 +326,14 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
     return field;
 }
 
+
+std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
+    const int ncomp, const int nghost, const FieldLoc floc) const
+{
+    return create_scratch_field("scratch_field", ncomp, nghost, floc);
+}
+
+
 // IXT function
 std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
     const std::string& name,
@@ -354,10 +362,11 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
     }
     return field;
 }
-std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
+
+std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
     const int ncomp, const int nghost, const FieldLoc floc) const
 {
-    return create_scratch_field("scratch_field", ncomp, nghost, floc);
+    return create_scratch_field_on_host("scratch_field_host", ncomp, nghost, floc);
 }
 
 void FieldRepo::advance_states() noexcept

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -391,7 +391,6 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field(
             "Scratch field creation is not permitted before mesh is "
             "initialized");
     }
-	amrex::Print()<<"ncomp in create_scratch_field"<<ncomp<<std::endl;
     std::unique_ptr<ScratchField> field(
         new ScratchField(*this, name, ncomp, nghost, floc));
 
@@ -463,7 +462,6 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
             "initialized");
     }
 
-	amrex::Print()<<"ncomp in create_int_scratch_field"<<ncomp<<std::endl;
     std::unique_ptr<IntScratchField> field(
         new IntScratchField(*this, name, ncomp, nghost, floc));
 

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -257,7 +257,6 @@ IntField& FieldRepo::declare_int_field(
         const std::string fname =
             field_impl::field_name_with_state(name, fstate);
         const int fid = static_cast<int>(m_int_field_vec.size());
-        const int fid = m_int_field_vec.size();
 
         std::unique_ptr<IntField> field(
             new IntField(*this, fname, fid, ncomp, ngrow, floc));
@@ -359,8 +358,6 @@ std::unique_ptr<ScratchField> FieldRepo::create_scratch_field_on_host(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
 	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
             *(m_leveldata[lev]->m_factory));
-	//amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
-        //    *(m_leveldata[lev]->m_factory));
     }
     return field;
 }
@@ -394,8 +391,6 @@ std::unique_ptr<IntScratchField> FieldRepo::create_int_scratch_field_on_host(
             ba, m_mesh.DistributionMap(lev), ncomp, nghost, 
 	amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()),
             *(m_leveldata[lev]->m_int_fact));
-	//amrex::MFInfo().SetArena(amrex::The_Cpu_Arena()),
-        //    *(m_leveldata[lev]->m_int_fact));
     }
     return field;
 }

--- a/amr-wind/core/IntScratchField.H
+++ b/amr-wind/core/IntScratchField.H
@@ -65,10 +65,10 @@ public:
 
     void setVal(int value) noexcept;
 
-    void setVal(
-        int value, int start_comp, int num_comp = 1, int nghost = 0) noexcept;
+    //void setVal(
+    //    int value, int start_comp, int num_comp = 1, int nghost = 0) noexcept;
 
-    void setVal(const amrex::Vector<int>& values, int nghost = 0) noexcept;
+    //void setVal(const amrex::Vector<int>& values, int nghost = 0) noexcept;
 
     /** Return a sub-view of the ScratchField instance
      */

--- a/amr-wind/core/IntScratchField.H
+++ b/amr-wind/core/IntScratchField.H
@@ -14,17 +14,7 @@ namespace amr_wind {
 
 class FieldRepo;
 
-/** A temporary computational field
- *  \ingroup fields
- *
- *  An IntScratchField is similar to a Field in usage, but is temporary in nature.
- *  It is used as a scratch buffer to compute intermediate quantities. However,
- *  unlike fields these don't have multiple states, and cannot survive across a
- *  regrid. By default, FieldRepo returns a unique pointer to this instance and
- *  it is not safe to hold this pointer across timesteps.
- *
- *  At present, IntScratchField cannot be used for I/O and/or post-processing
- * utilities.
+/** Integer version of ScratchField that works with iMultiFab
  */
 class IntScratchField
 {
@@ -65,36 +55,6 @@ public:
 
     void setVal(int value) noexcept;
 
-    //void setVal(
-    //    int value, int start_comp, int num_comp = 1, int nghost = 0) noexcept;
-
-    //void setVal(const amrex::Vector<int>& values, int nghost = 0) noexcept;
-
-    /** Return a sub-view of the ScratchField instance
-     */
-    /*
-    ViewField<IntScratchField> subview(const int scomp = 0, const int ncomp = 1)
-    {
-        return {*this, scomp, ncomp};
-    }
-    */
-	/*
-    void fillpatch(amrex::Real time) noexcept;
-    void fillpatch(amrex::Real time, const amrex::IntVect& ng) noexcept;
-
-    void fillpatch(
-        int lev,
-        amrex::Real time,
-        amrex::iMultiFab& mfab,
-        const amrex::IntVect& nghost) noexcept;
-
-    void fillpatch(
-        int lev,
-        amrex::Real time,
-        amrex::iMultiFab& mfab,
-        const amrex::IntVect& nghost,
-        amrex::Vector<amrex::BCRec>& bcrec) noexcept;
-	*/
 
 protected:
     IntScratchField(

--- a/amr-wind/core/IntScratchField.H
+++ b/amr-wind/core/IntScratchField.H
@@ -63,6 +63,13 @@ public:
     //! Return a reference to the field repository that created this field
     const FieldRepo& repo() const { return m_repo; }
 
+    void setVal(int value) noexcept;
+
+    void setVal(
+        int value, int start_comp, int num_comp = 1, int nghost = 0) noexcept;
+
+    void setVal(const amrex::Vector<int>& values, int nghost = 0) noexcept;
+
     /** Return a sub-view of the ScratchField instance
      */
     /*
@@ -71,7 +78,7 @@ public:
         return {*this, scomp, ncomp};
     }
     */
-
+	/*
     void fillpatch(amrex::Real time) noexcept;
     void fillpatch(amrex::Real time, const amrex::IntVect& ng) noexcept;
 
@@ -87,6 +94,7 @@ public:
         amrex::iMultiFab& mfab,
         const amrex::IntVect& nghost,
         amrex::Vector<amrex::BCRec>& bcrec) noexcept;
+	*/
 
 protected:
     IntScratchField(
@@ -113,4 +121,4 @@ protected:
 
 } // namespace amr_wind
 
-#endif /* SCRATCHFIELD_H */
+#endif /* INTSCRATCHFIELD_H */

--- a/amr-wind/core/IntScratchField.H
+++ b/amr-wind/core/IntScratchField.H
@@ -1,0 +1,116 @@
+#ifndef INTSCRATCHFIELD_H
+#define INTSCRATCHFIELD_H
+
+#include <string>
+#include <utility>
+
+#include "amr-wind/core/FieldDescTypes.H"
+#include "amr-wind/core/ViewField.H"
+#include "AMReX_iMultiFab.H"
+#include "AMReX_Vector.H"
+#include "AMReX_PhysBCFunct.H"
+
+namespace amr_wind {
+
+class FieldRepo;
+
+/** A temporary computational field
+ *  \ingroup fields
+ *
+ *  An IntScratchField is similar to a Field in usage, but is temporary in nature.
+ *  It is used as a scratch buffer to compute intermediate quantities. However,
+ *  unlike fields these don't have multiple states, and cannot survive across a
+ *  regrid. By default, FieldRepo returns a unique pointer to this instance and
+ *  it is not safe to hold this pointer across timesteps.
+ *
+ *  At present, IntScratchField cannot be used for I/O and/or post-processing
+ * utilities.
+ */
+class IntScratchField
+{
+public:
+    friend class FieldRepo;
+
+    IntScratchField(const IntScratchField&) = delete;
+    IntScratchField& operator=(const IntScratchField&) = delete;
+
+    //! Name if available for this scratch field
+    inline const std::string& name() const { return m_name; }
+
+    //! Number of components for this field
+    inline int num_comp() const { return m_ncomp; }
+
+    //! Ghost cells
+    inline const amrex::IntVect& num_grow() const { return m_ngrow; }
+
+    //! Cell, node, face where the field is stored
+    inline FieldLoc field_location() const { return m_floc; }
+
+    //! Return the field data for a given level
+    amrex::iMultiFab& operator()(int lev) { return m_data[lev]; }
+    const amrex::iMultiFab& operator()(int lev) const { return m_data[lev]; }
+
+    amrex::Vector<amrex::iMultiFab*> vec_ptrs() noexcept
+    {
+        return amrex::GetVecOfPtrs(m_data);
+    }
+
+    amrex::Vector<const amrex::iMultiFab*> vec_const_ptrs() const noexcept
+    {
+        return amrex::GetVecOfConstPtrs(m_data);
+    }
+
+    //! Return a reference to the field repository that created this field
+    const FieldRepo& repo() const { return m_repo; }
+
+    /** Return a sub-view of the ScratchField instance
+     */
+    /*
+    ViewField<IntScratchField> subview(const int scomp = 0, const int ncomp = 1)
+    {
+        return {*this, scomp, ncomp};
+    }
+    */
+
+    void fillpatch(amrex::Real time) noexcept;
+    void fillpatch(amrex::Real time, const amrex::IntVect& ng) noexcept;
+
+    void fillpatch(
+        int lev,
+        amrex::Real time,
+        amrex::iMultiFab& mfab,
+        const amrex::IntVect& nghost) noexcept;
+
+    void fillpatch(
+        int lev,
+        amrex::Real time,
+        amrex::iMultiFab& mfab,
+        const amrex::IntVect& nghost,
+        amrex::Vector<amrex::BCRec>& bcrec) noexcept;
+
+protected:
+    IntScratchField(
+        const FieldRepo& repo,
+        std::string name,
+        const int ncomp = 1,
+        const int ngrow = 1,
+        const FieldLoc floc = FieldLoc::CELL)
+        : m_repo(repo)
+        , m_name(std::move(name))
+        , m_ncomp(ncomp)
+        , m_ngrow(ngrow)
+        , m_floc(floc)
+    {}
+
+    const FieldRepo& m_repo;
+    std::string m_name;
+    int m_ncomp;
+    amrex::IntVect m_ngrow;
+    FieldLoc m_floc;
+
+    amrex::Vector<amrex::iMultiFab> m_data;
+};
+
+} // namespace amr_wind
+
+#endif /* SCRATCHFIELD_H */

--- a/amr-wind/core/IntScratchField.cpp
+++ b/amr-wind/core/IntScratchField.cpp
@@ -28,6 +28,7 @@ struct ISFBCNoOp
     {}
 };
 
+/*
 amrex::Vector<amrex::BCRec>
 scratch_field_bcrec(const amrex::Geometry& geom, const int ncomp)
 {
@@ -45,8 +46,45 @@ scratch_field_bcrec(const amrex::Geometry& geom, const int ncomp)
 
     return bcrec;
 }
+*/
 
 } // namespace
+
+
+void IntScratchField::setVal(int value) noexcept
+{
+    BL_PROFILE("amr-wind::IntScratchField::setVal 1");
+    for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+        operator()(lev).setVal(value);
+    }
+}
+
+void IntScratchField::setVal(
+    int value, int start_comp, int num_comp, int nghost) noexcept
+{
+    BL_PROFILE("amr-wind::IntScratchField::setVal 2");
+    for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+        operator()(lev).setVal(value, start_comp, num_comp, nghost);
+    }
+}
+
+void IntField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
+{
+    BL_PROFILE("amr-wind::IntScratchField::setVal 3");
+    AMREX_ASSERT(num_comp() == static_cast<int>(values.size()));
+
+    // Update 1 component at a time
+    const int ncomp = 1;
+    for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
+        auto& mf = operator()(lev);
+        for (int ic = 0; ic < num_comp(); ++ic) {
+            int value = values[ic];
+            mf.setVal(value, ic, ncomp, nghost);
+        }
+    }
+}
+
+/*
 void IntScratchField::fillpatch(amrex::Real time) noexcept
 {
     fillpatch(time, num_grow());
@@ -71,7 +109,6 @@ void IntScratchField::fillpatch(
     auto bcrec = scratch_field_bcrec(mesh.Geom(lev), num_comp());
     fillpatch(lev, time, mfab, nghost, bcrec);
 }
-
 void IntScratchField::fillpatch(
     int lev,
     amrex::Real time,
@@ -103,5 +140,6 @@ void IntScratchField::fillpatch(
             mesh.refRatio(lev - 1), mapper, bcrec, 0);
     }
 }
+*/
 
 } // namespace amr_wind

--- a/amr-wind/core/IntScratchField.cpp
+++ b/amr-wind/core/IntScratchField.cpp
@@ -2,7 +2,7 @@
 #include "amr-wind/core/FieldRepo.H"
 
 #include "AMReX_Gpu.H"
-#include "AMReX_FArrayBox.H"
+#include "AMReX_IArrayBox.H"
 #include "AMReX_Geometry.H"
 #include "AMReX_PhysBCFunct.H"
 #include "AMReX_FillPatchUtil.H"
@@ -12,41 +12,7 @@ namespace amr_wind {
 
 
 namespace {
-struct ISFBCNoOp
-{
-    AMREX_GPU_DEVICE
-    void operator()(
-        const amrex::IntVect& /* iv */,
-        amrex::Array4<int> const& /* field */,
-        const int /* dcomp */,
-        const int /* numcomp */,
-        amrex::GeometryData const& /* geom */,
-        const amrex::Real /* time */,
-        const amrex::BCRec* /* bcr */,
-        const int /* bcomp */,
-        const int /* orig_comp */) const
-    {}
-};
 
-/*
-amrex::Vector<amrex::BCRec>
-scratch_field_bcrec(const amrex::Geometry& geom, const int ncomp)
-{
-    amrex::Vector<amrex::BCRec> bcrec(ncomp);
-
-    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-        auto bcrv = geom.isPeriodic(dir) ? amrex::BCType::int_dir
-                                         : amrex::BCType::hoextrap;
-
-        for (int n = 0; n < ncomp; ++n) {
-            bcrec[n].setLo(dir, bcrv);
-            bcrec[n].setHi(dir, bcrv);
-        }
-    }
-
-    return bcrec;
-}
-*/
 
 } // namespace
 
@@ -68,7 +34,7 @@ void IntScratchField::setVal(
     }
 }
 
-void IntField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
+void IntScratchField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
 {
     BL_PROFILE("amr-wind::IntScratchField::setVal 3");
     AMREX_ASSERT(num_comp() == static_cast<int>(values.size()));
@@ -84,62 +50,5 @@ void IntField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
     }
 }
 
-/*
-void IntScratchField::fillpatch(amrex::Real time) noexcept
-{
-    fillpatch(time, num_grow());
-}
-
-void IntScratchField::fillpatch(
-    amrex::Real time, const amrex::IntVect& ng) noexcept
-{
-    const int nlevels = repo().num_active_levels();
-    for (int lev = 0; lev < nlevels; ++lev) {
-        fillpatch(lev, time, this->operator()(lev), ng);
-    }
-}
-
-void IntScratchField::fillpatch(
-    int lev,
-    amrex::Real time,
-    amrex::iMultiFab& mfab,
-    const amrex::IntVect& nghost) noexcept
-{
-    const auto& mesh = repo().mesh();
-    auto bcrec = scratch_field_bcrec(mesh.Geom(lev), num_comp());
-    fillpatch(lev, time, mfab, nghost, bcrec);
-}
-void IntScratchField::fillpatch(
-    int lev,
-    amrex::Real time,
-    amrex::iMultiFab& mfab,
-    const amrex::IntVect& nghost,
-    amrex::Vector<amrex::BCRec>& bcrec) noexcept
-{
-    const auto& mesh = repo().mesh();
-    amrex::Interpolater* mapper = &amrex::cell_cons_interp;
-
-    if (lev == 0) {
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> physbc(
-            mesh.Geom(lev), bcrec, ISFBCNoOp{});
-
-        amrex::FillPatchSingleLevel(
-            mfab, nghost, time, {&this->operator()(lev)}, {time}, 0, 0,
-            num_comp(), mesh.Geom(lev), physbc, 0);
-    } else {
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> cphysbc(
-            mesh.Geom(lev - 1), bcrec, ISFBCNoOp{});
-
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> fphysbc(
-            mesh.Geom(lev), bcrec, ISFBCNoOp{});
-
-        amrex::FillPatchTwoLevels(
-            mfab, nghost, time, {&this->operator()(lev - 1)}, {time},
-            {&this->operator()(lev)}, {time}, 0, 0, num_comp(),
-            mesh.Geom(lev - 1), mesh.Geom(lev), cphysbc, 0, fphysbc, 0,
-            mesh.refRatio(lev - 1), mapper, bcrec, 0);
-    }
-}
-*/
 
 } // namespace amr_wind

--- a/amr-wind/core/IntScratchField.cpp
+++ b/amr-wind/core/IntScratchField.cpp
@@ -10,13 +10,6 @@
 
 namespace amr_wind {
 
-
-namespace {
-
-
-} // namespace
-
-
 void IntScratchField::setVal(int value) noexcept
 {
     BL_PROFILE("amr-wind::IntScratchField::setVal 1");
@@ -24,34 +17,5 @@ void IntScratchField::setVal(int value) noexcept
         operator()(lev).setVal(value);
     }
 }
-
-/*
-void IntScratchField::setVal(
-    int value, int start_comp, int num_comp, int nghost) noexcept
-{
-    BL_PROFILE("amr-wind::IntScratchField::setVal 2");
-    for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
-        operator()(lev).setVal(value, start_comp, num_comp, nghost);
-    }
-}
-*/
-/*
-void IntScratchField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
-{
-    BL_PROFILE("amr-wind::IntScratchField::setVal 3");
-    AMREX_ASSERT(num_comp() == static_cast<int>(values.size()));
-
-    // Update 1 component at a time
-    const int ncomp = 1;
-    for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
-        auto& mf = operator()(lev);
-        for (int ic = 0; ic < num_comp(); ++ic) {
-            int value = values[ic];
-            mf.setVal(value, ic, ncomp, nghost);
-        }
-    }
-}
-*/
-
 
 } // namespace amr_wind

--- a/amr-wind/core/IntScratchField.cpp
+++ b/amr-wind/core/IntScratchField.cpp
@@ -1,0 +1,107 @@
+#include "amr-wind/core/IntScratchField.H"
+#include "amr-wind/core/FieldRepo.H"
+
+#include "AMReX_Gpu.H"
+#include "AMReX_FArrayBox.H"
+#include "AMReX_Geometry.H"
+#include "AMReX_PhysBCFunct.H"
+#include "AMReX_FillPatchUtil.H"
+#include "AMReX_iMultiFab.H"
+
+namespace amr_wind {
+
+
+namespace {
+struct ISFBCNoOp
+{
+    AMREX_GPU_DEVICE
+    void operator()(
+        const amrex::IntVect& /* iv */,
+        amrex::Array4<int> const& /* field */,
+        const int /* dcomp */,
+        const int /* numcomp */,
+        amrex::GeometryData const& /* geom */,
+        const amrex::Real /* time */,
+        const amrex::BCRec* /* bcr */,
+        const int /* bcomp */,
+        const int /* orig_comp */) const
+    {}
+};
+
+amrex::Vector<amrex::BCRec>
+scratch_field_bcrec(const amrex::Geometry& geom, const int ncomp)
+{
+    amrex::Vector<amrex::BCRec> bcrec(ncomp);
+
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+        auto bcrv = geom.isPeriodic(dir) ? amrex::BCType::int_dir
+                                         : amrex::BCType::hoextrap;
+
+        for (int n = 0; n < ncomp; ++n) {
+            bcrec[n].setLo(dir, bcrv);
+            bcrec[n].setHi(dir, bcrv);
+        }
+    }
+
+    return bcrec;
+}
+
+} // namespace
+void IntScratchField::fillpatch(amrex::Real time) noexcept
+{
+    fillpatch(time, num_grow());
+}
+
+void IntScratchField::fillpatch(
+    amrex::Real time, const amrex::IntVect& ng) noexcept
+{
+    const int nlevels = repo().num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        fillpatch(lev, time, this->operator()(lev), ng);
+    }
+}
+
+void IntScratchField::fillpatch(
+    int lev,
+    amrex::Real time,
+    amrex::iMultiFab& mfab,
+    const amrex::IntVect& nghost) noexcept
+{
+    const auto& mesh = repo().mesh();
+    auto bcrec = scratch_field_bcrec(mesh.Geom(lev), num_comp());
+    fillpatch(lev, time, mfab, nghost, bcrec);
+}
+
+void IntScratchField::fillpatch(
+    int lev,
+    amrex::Real time,
+    amrex::iMultiFab& mfab,
+    const amrex::IntVect& nghost,
+    amrex::Vector<amrex::BCRec>& bcrec) noexcept
+{
+    const auto& mesh = repo().mesh();
+    amrex::Interpolater* mapper = &amrex::cell_cons_interp;
+
+    if (lev == 0) {
+        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> physbc(
+            mesh.Geom(lev), bcrec, ISFBCNoOp{});
+
+        amrex::FillPatchSingleLevel(
+            mfab, nghost, time, {&this->operator()(lev)}, {time}, 0, 0,
+            num_comp(), mesh.Geom(lev), physbc, 0);
+    } else {
+        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> cphysbc(
+            mesh.Geom(lev - 1), bcrec, ISFBCNoOp{});
+
+        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<ISFBCNoOp>> fphysbc(
+            mesh.Geom(lev), bcrec, ISFBCNoOp{});
+
+        amrex::FillPatchTwoLevels(
+            mfab, nghost, time, {&this->operator()(lev - 1)}, {time},
+            {&this->operator()(lev)}, {time}, 0, 0, num_comp(),
+            mesh.Geom(lev - 1), mesh.Geom(lev), cphysbc, 0, fphysbc, 0,
+            mesh.refRatio(lev - 1), mapper, bcrec, 0);
+    }
+}
+
+} // namespace amr_wind

--- a/amr-wind/core/IntScratchField.cpp
+++ b/amr-wind/core/IntScratchField.cpp
@@ -25,6 +25,7 @@ void IntScratchField::setVal(int value) noexcept
     }
 }
 
+/*
 void IntScratchField::setVal(
     int value, int start_comp, int num_comp, int nghost) noexcept
 {
@@ -33,7 +34,8 @@ void IntScratchField::setVal(
         operator()(lev).setVal(value, start_comp, num_comp, nghost);
     }
 }
-
+*/
+/*
 void IntScratchField::setVal(const amrex::Vector<int>& values, int nghost) noexcept
 {
     BL_PROFILE("amr-wind::IntScratchField::setVal 3");
@@ -49,6 +51,7 @@ void IntScratchField::setVal(const amrex::Vector<int>& values, int nghost) noexc
         }
     }
 }
+*/
 
 
 } // namespace amr_wind

--- a/amr-wind/core/ViewField.cpp
+++ b/amr-wind/core/ViewField.cpp
@@ -1,7 +1,6 @@
 #include "amr-wind/core/ViewField.H"
 #include "amr-wind/core/Field.H"
 #include "amr-wind/core/ScratchField.H"
-#include "amr-wind/core/IntScratchField.H"
 #include "amr-wind/core/FieldRepo.H"
 
 namespace amr_wind {

--- a/amr-wind/core/ViewField.cpp
+++ b/amr-wind/core/ViewField.cpp
@@ -1,6 +1,7 @@
 #include "amr-wind/core/ViewField.H"
 #include "amr-wind/core/Field.H"
 #include "amr-wind/core/ScratchField.H"
+#include "amr-wind/core/IntScratchField.H"
 #include "amr-wind/core/FieldRepo.H"
 
 namespace amr_wind {

--- a/amr-wind/core/field_ops.H
+++ b/amr-wind/core/field_ops.H
@@ -114,6 +114,53 @@ copy(T1& dst, const T2& src, int srccomp, int dstcomp, int numcomp, int nghost)
     copy(dst, src, srccomp, dstcomp, numcomp, amrex::IntVect(nghost));
 }
 
+/** Copy source field to destination field
+ *  \ingroup field_ops
+ *
+ *  \tparam T1 IntScratchField
+ *  \tparam T2 IntScratchField
+ *  \param [out] dst Field that is updated
+ *  \param [in] src Field to be added
+ *  \param [in] srccomp Starting component index of source field
+ *  \param [in] dstcomp Starting component index of destination field
+ *  \param [in] numcomp Number of components to be updated
+ *  \param [in] nghost Number of ghost cells to be updated
+ */
+template <typename T1, typename T2>
+inline void copy_int(
+    T1& dst,
+    const T2& src,
+    int srccomp,
+    int dstcomp,
+    int numcomp,
+    const amrex::IntVect& nghost)
+{
+    const int nlevels = dst.repo().num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        amrex::iMultiFab::Copy(
+            dst(lev), src(lev), srccomp, dstcomp, numcomp, nghost);
+    }
+}
+
+/** Copy source field to destination field
+ *  \ingroup field_ops
+ *
+ *  \tparam T1 IntScratchField
+ *  \tparam T2 IntScratchField
+ *  \param [out] dst Field that is updated
+ *  \param [in] src Field to be added
+ *  \param [in] srccomp Starting component index of source field
+ *  \param [in] dstcomp Starting component index of destination field
+ *  \param [in] numcomp Number of components to be updated
+ *  \param [in] nghost Number of ghost cells to be updated
+ */
+template <typename T1, typename T2>
+inline void
+copy_int(T1& dst, const T2& src, int srccomp, int dstcomp, int numcomp, int nghost)
+{
+    copy(dst, src, srccomp, dstcomp, numcomp, amrex::IntVect(nghost));
+}
+
 /** Perform operation \f$y = a x + y\f$
  *  \ingroup field_ops
  *

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -88,7 +88,7 @@ void incflo::init_mesh()
 void incflo::init_amr_wind_modules()
 {
     BL_PROFILE("amr-wind::incflo::init_amr_wind_modules");
-
+	amrex::Print()<<"Inside init_amr_wind_modules"<<std::endl;
     if (m_sim.has_overset()) {
         m_sim.overset_manager()->post_init_actions();
     } else {

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -88,7 +88,6 @@ void incflo::init_mesh()
 void incflo::init_amr_wind_modules()
 {
     BL_PROFILE("amr-wind::incflo::init_amr_wind_modules");
-	amrex::Print()<<"Inside init_amr_wind_modules"<<std::endl;
     if (m_sim.has_overset()) {
         m_sim.overset_manager()->post_init_actions();
     } else {

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -93,8 +93,11 @@ public:
 
     AMROversetInfo& amr_overset_info() { return *m_amr_data; }
 
+	// These two are functions that can access the private
+	// m_qcell and m_qnode variables
     ScratchField& qvars_cell() { return *m_qcell; }
     ScratchField& qvars_node() { return *m_qnode; }
+	
 
 private:
     void amr_to_tioga_mesh();
@@ -116,6 +119,10 @@ private:
 
     std::unique_ptr<ScratchField> m_qcell;
     std::unique_ptr<ScratchField> m_qnode;
+
+	// IXT
+    std::unique_ptr<ScratchField> m_qcell_host;
+    std::unique_ptr<ScratchField> m_qnode_host;
 
     std::vector<std::string> m_cell_vars;
     std::vector<std::string> m_node_vars;

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -93,8 +93,6 @@ public:
 
     AMROversetInfo& amr_overset_info() { return *m_amr_data; }
 
-	// These two are functions that can access the private
-	// m_qcell and m_qnode variables
     ScratchField& qvars_cell() { return *m_qcell; }
     ScratchField& qvars_node() { return *m_qnode; }
 	
@@ -109,6 +107,12 @@ private:
 
     //! IBLANK for nodal fields
     IntField& m_iblank_node;
+
+    //! IBLANK on cell centered fields on host
+    IntField& m_iblank_cell_host;
+
+    //! IBLANK for nodal fields on host
+    IntField& m_iblank_node_host;
 
     //! AMReX mask for linear system solves
     IntField& m_mask_cell;

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -94,8 +94,10 @@ public:
 
     AMROversetInfo& amr_overset_info() { return *m_amr_data; }
 
-    ScratchField& qvars_cell() { return *m_qcell; }
-    ScratchField& qvars_node() { return *m_qnode; }
+    //ScratchField& qvars_cell() { return *m_qcell; }
+    //ScratchField& qvars_node() { return *m_qnode; }
+    ScratchField& qvars_cell() { return *m_qcell_host; }
+    ScratchField& qvars_node() { return *m_qnode_host; }
 
     IntScratchField& ibvar_cell_host() { return *m_iblank_cell_host; }
     IntScratchField& ibvar_node_host() { return *m_iblank_node_host; }

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -120,7 +120,6 @@ private:
     std::unique_ptr<ScratchField> m_qcell;
     std::unique_ptr<ScratchField> m_qnode;
 
-	// IXT
     std::unique_ptr<ScratchField> m_qcell_host;
     std::unique_ptr<ScratchField> m_qnode_host;
 

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -96,6 +96,9 @@ public:
 
     ScratchField& qvars_cell() { return *m_qcell; }
     ScratchField& qvars_node() { return *m_qnode; }
+
+    IntScratchField& ibvar_cell_host() { return *m_iblank_cell_host; }
+    IntScratchField& ibvar_node_host() { return *m_iblank_node_host; }
 	
 
 private:

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -94,8 +94,6 @@ public:
 
     AMROversetInfo& amr_overset_info() { return *m_amr_data; }
 
-    //ScratchField& qvars_cell() { return *m_qcell; }
-    //ScratchField& qvars_node() { return *m_qnode; }
     ScratchField& qvars_cell() { return *m_qcell_host; }
     ScratchField& qvars_node() { return *m_qnode_host; }
 	

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -9,6 +9,7 @@ namespace amr_wind {
 
 class IntField;
 class ScratchField;
+class IntScratchField;
 
 /** AMR mesh data in TIOGA format
  */
@@ -109,10 +110,12 @@ private:
     IntField& m_iblank_node;
 
     //! IBLANK on cell centered fields on host
-    IntField& m_iblank_cell_host;
+    //IntField& m_iblank_cell_host;
+    std::unique_ptr<IntScratchField> m_iblank_cell_host;
 
     //! IBLANK for nodal fields on host
-    IntField& m_iblank_node_host;
+    //IntField& m_iblank_node_host;
+    std::unique_ptr<IntScratchField> m_iblank_node_host;
 
     //! AMReX mask for linear system solves
     IntField& m_mask_cell;

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -106,6 +106,8 @@ public:
 private:
     void amr_to_tioga_mesh();
 
+    void amr_to_tioga_iblank();
+
     CFDSim& m_sim;
 
     //! IBLANK on cell centered fields

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -117,11 +117,9 @@ private:
     IntField& m_iblank_node;
 
     //! IBLANK on cell centered fields on host
-    //IntField& m_iblank_cell_host;
     std::unique_ptr<IntScratchField> m_iblank_cell_host;
 
     //! IBLANK for nodal fields on host
-    //IntField& m_iblank_node_host;
     std::unique_ptr<IntScratchField> m_iblank_node_host;
 
     //! AMReX mask for linear system solves

--- a/amr-wind/overset/TiogaInterface.H
+++ b/amr-wind/overset/TiogaInterface.H
@@ -98,9 +98,6 @@ public:
     //ScratchField& qvars_node() { return *m_qnode; }
     ScratchField& qvars_cell() { return *m_qcell_host; }
     ScratchField& qvars_node() { return *m_qnode_host; }
-
-    IntScratchField& ibvar_cell_host() { return *m_iblank_cell_host; }
-    IntScratchField& ibvar_node_host() { return *m_iblank_node_host; }
 	
 
 private:

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -454,10 +454,14 @@ void TiogaInterface::amr_to_tioga_mesh()
     amrex::Print()<<"tmp vectors set?"<<std::endl;
     for (int lev = 0; lev < nlevels; ++lev) {
         //auto& ad = *m_amr_data;
+	    amrex::Print()<<"Level is "<<lev<<"\n"<<std::endl;
         auto& ibfab = ibcell(lev);
         auto& ibnodefab = ibnode(lev);
+	amrex::Print()<<"ibnodefab "<<std::endl;
         auto& ibfab_host = (*m_iblank_cell_host)(lev);
+	amrex::Print()<<"ibfab_host "<<std::endl;
         auto& ibnodefab_host = (*m_iblank_node_host)(lev);
+	amrex::Print()<<"ibnodefab_host "<<std::endl;
         //auto& ibfab_host = ibcell_host(lev);
         //auto& ibnodefab_host = ibnode_host(lev);
 

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -107,7 +107,11 @@ TiogaInterface::TiogaInterface(CFDSim& sim)
 
 void TiogaInterface::post_init_actions()
 {
-	amrex::Print()<<"post_init_actions"<<std::endl;
+amrex::Print()<<"post_init_actions"<<std::endl;
+    auto& repo = m_sim.repo();
+    const int num_ghost = m_sim.pde_manager().num_ghost_state();
+    m_iblank_cell_host = repo.create_int_scratch_field_on_host("iblank_cell_host",1,num_ghost, FieldLoc::CELL);
+    m_iblank_node_host = repo.create_int_scratch_field_on_host("iblank_node_host",1,num_ghost, FieldLoc::NODE);
     amr_to_tioga_mesh();
 
     // Initialize masking so that all cells are active in solvers
@@ -140,9 +144,11 @@ void TiogaInterface::pre_overset_conn_work()
     //    std::accumulate(cell_vars.begin(), cell_vars.end(), 0, comp_counter);
     //const int nnode_vars =
     //    std::accumulate(node_vars.begin(), node_vars.end(), 0, comp_counter);
+	/*
     const int num_ghost = m_sim.pde_manager().num_ghost_state();
     m_iblank_cell_host = repo.create_int_scratch_field_on_host("iblank_cell_host",1,num_ghost, FieldLoc::CELL);
     m_iblank_node_host = repo.create_int_scratch_field_on_host("iblank_node_host",1,num_ghost, FieldLoc::NODE);
+*/
     (*m_iblank_cell_host).setVal(1);
     (*m_iblank_node_host).setVal(1);
     //auto& repo = m_sim.repo();
@@ -390,7 +396,6 @@ void TiogaInterface::amr_to_tioga_mesh()
             }
         }
     }
-	amrex::Print()<<"ngrids_local "<< ngrids_local<<std::endl;
     m_amr_data = std::make_unique<AMROversetInfo>(ngrids_global, ngrids_local);
     std::vector<int> lgrid_id(nproc, 0);
 

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -117,7 +117,10 @@ void TiogaInterface::post_overset_conn_work()
         eqn->post_regrid_actions();
     }
 }
-
+	// IXT comment
+	// This is called right before dataUpdate_AMR is called inside exawind
+	// through the tioga instance m_tg
+	// This is likely where the relevant exchange occurs
 void TiogaInterface::register_solution(
     const std::vector<std::string>& cell_vars,
     const std::vector<std::string>& node_vars)
@@ -135,10 +138,14 @@ void TiogaInterface::register_solution(
     m_qcell = repo.create_scratch_field(ncell_vars, num_ghost, FieldLoc::CELL);
     m_qnode = repo.create_scratch_field(nnode_vars, num_ghost, FieldLoc::NODE);
 
+	// IXT comments
+	// These are strings
     // Store field variable names for use in update_solution step
     m_cell_vars = cell_vars;
     m_node_vars = node_vars;
 
+	// IXT comments
+	// Print out the string cvar here
     // Move cell variables into scratch field
     {
         int icomp = 0;
@@ -152,8 +159,14 @@ void TiogaInterface::register_solution(
         AMREX_ASSERT(ncell_vars == icomp);
     }
 
+	// IXT comments
+	// Print out cvar here to check what is being copied
     // Move node variables into scratch field
     {
+	// IXT comments
+	// get_field is defined inside /amr-wind/amr-wind/core/FieldRepo.cpp
+	// It uses AMRex functions
+	// It returns a Field
         int icomp = 0;
         for (const auto& cvar : m_node_vars) {
             auto& fld = repo.get_field(cvar);
@@ -165,15 +178,28 @@ void TiogaInterface::register_solution(
         AMREX_ASSERT(nnode_vars == icomp);
     }
 
+	// IXT comments
     // Update data pointers for TIOGA exchange
     {
         int ilp = 0;
         const int nlevels = m_sim.repo().num_active_levels();
         auto& ad = *m_amr_data;
         for (int lev = 0; lev < nlevels; ++lev) {
+		// IXT comments
+		// Look up how this definition with lev is done here
+		// qcfab is a Fab defined for cells?
+		// qnfab is a Fab defined for cells?
+		// Figure out what Fab is in AMRex
+		// It stores floating point data on a rectangular domain?
             auto& qcfab = (*m_qcell)(lev);
             auto& qnfab = (*m_qnode)(lev);
 
+	// IXT comments
+	// ad is AMR data,
+	// Is h_view for the host to view, and d_view for the device to view?	
+	//  Should the h_view data be explicitly sent to CPU memory from GPU memory?
+	// Make sure you understand what the ad and qcfab objects are
+	// Understand what MFIter does
             for (amrex::MFIter mfi(qcfab); mfi.isValid(); ++mfi) {
                 ad.qcell.h_view[ilp] = qcfab[mfi].dataPtr();
                 ad.qcell.d_view[ilp] = qcfab[mfi].dataPtr();
@@ -190,7 +216,8 @@ void TiogaInterface::update_solution()
 {
     auto& repo = m_sim.repo();
     const int num_ghost = m_sim.pde_manager().num_ghost_state();
-
+	// IXT
+	// print cvar and ncomp here
     // Update cell variables
     {
         int icomp = 0;
@@ -203,6 +230,8 @@ void TiogaInterface::update_solution()
         }
     }
 
+	// IXT
+	// print cvar and ncomp here
     // Update nodal variables
     {
         int icomp = 0;

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -110,12 +110,10 @@ void TiogaInterface::pre_overset_conn_work()
     m_iblank_cell_host = repo.create_int_scratch_field_on_host("iblank_cell_host",1,num_ghost, FieldLoc::CELL);
     m_iblank_node_host = repo.create_int_scratch_field_on_host("iblank_node_host",1,num_ghost, FieldLoc::NODE);
 
-	amr_to_tioga_iblank();
+    amr_to_tioga_iblank();
 
     m_iblank_cell.setVal(1);
     m_iblank_node.setVal(1);
-
-
 
     (*m_iblank_cell_host).setVal(1);
     (*m_iblank_node_host).setVal(1);
@@ -240,8 +238,8 @@ void TiogaInterface::register_solution(
         int ilp = 0;
         const int nlevels = m_sim.repo().num_active_levels();
         auto& ad = *m_amr_data;
-    amrex::Vector<amrex::Real*> qcellPtr(ad.qcell.size());
-    amrex::Vector<amrex::Real*> qnodePtr(ad.qnode.size());
+	amrex::Vector<amrex::Real*> qcellPtr(ad.qcell.size());
+    	amrex::Vector<amrex::Real*> qnodePtr(ad.qnode.size());
         for (int lev = 0; lev < nlevels; ++lev) {
             auto& qcfab = (*m_qcell)(lev);
             auto& qnfab = (*m_qnode)(lev);
@@ -262,7 +260,7 @@ void TiogaInterface::register_solution(
                 ++ilp;
             }
         }
-	// Host to device copy from standard vector to 
+	// Host to device copy from standard vector to d_view 
         amrex::Gpu::copy(
             amrex::Gpu::hostToDevice, qcellPtr.begin(), qcellPtr.end(),
             ad.qcell.d_view.begin());
@@ -283,14 +281,13 @@ void TiogaInterface::update_solution()
         for (const auto& cvar : m_cell_vars) {
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
-            // Device to host copy happens here
+            // Host to device copy happens here
             const int nlevels = repo.num_active_levels();
             for (int lev = 0; lev < nlevels; ++lev) {
 	    	htod_memcpy(fld(lev),(*m_qcell_host)(lev),icomp,0,ncomp);
             }
             fld.fillpatch(m_sim.time().new_time());
             icomp += ncomp;
-
         }
      }
 

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -127,12 +127,15 @@ void TiogaInterface::pre_overset_conn_work()
     m_iblank_cell.setVal(1);
     m_iblank_node.setVal(1);
 
-    auto& repo = m_sim.repo();
-    const int nlevels = repo.num_active_levels();
-    for (int lev = 0; lev < nlevels; ++lev) {
-	dtoh_memcpy(m_iblank_cell_host(lev), m_iblank_cell(lev),0,0,1);
-	dtoh_memcpy(m_iblank_node_host(lev), m_iblank_node(lev),0,0,1);
-    }
+    m_iblank_cell_host.setVal(1);
+    m_iblank_node_host.setVal(1);
+
+    //auto& repo = m_sim.repo();
+    //const int nlevels = repo.num_active_levels();
+    //for (int lev = 0; lev < nlevels; ++lev) {
+	//dtoh_memcpy(m_iblank_cell_host(lev), m_iblank_cell(lev),0,0,1);
+	//dtoh_memcpy(m_iblank_node_host(lev), m_iblank_node(lev),0,0,1);
+    //}
 	
 
 }

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -130,10 +130,8 @@ void TiogaInterface::pre_overset_conn_work()
     auto& repo = m_sim.repo();
     const int nlevels = repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
-	//dtoh_memcpy((*m_qcell_host)(lev), fld(lev),0,icomp,ncomp);
 	dtoh_memcpy(m_iblank_cell_host(lev), m_iblank_cell(lev),0,0,1);
 	dtoh_memcpy(m_iblank_node_host(lev), m_iblank_node(lev),0,0,1);
-
     }
 	
 
@@ -141,6 +139,13 @@ void TiogaInterface::pre_overset_conn_work()
 
 void TiogaInterface::post_overset_conn_work()
 {
+
+    auto& repo = m_sim.repo();
+    const int nlevels = repo.num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+	htod_memcpy(m_iblank_cell(lev),m_iblank_cell_host(lev),0,0,1);
+	htod_memcpy(m_iblank_node(lev),m_iblank_node_host(lev),0,0,1);
+    }
 
     iblank_to_mask(m_iblank_cell, m_mask_cell);
     iblank_to_mask(m_iblank_node, m_mask_node);

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -105,68 +105,69 @@ void TiogaInterface::pre_overset_conn_work()
     m_iblank_cell.setVal(1);
     m_iblank_node.setVal(1);
 
-        //const auto& mbl = m_iblank_cell;
-
-	//std::cout<<"Inside pre_overset_conn_work"<<"\n";
-	//amrex::Print() << "Inside pre_overset_conn_work"<<std::endl;
-
-	// IXT comments
-/*
-    const auto& nlevels = m_iblank_cell.repo().mesh().finestLevel() + 1;
-	//amrex::Print << "nlevels is "<< nlevels << "\n";
+    // const auto& mbl = m_iblank_cell;
 
 
-    for (int lev = 0; lev < nlevels; ++lev) {
-        const auto& mbl = m_iblank_cell(lev);
-	//std::cout << "lev is " << lev <<"\n";
-	//amrex::Print() << "lev is " << lev <<"\n";
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
-            const auto& gbx = mfi.growntilebox();
-            const auto& ibarr = mbl.const_array(mfi);
-            amrex::ParallelFor(
-                gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			//amrex::Print()<<"The quantity is "<<"\n";
-			amrex::Print()<<"pre_ibarr is "<<ibarr(i,j,k)<<"\n";
-			//amrex::Print() << "Printing in AMRex?" <<"\n";
-			//amrex::Print() << "Printing in AMRex?" << amrex::Version()<<"\n";
-                    //marr(i, j, k) = amrex::max(ibarr(i, j, k), 0);
-                });
+    // IXT comments
+    /*
+        const auto& nlevels = m_iblank_cell.repo().mesh().finestLevel() + 1;
+            //amrex::Print << "nlevels is "<< nlevels << "\n";
+
+
+        for (int lev = 0; lev < nlevels; ++lev) {
+            const auto& mbl = m_iblank_cell(lev);
+            //std::cout << "lev is " << lev <<"\n";
+            //amrex::Print() << "lev is " << lev <<"\n";
+    #ifdef AMREX_USE_OMP
+    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+    #endif
+            for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
+                const auto& gbx = mfi.growntilebox();
+                const auto& ibarr = mbl.const_array(mfi);
+                amrex::ParallelFor(
+                    gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            //amrex::Print()<<"The quantity is "<<"\n";
+                            amrex::Print()<<"pre_ibarr is "<<ibarr(i,j,k)<<"\n";
+                            //amrex::Print() << "Printing in AMRex?" <<"\n";
+                            //amrex::Print() << "Printing in AMRex?" <<
+    amrex::Version()<<"\n";
+                        //marr(i, j, k) = amrex::max(ibarr(i, j, k), 0);
+                    });
+            }
         }
-    }
-*/
+    */
 }
 
 void TiogaInterface::post_overset_conn_work()
 {
 
-	//std::cout<<"Inside post_overset_conn_work"<<"\n";
+    // Copy from m_iblank_cell_host to m_mask_cell
+    // Copy from m_iblank_node_host to m_mask_node
     iblank_to_mask(m_iblank_cell, m_mask_cell);
     iblank_to_mask(m_iblank_node, m_mask_node);
-	// IXT comments
-	// Print m_mask_cell
-	// Print m_mask_node here
+    // IXT comments
+    // Print m_mask_cell
+    // Print m_mask_node here
 
-/*
-    const auto& nlevels = m_iblank_cell.repo().mesh().finestLevel() + 1;
-    for (int lev = 0; lev < nlevels; ++lev) {
-        //const auto& mbl = m_mask_cell(lev);
-        const auto& mbl = m_mask_node(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
-            const auto& gbx = mfi.growntilebox();
-            const auto& ibarr = mbl.const_array(mfi);
-            amrex::ParallelFor(
-                gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			amrex::Print()<<"post_ibarr is "<<ibarr(i,j,k)<<"\n";
-                });
+    /*
+        const auto& nlevels = m_iblank_cell.repo().mesh().finestLevel() + 1;
+        for (int lev = 0; lev < nlevels; ++lev) {
+            //const auto& mbl = m_mask_cell(lev);
+            const auto& mbl = m_mask_node(lev);
+    #ifdef AMREX_USE_OMP
+    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+    #endif
+            for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
+                const auto& gbx = mfi.growntilebox();
+                const auto& ibarr = mbl.const_array(mfi);
+                amrex::ParallelFor(
+                    gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            amrex::Print()<<"post_ibarr is
+    "<<ibarr(i,j,k)<<"\n";
+                    });
+            }
         }
-    }
-*/
+    */
 
     // Update equation systems after a connectivity update
     m_sim.pde_manager().icns().post_regrid_actions();
@@ -174,10 +175,10 @@ void TiogaInterface::post_overset_conn_work()
         eqn->post_regrid_actions();
     }
 }
-	// IXT comment
-	// This is called right before dataUpdate_AMR is called inside exawind
-	// through the tioga instance m_tg
-	// This is likely where the relevant exchange occurs
+// IXT comment
+// This is called right before dataUpdate_AMR is called inside exawind
+// through the tioga instance m_tg
+// This is likely where the relevant exchange occurs
 void TiogaInterface::register_solution(
     const std::vector<std::string>& cell_vars,
     const std::vector<std::string>& node_vars)
@@ -195,56 +196,133 @@ void TiogaInterface::register_solution(
     m_qcell = repo.create_scratch_field(ncell_vars, num_ghost, FieldLoc::CELL);
     m_qnode = repo.create_scratch_field(nnode_vars, num_ghost, FieldLoc::NODE);
 
-
-
-	// IXT
-	// call create_scratch_field_on_host here
-	//amrex::Print()<<"ncell_vars "<<ncell_vars<<"num_ghost "<<num_ghost<<std::endl;
-    m_qcell_host = repo.create_scratch_field_on_host(ncell_vars, num_ghost, FieldLoc::CELL);
-    m_qnode_host = repo.create_scratch_field_on_host(nnode_vars, num_ghost, FieldLoc::NODE);
+    // IXT
+    // call create_scratch_field_on_host here
+    amrex::Print() << "ncell_vars " << ncell_vars << " nnode_vars "
+                   << nnode_vars << " num_ghost " << num_ghost << std::endl;
+    m_qcell_host = repo.create_scratch_field_on_host(
+        2*ncell_vars, num_ghost, FieldLoc::CELL);
+    m_qnode_host = repo.create_scratch_field_on_host(
+        2*nnode_vars, num_ghost, FieldLoc::NODE);
+    //m_qcell_host = repo.create_scratch_field_on_host(
+    //    ncell_vars, num_ghost, FieldLoc::CELL);
+    //m_qnode_host = repo.create_scratch_field_on_host(
+    //    nnode_vars, num_ghost, FieldLoc::NODE);
     // Store field variable names for use in update_solution step
     // These are both vectors holding strings
     m_cell_vars = cell_vars;
     m_node_vars = node_vars;
 
-
-	// IXT comments
+    // IXT comments
     // Move cell variables into scratch field
     {
         int icomp = 0;
         for (const auto& cvar : m_cell_vars) {
-		//amrex::Print()<<"cvar"<<cvar<<std::endl;
+            // amrex::Print()<<"cvar"<<cvar<<std::endl;
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
             field_ops::copy(*m_qcell, fld, 0, icomp, ncomp, num_ghost);
-	// Consider calling an explicit copy to the CPU field here for testing
+            // Consider calling an explicit copy to the CPU field here for
+            // testing
             icomp += ncomp;
         }
         AMREX_ASSERT(ncell_vars == icomp);
     }
 
+    // Move cell variables into host scratch field
+    {
+        int icomp = 0;
+        for (const auto& cvar : m_cell_vars) {
+            // amrex::Print()<<"cvar"<<cvar<<std::endl;
+            auto& fld = repo.get_field(cvar);
+            const int ncomp = fld.num_comp();
+		amrex::Print()<<"NCOMP IS "<<ncomp<<std::endl;
+            fld.fillpatch(m_sim.time().new_time());
+            // Device to host copy happens here
+            const int nlevels = repo.num_active_levels();
+            for (int lev = 0; lev < nlevels; ++lev) {
+		//dtoh_memcpy((*m_qcell_host)(lev), fld(lev),0,icomp,2*ncomp);
+		dtoh_memcpy((*m_qcell_host)(lev), fld(lev),0,icomp,ncomp);
+
+            }
+	//amrex::Print()<<"preicomp "<<icomp<<" ncomp"<<ncomp<<std::endl;
+            icomp += ncomp;
+	//amrex::Print()<<"posticomp "<<icomp<<" ncomp"<<ncomp<<std::endl;
+	/*
+	for (int lev = 0; lev < nlevels; ++lev) {
+	    const auto& mbl = (*m_qcell_host)(lev);
+	    for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
+		const auto& gbx = mfi.growntilebox();
+		const auto& ibarr = mbl.const_array(mfi);
+		amrex::ParallelFor(
+		    gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			    amrex::Print()<<i<<" "<<j<<" "<<k<<" "<<"field is "<<ibarr(i,j,k,2)<<std::endl;
+			    //amrex::Print()<<i<<" "<<j<<" "<<k<<" "<<"lev "<<lev<<"field is "<<ibarr(i,j,k)<<"\n";
+		    });
+	    }
+	}
+	*/
+        }
+        AMREX_ASSERT(ncell_vars == icomp);
+
+	// Copy the device field to the host field again
+        for (const auto& cvar : m_cell_vars) {
+            // amrex::Print()<<"cvar"<<cvar<<std::endl;
+            auto& fld = repo.get_field(cvar);
+            const int ncomp = fld.num_comp();
+            fld.fillpatch(m_sim.time().new_time());
+            // Device to host copy happens here
+            const int nlevels = repo.num_active_levels();
+            for (int lev = 0; lev < nlevels; ++lev) {
+		dtoh_memcpy((*m_qcell_host)(lev), fld(lev),0,icomp,ncomp);
+
+            }
+
+	//amrex::Print()<<"preicomp2 "<<icomp<<" ncomp"<<ncomp<<std::endl;
+            icomp += ncomp;
+	//amrex::Print()<<"posticomp2 "<<icomp<<" ncomp"<<ncomp<<std::endl;
+	
+	/*
+	for (int lev = 0; lev < nlevels; ++lev) {
+	    const auto& mbl = (*m_qcell_host)(lev);
+	    for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
+		const auto& gbx = mfi.growntilebox();
+		const auto& ibarr = mbl.const_array(mfi);
+		amrex::ParallelFor(
+		    gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			    amrex::Print()<<i<<" "<<j<<" "<<k<<" "<<"field is "<<ibarr(i,j,k,0)<<std::endl;
+			    //amrex::Print()<<i<<" "<<j<<" "<<k<<" "<<"lev "<<lev<<"field is "<<ibarr(i,j,k)<<"\n";
+		    });
+	    }
+	}
+	*/
+        }
+    }
+    amrex::Arena::PrintUsage();
     // Move node variables into scratch field
     {
         int icomp = 0;
         for (const auto& cvar : m_node_vars) {
             auto& fld = repo.get_field(cvar);
-//////////////////
-	{
-    const auto& nlevels = fld.repo().mesh().finestLevel() + 1;
-    for (int lev = 0; lev < nlevels; ++lev) {
-        const auto& mbl = fld(lev);
-        for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
-            const auto& gbx = mfi.growntilebox();
-            const auto& ibarr = mbl.const_array(mfi);
-            amrex::ParallelFor(
-                gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			amrex::Print()<<"fld is "<<ibarr(i,j,k)<<"\n";
-                });
+            //////////////////
+            /*
+            {
+        const auto& nlevels = fld.repo().mesh().finestLevel() + 1;
+        for (int lev = 0; lev < nlevels; ++lev) {
+            const auto& mbl = fld(lev);
+            for (amrex::MFIter mfi(mbl); mfi.isValid(); ++mfi) {
+                const auto& gbx = mfi.growntilebox();
+                const auto& ibarr = mbl.const_array(mfi);
+                amrex::ParallelFor(
+                    gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            amrex::Print()<<"fld is "<<ibarr(i,j,k)<<"\n";
+                    });
+            }
         }
-    }
-	}
-////////////////////////
+            }
+            */
+            ////////////////////////
 
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
@@ -252,12 +330,10 @@ void TiogaInterface::register_solution(
             icomp += ncomp;
         }
         AMREX_ASSERT(nnode_vars == icomp);
-
-
     }
-	// Copy from device to host
-	// Print host data
-	// Call amrex::Arena::PrintUsage();
+    // Copy from device to host
+    // Print host data
+    // Call amrex::Arena::PrintUsage();
 
     // Update data pointers for TIOGA exchange
     {
@@ -269,17 +345,17 @@ void TiogaInterface::register_solution(
             auto& qnfab = (*m_qnode)(lev);
 
             for (amrex::MFIter mfi(qcfab); mfi.isValid(); ++mfi) {
-		std::cout<<"Is this being called?\n";
-		// IXT comments
-		// Copy from device to host
+                std::cout << "Is this being called?\n";
+                // IXT comments
+                // Copy from device to host
                 ad.qcell.h_view[ilp] = qcfab[mfi].dataPtr();
-		// Do nothing for d_view
-		// d_view is an amrex::Gpu::DeviceVector
+                // Do nothing for d_view
+                // d_view is an amrex::Gpu::DeviceVector
                 ad.qcell.d_view[ilp] = qcfab[mfi].dataPtr();
-		// Copy from device to host
+                // Copy from device to host
                 ad.qnode.h_view[ilp] = qnfab[mfi].dataPtr();
-		// Do nothing for d_view
-		// d_view is an amrex::Gpu::DeviceVector
+                // Do nothing for d_view
+                // d_view is an amrex::Gpu::DeviceVector
                 ad.qnode.d_view[ilp] = qnfab[mfi].dataPtr();
 
                 ++ilp;
@@ -295,10 +371,10 @@ void TiogaInterface::update_solution()
 
     int prank;
     MPI_Comm_rank(MPI_COMM_WORLD, &prank);
-	//std::cout<<"Inside update_solution"<<"\n";
-	//std::cout<<"Rank Inside update_solution "<<prank<<"\n";
-	// IXT
-	// print cvar and ncomp here
+    // std::cout<<"Inside update_solution"<<"\n";
+    // std::cout<<"Rank Inside update_solution "<<prank<<"\n";
+    //  IXT
+    //  print cvar and ncomp here
     // Update cell variables
     {
         int icomp = 0;
@@ -311,9 +387,8 @@ void TiogaInterface::update_solution()
         }
     }
 
-
-	// IXT
-	// print cvar and ncomp here
+    // IXT
+    // print cvar and ncomp here
     // Update nodal variables
     {
         int icomp = 0;
@@ -410,7 +485,7 @@ void TiogaInterface::amr_to_tioga_mesh()
         auto& ad = *m_amr_data;
         auto& ibfab = ibcell(lev);
         auto& ibnodefab = ibnode(lev);
-	// h_view might need an explicit copy from device to host
+        // h_view might need an explicit copy from device to host
         for (amrex::MFIter mfi(ibfab); mfi.isValid(); ++mfi) {
             auto& ib = ibfab[mfi];
             auto& ibn = ibnodefab[mfi];

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -127,8 +127,15 @@ void TiogaInterface::pre_overset_conn_work()
     m_iblank_cell.setVal(1);
     m_iblank_node.setVal(1);
 
+    auto& repo = m_sim.repo();
+    const int nlevels = repo.num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+	//dtoh_memcpy((*m_qcell_host)(lev), fld(lev),0,icomp,ncomp);
+	dtoh_memcpy(m_iblank_cell_host(lev), m_iblank_cell(lev),0,0,1);
+	dtoh_memcpy(m_iblank_node_host(lev), m_iblank_node(lev),0,0,1);
+
+    }
 	
-dtoh_memcpy(m_iblank_cell_host, m_iblank_cell,0,0,1);
 
 }
 
@@ -412,15 +419,24 @@ void TiogaInterface::amr_to_tioga_mesh()
     ilp = 0;
     auto& ibcell = m_sim.repo().get_int_field("iblank_cell");
     auto& ibnode = m_sim.repo().get_int_field("iblank_node");
+
+    auto& ibcell_host = m_sim.repo().get_int_field("iblank_cell_host");
+    auto& ibnode_host = m_sim.repo().get_int_field("iblank_node_host");
     for (int lev = 0; lev < nlevels; ++lev) {
         auto& ad = *m_amr_data;
         auto& ibfab = ibcell(lev);
         auto& ibnodefab = ibnode(lev);
+        auto& ibfab_host = ibcell_host(lev);
+        auto& ibnodefab_host = ibnode_host(lev);
         for (amrex::MFIter mfi(ibfab); mfi.isValid(); ++mfi) {
             auto& ib = ibfab[mfi];
             auto& ibn = ibnodefab[mfi];
-            ad.iblank_cell.h_view[ilp] = ib.dataPtr();
-            ad.iblank_node.h_view[ilp] = ibn.dataPtr();
+            auto& ib_host = ibfab_host[mfi];
+            auto& ibn_host = ibnodefab_host[mfi];
+            ad.iblank_cell.h_view[ilp] = ib_host.dataPtr();
+            ad.iblank_node.h_view[ilp] = ibn_host.dataPtr();
+            //ad.iblank_cell.h_view[ilp] = ib.dataPtr();
+            //ad.iblank_node.h_view[ilp] = ibn.dataPtr();
             ad.iblank_cell.d_view[ilp] = ib.dataPtr();
             ad.iblank_node.d_view[ilp] = ibn.dataPtr();
 

--- a/unit_tests/core/test_field.cpp
+++ b/unit_tests/core/test_field.cpp
@@ -321,12 +321,10 @@ TEST_F(FieldRepoTest, int_scratch_fields)
     create_mesh_instance();
 
     auto& frepo = mesh().field_repo();
-    // Check that scratch field creation is disallowed before mesh is created
-    amrex::Print()<<"Before except throw"<<std::endl;
+    // Check that int scratch field creation is disallowed before mesh is created
     #if !(defined(AMREX_USE_MPI) && defined(__APPLE__))
     EXPECT_THROW(frepo.create_int_scratch_field_on_host(1, 0), amrex::RuntimeError);
     #endif
-    amrex::Print()<<"After except throw"<<std::endl;
     initialize_mesh();
 
     // cppcheck-suppress constVariable
@@ -337,12 +335,6 @@ TEST_F(FieldRepoTest, int_scratch_fields)
         "iblank_node_host", 1, 0, amr_wind::FieldLoc::NODE);
 
     const int nlevels = frepo.num_active_levels();
-    /*
-    for (int lev = 0; lev < nlevels; ++lev) {
-        (*ibcell_host)(lev).setVal(1);
-        (*ibnode_host)(lev).setVal(0);
-    }
-    */
 
         (*ibcell_host).setVal(1);
         (*ibnode_host).setVal(0);

--- a/unit_tests/core/test_field.cpp
+++ b/unit_tests/core/test_field.cpp
@@ -312,6 +312,49 @@ TEST_F(FieldRepoTest, scratch_fields)
     }
 }
 
+
+TEST_F(FieldRepoTest, int_scratch_fields)
+{
+
+
+    populate_parameters();
+    create_mesh_instance();
+
+    auto& frepo = mesh().field_repo();
+    // Check that scratch field creation is disallowed before mesh is created
+    amrex::Print()<<"Before except throw"<<std::endl;
+    #if !(defined(AMREX_USE_MPI) && defined(__APPLE__))
+    EXPECT_THROW(frepo.create_int_scratch_field_on_host(1, 0), amrex::RuntimeError);
+    #endif
+    amrex::Print()<<"After except throw"<<std::endl;
+    initialize_mesh();
+
+    // cppcheck-suppress constVariable
+    auto ibcell_host = frepo.create_int_scratch_field_on_host(
+	"iblank_cell_host", 1, 0, amr_wind::FieldLoc::CELL);
+    // cppcheck-suppress constVariable
+    auto ibnode_host = frepo.create_int_scratch_field_on_host(
+        "iblank_node_host", 1, 0, amr_wind::FieldLoc::NODE);
+
+    const int nlevels = frepo.num_active_levels();
+    /*
+    for (int lev = 0; lev < nlevels; ++lev) {
+        (*ibcell_host)(lev).setVal(1);
+        (*ibnode_host)(lev).setVal(0);
+    }
+    */
+
+        (*ibcell_host).setVal(1);
+        (*ibnode_host).setVal(0);
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        EXPECT_EQ((*ibcell_host)(lev).max(0), 1);
+        EXPECT_EQ((*ibcell_host)(lev).min(0), 1);
+        EXPECT_EQ((*ibnode_host)(lev).max(0), 0);
+        EXPECT_EQ((*ibnode_host)(lev).min(0), 0);
+    }
+}
+
 TEST_F(FieldRepoTest, int_fields)
 {
     initialize_mesh();


### PR DESCRIPTION
Removed unified memory from TiogaInterface

* Host allocated m_qcell_host and m_qnode_host are passed to TIOGA
* Host allocated iblank_cell_host and iblank_node_host are passed to TIOGA
* The newly added IntScratchField class enables integer scratch fields
* A unit test for IntScratchField is added
* amr_to_tioga_mesh is split into two functions
* 
![plot_power](https://user-images.githubusercontent.com/114435459/222641118-8f9801ce-cfd0-4643-ae58-ae7e41b66660.png)
![plot_thrust](https://user-images.githubusercontent.com/114435459/222641120-0a0255fa-5dc4-4c3d-82fd-ac54c863925e.png)
