### PR TITLE
Use start time index as default value for checkpoint, plot, and regrid start upon restart

### DIFF
--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -230,6 +230,15 @@ void SimTime::set_restart_time(int tidx, amrex::Real time)
 {
     m_time_index = tidx;
     m_start_time_index = tidx;
+    m_regrid_start_index = tidx;
+    m_plt_start_index = tidx;
+    m_chkpt_start_index = tidx;
+
+    // check if the user has set plt/regrid/checkpoint index
+    amrex::ParmParse pp("time");
+    pp.query("regrid_start", m_regrid_start_index);
+    pp.query("plot_start", m_plt_start_index);
+    pp.query("checkpoint_start", m_chkpt_start_index);
 
     m_new_time = time;
     m_cur_time = time;

--- a/docs/sphinx/user/inputs_time.rst
+++ b/docs/sphinx/user/inputs_time.rst
@@ -85,21 +85,21 @@ This section deals with parameters that control the simulation.
    
 .. input_param:: time.regrid_start
 
-  **type:** Integer, optional, default = 0
+  **type:** Integer, optional, default = 0; default = start index upon restart
 
   This user-specified parameter sets the base timestep onwards which the mesh is adaptively
   refined.
 
 .. input_param:: time.plot_start
 
-  **type:** Integer, optional, default = 0
+  **type:** Integer, optional, default = 0; default = start index upon restart
 
   This user-specified parameter sets the base timestep onwards which the output (plot files)
   are written to the disk.
 
 .. input_param:: time.checkpoint_start
 
-  **type:** Integer, optional, default = 0
+  **type:** Integer, optional, default = 0; default = start index upon restart
 
   This user-specified parameter sets the base timestep onwards which the checkpoint (restart) 
   files are written to the disk.


### PR DESCRIPTION
See #840 and #845

Any "more elegant" ideas are welcome. 

P.S. - This is currently inconsistent with Nalu-Wind behavior which acts on multiples of output/restart frequency. 