### PR TITLE
Changes to velocity sampling in fixed wing

### DIFF
--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -93,7 +93,7 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
         amrex::Real src_force[AMREX_SPACEDIM]{0.0, 0.0, 0.0};
         for (int ip = 0; ip < npts; ++ip) {
             const auto dist = cc - pos[ip];
-            const auto dist_local = dist; //tmat[ip] & dist;
+            const auto dist_local = dist; // tmat[ip] & dist;
             const auto gauss_fac = utils::gaussian3d(dist_local, eps[ip]);
             const auto& pforce = force[ip];
 

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -93,7 +93,7 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
         amrex::Real src_force[AMREX_SPACEDIM]{0.0, 0.0, 0.0};
         for (int ip = 0; ip < npts; ++ip) {
             const auto dist = cc - pos[ip];
-            const auto dist_local = tmat[ip] & dist;
+            const auto dist_local = dist; //tmat[ip] & dist;
             const auto gauss_fac = utils::gaussian3d(dist_local, eps[ip]);
             const auto& pforce = force[ip];
 

--- a/amr-wind/wind_energy/actuator/FLLCOp.H
+++ b/amr-wind/wind_energy/actuator/FLLCOp.H
@@ -52,7 +52,8 @@ struct FLLCOp
         for (int ip = 0; ip < npts; ++ip) {
             const auto& tmat = data.orientation[ip];
             const auto force = data.force[ip];
-            const auto vel = (data.vel_rel[ip] & tmat);
+            //const auto vel = (data.vel_rel[ip] & tmat)-u_les[ip];
+            const auto vel = data.vel_rel[ip];
             const auto dr = fllc.dr[ip];
             const auto vmag =
                 std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
@@ -89,8 +90,9 @@ struct FLLCOp
                 const auto eps_opt = fllc.optimal_epsilon[jp];
                 const auto eps_les2 = eps_les * eps_les;
                 const auto eps_opt2 = eps_opt * eps_opt;
-
+//            const auto& tmat = data.orientation[jp];
                 const auto& vel = data.vel_rel[jp];
+//                const auto& vel = data.vel_rel[jp] & tmat;
                 const auto vmag =
                     std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
                 auto k_les = 0.;

--- a/amr-wind/wind_energy/actuator/FLLCOp.H
+++ b/amr-wind/wind_energy/actuator/FLLCOp.H
@@ -52,7 +52,7 @@ struct FLLCOp
         for (int ip = 0; ip < npts; ++ip) {
             const auto& tmat = data.orientation[ip];
             const auto force = data.force[ip];
-            const auto vel = data.vel_rel[ip] & tmat;
+            const auto vel = (data.vel_rel[ip] & tmat);
             const auto dr = fllc.dr[ip];
             const auto vmag =
                 std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
@@ -81,35 +81,45 @@ struct FLLCOp
          */
         for (int ip = 0; ip < npts; ++ip) {
 
-            const auto eps_les = fllc.epsilon;
-            const auto eps_opt = fllc.optimal_epsilon[ip];
+            const auto coefficient = 1.0 / (2.0 * amr_wind::utils::pi());
 
             for (int jp = 0; jp < npts; ++jp) {
 
-                if (ip == jp) {
-                    continue;
-                }
+                const auto eps_les = fllc.epsilon;
+                const auto eps_opt = fllc.optimal_epsilon[jp];
+                const auto eps_les2 = eps_les * eps_les;
+                const auto eps_opt2 = eps_opt * eps_opt;
 
-                const auto r_dis = vs::mag(data.vel_pos[ip] - data.vel_pos[jp]);
                 const auto& vel = data.vel_rel[jp];
                 const auto vmag =
                     std::max(vs::mag(vel), vs::DTraits<amrex::Real>::eps());
+                auto k_les = 0.;
+                auto k_opt = 0.;
 
-                auto coefficient =
-                    1.0 / (-4.0 * amr_wind::utils::pi() * r_dis * vmag);
-                const auto cLes =
-                    1.0 - std::exp(-r_dis * r_dis / (eps_les * eps_les));
-                const auto cOpt =
-                    1.0 - std::exp(-r_dis * r_dis / (eps_opt * eps_opt));
+                if (ip == jp) {
 
-                // The sign of the induced velocity depends on which side of the
-                // blade we are on
-                if (ip < jp) {
-                    coefficient *= -1;
+                    k_les = .5 / (eps_les2);
+                    k_opt = .5 / (eps_opt2);
+
                 }
 
-                u_les[ip] = u_les[ip] - dG[jp] * coefficient * cLes;
-                u_opt[ip] = u_opt[ip] - dG[jp] * coefficient * cOpt;
+                else {
+
+                    const auto r_dis =
+                        vs::mag(data.vel_pos[ip] - data.vel_pos[jp]);
+                    auto exp_les = std::exp(-r_dis * r_dis / eps_les2);
+                    auto exp_opt = std::exp(-r_dis * r_dis / eps_opt2);
+
+                    k_les = exp_les / eps_les2 +
+                            1. / (2. * r_dis * r_dis) * (exp_les - 1.);
+                    k_opt = exp_opt / eps_opt2 +
+                            1. / (2. * r_dis * r_dis) * (exp_opt - 1.);
+                }
+
+                u_les[ip] = u_les[ip] +
+                            coefficient * G[jp] / vmag * k_les * fllc.dr[jp];
+                u_opt[ip] = u_opt[ip] +
+                            coefficient * G[jp] / vmag * k_opt * fllc.dr[jp];
             }
 
             // Relaxation to compute the induced velocity

--- a/amr-wind/wind_energy/actuator/wing/ActuatorWing.H
+++ b/amr-wind/wind_energy/actuator/wing/ActuatorWing.H
@@ -25,6 +25,9 @@ struct WingBaseData
     //! Ending coordinate of the wing
     vs::Vector end;
 
+    //! The normal vector perpendicular to the span
+    vs::Vector blade_x{1.0, 0, 0};
+
     //! Gaussian smearing factor input by user
     vs::Vector eps_inp;
 

--- a/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
@@ -78,13 +78,15 @@ struct ReadInputsOp<FixedWing, ActSrcLine>
             amrex::max(p1.z(), p2.z()) + search_radius
         );
         // clang-format on
-//std::cout << "search_radius" << search_radius << std::endl;
-//std::cout << "xmin" << amrex::min(p1.x(), p2.x()) - search_radius  << std::endl;
-//std::cout << "ymin" << amrex::min(p1.y(), p2.y()) - search_radius  << std::endl;
-//std::cout << "zmin" << amrex::min(p1.z(), p2.z()) - search_radius  << std::endl;
-//std::cout << "xmax" << amrex::max(p1.x(), p2.x()) + search_radius  << std::endl;
-//std::cout << "ymax" << amrex::max(p1.y(), p2.y()) + search_radius  << std::endl;
-//std::cout << "zmax" << amrex::max(p1.z(), p2.z()) + search_radius  << std::endl;
+        // std::cout << "search_radius" << search_radius << std::endl;
+        // std::cout << "xmin" << amrex::min(p1.x(), p2.x()) - search_radius  <<
+        // std::endl; std::cout << "ymin" << amrex::min(p1.y(), p2.y()) -
+        // search_radius  << std::endl; std::cout << "zmin" << amrex::min(p1.z(),
+        // p2.z()) - search_radius  << std::endl; std::cout << "xmax" <<
+        // amrex::max(p1.x(), p2.x()) + search_radius  << std::endl; std::cout <<
+        // "ymax" << amrex::max(p1.y(), p2.y()) + search_radius  << std::endl;
+        // std::cout << "zmax" << amrex::max(p1.z(), p2.z()) + search_radius  <<
+        // std::endl;
     }
 };
 
@@ -103,7 +105,7 @@ struct InitDataOp<FixedWing, ActSrcLine>
             const auto wlen = vs::mag(grid.pos.back() - grid.pos.front());
             RealList wx(npts);
             for (int i = 0; i < npts; ++i) {
-                wx[i] = vs::mag(grid.pos[i]-grid.pos[0]) / wlen;
+                wx[i] = vs::mag(grid.pos[i] - grid.pos[0]) / wlen;
             }
             meta.chord.resize(npts);
             //::amr_wind::interp::linear_monotonic(

--- a/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
@@ -65,7 +65,7 @@ struct ReadInputsOp<FixedWing, ActSrcLine>
         amrex::Real max_epsc = *std::max_element(
             wdata.epsilon_chord.begin(), wdata.epsilon_chord.end());
         amrex::Real search_radius =
-            amrex::max(max_eps, max_epsc) * max_chord * 3.0;
+            amrex::max(max_eps, max_epsc * max_chord) * 12.0;
         const auto& p1 = wdata.start;
         const auto& p2 = wdata.end;
         // clang-format off
@@ -78,6 +78,13 @@ struct ReadInputsOp<FixedWing, ActSrcLine>
             amrex::max(p1.z(), p2.z()) + search_radius
         );
         // clang-format on
+//std::cout << "search_radius" << search_radius << std::endl;
+//std::cout << "xmin" << amrex::min(p1.x(), p2.x()) - search_radius  << std::endl;
+//std::cout << "ymin" << amrex::min(p1.y(), p2.y()) - search_radius  << std::endl;
+//std::cout << "zmin" << amrex::min(p1.z(), p2.z()) - search_radius  << std::endl;
+//std::cout << "xmax" << amrex::max(p1.x(), p2.x()) + search_radius  << std::endl;
+//std::cout << "ymax" << amrex::max(p1.y(), p2.y()) + search_radius  << std::endl;
+//std::cout << "zmax" << amrex::max(p1.z(), p2.z()) + search_radius  << std::endl;
     }
 };
 
