### PR TITLE
Fixing mueff in ABLStats output

### DIFF
--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -89,6 +89,7 @@ void ABLStats::calc_averages()
     m_pa_temp();
     m_pa_vel_fine();
     m_pa_temp_fine();
+    m_pa_mueff();
 }
 
 //! Calculate sfs stress averages


### PR DESCRIPTION
The plane averages were not being populated for `mueff`. This fixes 0s in the netcdf stats output for `mueff`. 