### PR TITLE
bug fix for fixed wings with non-uniform chord

### DIFF
--- a/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
@@ -96,7 +96,7 @@ struct InitDataOp<FixedWing, ActSrcLine>
             const auto wlen = vs::mag(grid.pos.back() - grid.pos.front());
             RealList wx(npts);
             for (int i = 0; i < npts; ++i) {
-                wx[i] = vs::mag(grid.pos[i]) / wlen;
+                wx[i] = vs::mag(grid.pos[i] - grid.pos[0]) / wlen;
             }
             meta.chord.resize(npts);
             ::amr_wind::interp::linear_monotonic(


### PR DESCRIPTION
This bug fix ensures that the interpolation of the wing goes from the root to the tip, allowing for placement of the wing in any part of the domain and correct interpolation of chord values.