### PR TITLE
Fix rotor rotation direction for Joukowski ADM

### DIFF
--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -225,7 +225,9 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 const auto point_current = grid.pos[ip];
 
                 // TODO add sign convention for rotation (+/- RPM)
-                const auto theta_vec = utils::compute_tangential_vector(
+                // Negative sign on theta_vec means turbine is rotating
+                // clockwise when standing upstream looking downstream
+                const auto theta_vec = -utils::compute_tangential_vector(
                     ddata.center, ddata.normal_vec, point_current);
 
                 // normal vec by definition is opposite of the wind direction


### PR DESCRIPTION
This commit addresses issue [821](https://github.com/Exawind/amr-wind/issues/821).

It should make it so that the turbine rotor spins in the clockwise direction when upstream looking downstream at the turbine, and the swirl in the wake is consistent with OpenFAST wakes.  I ran it on a test case and confirmed that:
1. The wake swirl goes in the right direction
2. Turbine power is unaffected.

For future reference, if you're upstream looking downstream at the turbine, use the _left_-handed rule for determining the direction of turbine rotation.