### PR TITLE
Align starting index of plt and chk

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -234,6 +234,9 @@ void SimTime::set_restart_time(int tidx, amrex::Real time)
     m_new_time = time;
     m_cur_time = time;
     m_start_time = time;
+
+    m_chkpt_start_index = m_start_time_index;
+    m_plt_start_index   = m_start_time_index;
 }
 
 } // namespace amr_wind


### PR DESCRIPTION
Checkpoint starting index was not being taken into consideration when a restarted run was executed. It resulted in the first checkpoint index not being the starting index plus the checkpoint interval. With the recent OpenFAST restart capability (PR #807), that resulted in OpenFAST checkpoints that were _not_ aligned with AMR-Wind checkpoints, rendering the restart capability worthless in this scenario. Related: PR #488.