@@ -96,10 +103,11 @@ struct InitDataOp<FixedWing, ActSrcLine>
             const auto wlen = vs::mag(grid.pos.back() - grid.pos.front());
             RealList wx(npts);
             for (int i = 0; i < npts; ++i) {
-                wx[i] = vs::mag(grid.pos[i]) / wlen;
+                wx[i] = vs::mag(grid.pos[i]-grid.pos[0]) / wlen;
             }
             meta.chord.resize(npts);
-            ::amr_wind::interp::linear_monotonic(
+            //::amr_wind::interp::linear_monotonic(
+            ::amr_wind::interp::linear(
                 meta.span_locs, meta.chord_inp, wx, meta.chord);
             // clang-format off
             meta.epsilon_chord = {

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -118,18 +118,61 @@ struct ComputeForceOp<
         amrex::Real total_lift = 0.0;
         amrex::Real total_drag = 0.0;
         for (int ip = 0; ip < npts; ++ip) {
-            const auto& tmat = grid.orientation[ip];
+//            const auto& tmat = grid.orientation[ip];
             // Effective velocity at the wing control point in local frame
-            auto wvel = tmat & grid.vel[ip];
+//            auto wvel = tmat & grid.vel[ip];
             // Set spanwise component to zero to get a pure 2D velocity
-            wvel.y() = 0.0;
+//            wvel.y() = 0.0;
 
-            const auto vmag = vs::mag(wvel);
-            const auto aoa = std::atan2(wvel.z(), wvel.x());
+            // Build the local reference frame
+            vs::Vector wspan = wdata.end - wdata.start;
+            wspan = wspan.unit();
+  
+            // Use the global coord to orient the blade
+            // This works only for inflow in the x direction
+            auto blade_x = wdata.blade_x;
+            auto blade_y = wspan;
+            auto blade_z = (blade_x^blade_y).unit();
+
+//std::cout << "blade_x" << std::endl;
+//std::cout << blade_x[0] << std::endl;
+//std::cout << blade_x[1] << std::endl;
+//std::cout << blade_x[2] << std::endl;
+//std::cout << "blade_y" << std::endl;
+//std::cout << blade_y[0] << std::endl;
+//std::cout << blade_y[1] << std::endl;
+//std::cout << blade_y[2] << std::endl;
+//std::cout << "blade_z" << std::endl;
+//std::cout << blade_z[0] << std::endl;
+//std::cout << blade_z[1] << std::endl;
+//std::cout << blade_z[2] << std::endl;
+
+// Quaternion used to rotate (x, y, z) onto blade local reference frame
+//auto uv = amr_wind::utils::degrees(1. + (local_y & wspan));
+//auto tmat2 = vs::quaternion(blade_y,  uv);
+// Rotate the other axes 
+//auto blade_x = tmat2 & local_x;
+//auto blade_z = tmat2 & local_z;
+
+
+
+//            const auto vmag = vs::mag(wvel);
+//            const auto aoa = std::atan2(wvel.z(), wvel.x());
+
+vs::Vector windvector;
+windvector[0] = grid.vel[ip] & blade_x;
+windvector[1] = 0; //grid.vel[ip] & blade_y;
+windvector[2] = grid.vel[ip] & blade_z;
+
+const auto vmag = vs::mag(windvector);
+//const auto aoa = amr_wind::utils::degrees(std::atan2(windvector[2], windvector[0])) + wdata.pitch;
+const auto aoa = std::atan2(windvector[2], windvector[0]) + amr_wind::utils::radians(wdata.pitch);
+//std::cout << aoa << std::endl;
+//std::cout << "Pitch " << wdata.pitch << std::endl;
 
             // Make up some Cl, Cd values
             amrex::Real cl, cd;
-            aflookup(aoa, cl, cd);
+            aflookup(aoa, cl, cd); // This function calls aoa in radians (-pi to pi) 
 
             // Assume unit chord
             const auto qval = 0.5 * vmag * vmag * chord[ip] * dx[ip];
@@ -137,14 +180,18 @@ struct ComputeForceOp<
             const auto drag = qval * cd;
             // Determine unit vector parallel and perpendicular to velocity
             // vector
-            const auto drag_dir = wvel.unit() & tmat;
-            const auto lift_dir = drag_dir ^ tmat.y();
+//            const auto drag_dir = wvel.unit() & tmat;
+//            const auto lift_dir = drag_dir ^ tmat.y();
+
+// Directions 
+const auto drag_dir = (blade_x * windvector.x() + blade_z * windvector.z() ).unit();
+const auto lift_dir = (drag_dir ^ blade_y).unit();
 
             // Compute force on fluid from this section of wing
             grid.force[ip] = -(lift_dir * lift + drag * drag_dir);
 
             // Assign values for output
-            wdata.vel_rel[ip] = wvel;
+            wdata.vel_rel[ip] = windvector;
             wdata.aoa[ip] = amr_wind::utils::degrees(aoa);
             wdata.cl[ip] = cl;
             wdata.cd[ip] = cd;

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -118,61 +118,64 @@ struct ComputeForceOp<
         amrex::Real total_lift = 0.0;
         amrex::Real total_drag = 0.0;
         for (int ip = 0; ip < npts; ++ip) {
-//            const auto& tmat = grid.orientation[ip];
+            //            const auto& tmat = grid.orientation[ip];
             // Effective velocity at the wing control point in local frame
-//            auto wvel = tmat & grid.vel[ip];
+            //            auto wvel = tmat & grid.vel[ip];
             // Set spanwise component to zero to get a pure 2D velocity
-//            wvel.y() = 0.0;
+            //            wvel.y() = 0.0;
 
             // Build the local reference frame
             vs::Vector wspan = wdata.end - wdata.start;
             wspan = wspan.unit();
-  
+
             // Use the global coord to orient the blade
             // This works only for inflow in the x direction
             auto blade_x = wdata.blade_x;
             auto blade_y = wspan;
-            auto blade_z = (blade_x^blade_y).unit();
+            auto blade_z = (blade_x ^ blade_y).unit();
 
-//std::cout << "blade_x" << std::endl;
-//std::cout << blade_x[0] << std::endl;
-//std::cout << blade_x[1] << std::endl;
-//std::cout << blade_x[2] << std::endl;
-//std::cout << "blade_y" << std::endl;
-//std::cout << blade_y[0] << std::endl;
-//std::cout << blade_y[1] << std::endl;
-//std::cout << blade_y[2] << std::endl;
-//std::cout << "blade_z" << std::endl;
-//std::cout << blade_z[0] << std::endl;
-//std::cout << blade_z[1] << std::endl;
-//std::cout << blade_z[2] << std::endl;
+            // std::cout << "blade_x" << std::endl;
+            // std::cout << blade_x[0] << std::endl;
+            // std::cout << blade_x[1] << std::endl;
+            // std::cout << blade_x[2] << std::endl;
+            // std::cout << "blade_y" << std::endl;
+            // std::cout << blade_y[0] << std::endl;
+            // std::cout << blade_y[1] << std::endl;
+            // std::cout << blade_y[2] << std::endl;
+            // std::cout << "blade_z" << std::endl;
+            // std::cout << blade_z[0] << std::endl;
+            // std::cout << blade_z[1] << std::endl;
+            // std::cout << blade_z[2] << std::endl;
 
-// Quaternion used to rotate (x, y, z) onto blade local reference frame
-//auto uv = amr_wind::utils::degrees(1. + (local_y & wspan));
-//auto tmat2 = vs::quaternion(blade_y,  uv);
-// Rotate the other axes 
-//auto blade_x = tmat2 & local_x;
-//auto blade_z = tmat2 & local_z;
+            // Quaternion used to rotate (x, y, z) onto blade local reference
+            // frame
+            // auto uv = amr_wind::utils::degrees(1. + (local_y & wspan));
+            // auto tmat2 = vs::quaternion(blade_y,  uv);
+            // Rotate the other axes
+            // auto blade_x = tmat2 & local_x;
+            // auto blade_z = tmat2 & local_z;
 
+            //            const auto vmag = vs::mag(wvel);
+            //            const auto aoa = std::atan2(wvel.z(), wvel.x());
 
+            vs::Vector windvector;
+            windvector[0] = grid.vel[ip] & blade_x;
+            windvector[1] = 0; // grid.vel[ip] & blade_y;
+            windvector[2] = grid.vel[ip] & blade_z;
 
-//            const auto vmag = vs::mag(wvel);
-//            const auto aoa = std::atan2(wvel.z(), wvel.x());
-
-vs::Vector windvector;
-windvector[0] = grid.vel[ip] & blade_x;
-windvector[1] = 0; //grid.vel[ip] & blade_y;
-windvector[2] = grid.vel[ip] & blade_z;
-
-const auto vmag = vs::mag(windvector);
-//const auto aoa = amr_wind::utils::degrees(std::atan2(windvector[2], windvector[0])) + wdata.pitch;
-const auto aoa = std::atan2(windvector[2], windvector[0]) + amr_wind::utils::radians(wdata.pitch);
-//std::cout << aoa << std::endl;
-//std::cout << "Pitch " << wdata.pitch << std::endl;
+            const auto vmag = vs::mag(windvector);
+            // const auto aoa =
+            // amr_wind::utils::degrees(std::atan2(windvector[2], windvector[0]))
+            // + wdata.pitch;
+            const auto aoa = std::atan2(windvector[2], windvector[0]) +
+                             amr_wind::utils::radians(wdata.pitch);
+            // std::cout << aoa << std::endl;
+            // std::cout << "Pitch " << wdata.pitch << std::endl;
 
             // Make up some Cl, Cd values
             amrex::Real cl, cd;
-            aflookup(aoa, cl, cd); // This function calls aoa in radians (-pi to pi) 
+            aflookup(
+                aoa, cl, cd); // This function calls aoa in radians (-pi to pi)
 
             // Assume unit chord
             const auto qval = 0.5 * vmag * vmag * chord[ip] * dx[ip];
@@ -180,12 +183,13 @@ const auto aoa = std::atan2(windvector[2], windvector[0]) + amr_wind::utils::rad
             const auto drag = qval * cd;
             // Determine unit vector parallel and perpendicular to velocity
             // vector
-//            const auto drag_dir = wvel.unit() & tmat;
-//            const auto lift_dir = drag_dir ^ tmat.y();
+            //            const auto drag_dir = wvel.unit() & tmat;
+            //            const auto lift_dir = drag_dir ^ tmat.y();
 
-// Directions 
-const auto drag_dir = (blade_x * windvector.x() + blade_z * windvector.z() ).unit();
-const auto lift_dir = (drag_dir ^ blade_y).unit();
+            // Directions
+            const auto drag_dir =
+                (blade_x * windvector.x() + blade_z * windvector.z()).unit();
+            const auto lift_dir = (drag_dir ^ blade_y).unit();
 
             // Compute force on fluid from this section of wing
             grid.force[ip] = -(lift_dir * lift + drag * drag_dir);

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.cpp
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.cpp
@@ -106,6 +106,7 @@ void prepare_netcdf_file(
     grp.def_var("integrated_drag", NC_DOUBLE, {nt_name});
     grp.def_var("xyz", NC_DOUBLE, {np_name, "ndim"});
     grp.def_var("chord", NC_DOUBLE, {np_name});
+    grp.def_var("epsilon", NC_DOUBLE, {np_name, "ndim"});
     grp.def_var("dx", NC_DOUBLE, {np_name});
     grp.def_var("veff", NC_DOUBLE, {nt_name, np_name, "ndim"});
     grp.def_var("vrel", NC_DOUBLE, {nt_name, np_name, "ndim"});
@@ -123,6 +124,8 @@ void prepare_netcdf_file(
         xyz.put(&(grid.pos[0][0]), start, count);
         auto chord = grp.var("chord");
         chord.put(&(meta.chord[0]), {0}, {npts});
+        auto epsilon = grp.var("epsilon");
+        epsilon.put(&(grid.epsilon[0][0]), {0, 0}, {npts, AMREX_SPACEDIM});
         auto dx = grp.var("dx");
         dx.put(&(meta.dx[0]), {0}, {npts});
     }


### PR DESCRIPTION
I am trying a different approach to do velocity sampling in the fixed wing ALM. We noticed that the projections of the velocity on the actuator points were not consistent with the definitions we have used before. These changes follow the standard approach in [SOWFA](https://github.com/NREL/SOWFA-6/blob/c255cb5ccdd838bf912036a60345adb531f05f27/src/turbineModels/turbineModelsStandard/horizontalAxisWindTurbinesALM/horizontalAxisWindTurbinesALM.C#L1123). 

I am looking for feedback on these changes.