### PR TITLE
FLLC: Add updated formulation

### DIFF
--- a/amr-wind/wind_energy/actuator/FLLC.H
+++ b/amr-wind/wind_energy/actuator/FLLC.H
@@ -5,9 +5,17 @@
 #include "amr-wind/wind_energy/actuator/ActParser.H"
 
 namespace amr_wind::actuator {
+
+enum class FLLCType { ConstantChord, VariableChord };
+
+static std::map<std::string, FLLCType> FLLCTypeMap{
+    {"constant_chord", FLLCType::ConstantChord},
+    {"variable_chord", FLLCType::VariableChord}};
+
 struct FLLCData
 {
     // constants
+    FLLCType correction_type{FLLCType::VariableChord};
     amrex::Real epsilon;
     amrex::Real relaxation_factor{0.1};
     RealList dr;

--- a/amr-wind/wind_energy/actuator/FLLC.cpp
+++ b/amr-wind/wind_energy/actuator/FLLC.cpp
@@ -45,6 +45,9 @@ void FLLCParse(const utils::ActParser& pp, FLLCData& data)
 {
     pp.query("epsilon", data.epsilon);
     pp.query("fllc_relaxation_factor", data.relaxation_factor);
+    std::string typeString = "variable_chord";
+    pp.query("fllc_type", typeString);
+    data.correction_type = FLLCTypeMap.at(typeString);
 
     if (!pp.contains("epsilon") || !pp.contains("epsilon_chord")) {
         amrex::Abort(

--- a/amr-wind/wind_energy/actuator/FLLCOp.H
+++ b/amr-wind/wind_energy/actuator/FLLCOp.H
@@ -17,10 +17,27 @@ struct FLLCOp
 {
     void operator()(ComponentView& data, FLLCData& fllc)
     {
-        namespace interp = ::amr_wind::interp;
         if (!fllc.initialized) {
             return;
         }
+        switch (fllc.correction_type) {
+        case FLLCType::ConstantChord: {
+            constant_chord(data, fllc);
+            break;
+        }
+        case FLLCType::VariableChord: {
+            variable_chord(data, fllc);
+            break;
+        }
+        default:
+            // this should be unreachable
+            throw std::runtime_error("Invalid FLLC type");
+        }
+    }
+
+    static void constant_chord(ComponentView& data, FLLCData& fllc)
+    {
+        namespace interp = ::amr_wind::interp;
 
         const int npts = static_cast<int>(fllc.correction_velocity.size());
         auto& du = fllc.correction_velocity;
@@ -130,6 +147,120 @@ struct FLLCOp
 
         /**
          * Step 5
+         * Interpolate back to vel positions if necessary
+         */
+        if (fllc.different_sizes) {
+            interp::linear(
+                fllc.span_distance_force, u_force_pnt_slice,
+                fllc.span_distance_vel, data.vel);
+        }
+    }
+
+    static void variable_chord(ComponentView& data, FLLCData& fllc)
+    {
+        namespace interp = ::amr_wind::interp;
+
+        const int npts = static_cast<int>(fllc.correction_velocity.size());
+        auto& du = fllc.correction_velocity;
+
+        auto& u_les = fllc.les_velocity;
+        auto& u_opt = fllc.optimal_velocity;
+        auto& G = fllc.lift;
+        VecSlice u_force_pnt_slice =
+            ::amr_wind::utils::slice(fllc.force_point_velocity, 0);
+        vs::Vector* vel_ptr = data.vel.data();
+
+        /**
+         * Step 0
+         * Linear interpolate velocity if force and vel points are mismatched
+         */
+        if (fllc.different_sizes) {
+            interp::linear(
+                fllc.span_distance_vel, data.vel, fllc.span_distance_force,
+                u_force_pnt_slice);
+            vel_ptr = u_force_pnt_slice.data();
+        }
+
+        /**
+         * Step 1
+         * Compute the lift force distribution (G)
+         */
+        for (int ip = 0; ip < npts; ++ip) {
+            const auto force = data.force[ip];
+            const auto vel = data.vel_rel[ip];
+            const auto dr = fllc.dr[ip];
+            const auto vmag =
+                std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
+            const auto vmag2 = vmag * vmag;
+
+            const auto fv = force & vel;
+
+            G[ip] = (force - vel * fv / vmag2) / dr;
+        }
+
+        /**
+         * Step 2
+         * Compute the induced velocities
+         */
+        for (int ip = 0; ip < npts; ++ip) {
+
+            const auto coefficient = 1.0 / (2.0 * amr_wind::utils::pi());
+
+            for (int jp = 0; jp < npts; ++jp) {
+
+                const auto eps_les = fllc.epsilon;
+                const auto eps_opt = fllc.optimal_epsilon[jp];
+                const auto eps_les2 = eps_les * eps_les;
+                const auto eps_opt2 = eps_opt * eps_opt;
+                const auto& vel = data.vel_rel[jp];
+                const auto vmag =
+                    std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
+                auto k_les = 0.;
+                auto k_opt = 0.;
+
+                if (ip == jp) {
+
+                    k_les = .5 / (eps_les2);
+                    k_opt = .5 / (eps_opt2);
+
+                }
+
+                else {
+
+                    const auto r_dis =
+                        vs::mag(data.vel_pos[ip] - data.vel_pos[jp]);
+                    auto exp_les = std::exp(-r_dis * r_dis / eps_les2);
+                    auto exp_opt = std::exp(-r_dis * r_dis / eps_opt2);
+
+                    k_les = exp_les / eps_les2 +
+                            1. / (2. * r_dis * r_dis) * (exp_les - 1.);
+                    k_opt = exp_opt / eps_opt2 +
+                            1. / (2. * r_dis * r_dis) * (exp_opt - 1.);
+                }
+
+                u_les[ip] = u_les[ip] +
+                            coefficient * G[jp] / vmag * k_les * fllc.dr[jp];
+                u_opt[ip] = u_opt[ip] +
+                            coefficient * G[jp] / vmag * k_opt * fllc.dr[jp];
+            }
+
+            // Relaxation to compute the induced velocity
+            const auto f = fllc.relaxation_factor;
+            du[ip] = (1. - f) * du[ip] + f * (u_opt[ip] - u_les[ip]);
+        }
+
+        /**
+         * Step 3
+         * Compute the induced velocity difference
+         */
+        for (int ip = 0; ip < npts; ++ip) {
+            vel_ptr[ip] = vel_ptr[ip] + du[ip];
+            u_les[ip] *= 0.0;
+            u_opt[ip] *= 0.0;
+        }
+
+        /**
+         * Step 4
          * Interpolate back to vel positions if necessary
          */
         if (fllc.different_sizes) {

--- a/docs/sphinx/user/inputs_Actuator.rst
+++ b/docs/sphinx/user/inputs_Actuator.rst
@@ -88,6 +88,23 @@ Example for ``FixedWingLine``::
   that would be greater than at least 2.5 times the grid size ``dx``.
   The default is `0`.
 
+.. input_param:: Actuator.FixedWingLine.fllc_type
+
+  **type:** String, optional
+
+  This option tells whether to use the original fllc formulation as outlined in
+  `Martinez-Tossas and Meneveau (2019) <https://doi.org/10.1017/jfm.2018.994>`_
+  which assumes a constant chord length across blade (`constant_chord`), or
+  to use a new forumlation which accounts for chord variations (`variable_chord`).
+
+.. input_param:: Actuator.FixedWingLine.fllc_relaxation_factor
+
+  **type:** Double
+
+  The relaxation factor to be applied to the updated velocity see:
+  `Martinez-Tossas and Meneveau (2019) <https://doi.org/10.1017/jfm.2018.994>`_
+  The default value is `0.1`.
+
 .. input_param:: Actuator.FixedWingLine.pitch
 
    **type:** Real number, optional
@@ -202,6 +219,14 @@ Example for ``TurbineFastLine``::
 .. input_param:: Actuator.TurbineFastLine.fllc
 
    Same as :input_param:`Actuator.FixedWingLine.fllc`.
+
+.. input_param:: Actuator.TurbineFastLine.fllc_relaxation_factor
+
+   Same as :input_param:`Actuator.FixedWingLine.fllc_relaxation_factor`.
+
+.. input_param:: Actuator.TurbineFastLine.fllc_type
+
+   Same as :input_param:`Actuator.FixedWingLine.fllc_type`.
 
 .. input_param:: Actuator.TurbineFastLine.openfast_start_time
 


### PR DESCRIPTION
Add the new formulation for the filtered lifting line correction that can account for variable chord length.

This PR preserves the original formulation we've been using, and it can be accessed by setting `fllc.fllc_type=constant_chord`.

The new formulation should be superior in most instances and is made the new default. 