### PR TITLE
change member variable to reflect default diffusion type of Crank_Nicolson

### DIFF
--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -177,7 +177,7 @@ private:
     //! number of cells on all levels including covered cells
     amrex::Long m_cell_count{-1};
 
-    DiffusionType m_diff_type = DiffusionType::Implicit;
+    DiffusionType m_diff_type = DiffusionType::Crank_Nicolson;
 
     //
     // end of member variables


### PR DESCRIPTION
changing the member variable for consistent readability of the code. The default diffusion type is set in `setup/init.cpp`.
P.S. - https://github.com/Exawind/amr-wind/blob/main/amr-wind/setup/init.cpp#L34