### PR TITLE
Rudimentary approach to sharpening the VOF data from Nalu-Wind

### DIFF
--- a/amr-wind/equation_systems/vof/vof_advection.H
+++ b/amr-wind/equation_systems/vof/vof_advection.H
@@ -3,6 +3,7 @@
 #define VOF_ADVECTION_H
 
 #include "amr-wind/equation_systems/vof/vof.H"
+#include "amr-wind/equation_systems/vof/vof_hybridsolver_ops.H"
 #include "amr-wind/equation_systems/vof/SplitAdvection.H"
 
 namespace amr_wind::pde {
@@ -50,8 +51,8 @@ struct AdvectionOp<VOF, fvm::Godunov>
         // cppcheck-suppress constVariable
         auto& dof_field = fields.field;
         //
-        // Advect volume using either the Explicit Lagrangian onto-cell or
-        // Implicit Eulerian Sweeping method with PLIC reconstruction
+        // Advect volume using Implicit Eulerian Sweeping method with PLIC
+        // reconstruction
         //
 
         auto flux_x =
@@ -85,6 +86,12 @@ struct AdvectionOp<VOF, fvm::Godunov>
             advas[lev][2] = &aa_z(lev);
         }
 
+        // Sharpen acquired vof field if hybrid solver is being used
+        if (repo.int_field_exists("iblank_cell")) {
+            auto& f_iblank = repo.get_int_field("iblank_cell");
+            amr_wind::multiphase::sharpen_acquired_vof(
+                nlevels, f_iblank, dof_field);
+        }
         // Split advection step 1, with cmask calculation
         multiphase::split_advection_step(
             isweep, 0, nlevels, dof_field, fluxes, (*fluxC), advas, u_mac,

--- a/amr-wind/equation_systems/vof/vof_hybridsolver_ops.H
+++ b/amr-wind/equation_systems/vof/vof_hybridsolver_ops.H
@@ -1,0 +1,50 @@
+#ifndef VOF_HYBRIDSOLVER_OPS_H_
+#define VOF_HYBRIDSOLVER_OPS_H_
+
+#include <AMReX_FArrayBox.H>
+#include "amr-wind/core/FieldRepo.H"
+#include <cmath>
+
+namespace amr_wind::multiphase {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sharpen_kernel(
+    int i,
+    int j,
+    int k,
+    amrex::Array4<amrex::Real const> const& volfrac) noexcept
+{
+    return std::max(
+        0.0,
+        std::min(
+            1.0,
+            0.5 + (volfrac(i, j, k) < 0.5 ? -1.0 : 1.0) *
+                      std::pow(std::abs(volfrac(i, j, k) - 0.5), 1.0 / 3.0)));
+}
+
+void sharpen_acquired_vof(
+    const int nlevels, amr_wind::IntField& f_iblank, amr_wind::Field& f_vof)
+{
+    // Sharpen data from nalu-wind (in iblank regions)
+    for (int lev = 0; lev < nlevels; ++lev) {
+        auto& iblank = f_iblank(lev);
+        auto& vof = f_vof(lev);
+
+        for (amrex::MFIter mfi(iblank); mfi.isValid(); ++mfi) {
+            const auto& gbx = mfi.growntilebox();
+            const amrex::Array4<const int>& native_flag =
+                iblank.const_array(mfi);
+            const amrex::Array4<amrex::Real>& volfrac = vof.array(mfi);
+            amrex::ParallelFor(
+                gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    // In iblanked regions, sharpen VOF and limit it
+                    volfrac(i, j, k) = (native_flag(i, j, k) > 0)
+                                           ? volfrac(i, j, k)
+                                           : sharpen_kernel(i, j, k, volfrac);
+                });
+        }
+    }
+}
+
+} // namespace amr_wind::multiphase
+
+#endif // VOF_HYBRIDSOLVER_OPS.H

--- a/amr-wind/equation_systems/vof/vof_hybridsolver_ops.H
+++ b/amr-wind/equation_systems/vof/vof_hybridsolver_ops.H
@@ -21,7 +21,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real sharpen_kernel(
                       std::pow(std::abs(volfrac(i, j, k) - 0.5), 1.0 / 3.0)));
 }
 
-void sharpen_acquired_vof(
+static void sharpen_acquired_vof(
     const int nlevels, amr_wind::IntField& f_iblank, amr_wind::Field& f_vof)
 {
     // Sharpen data from nalu-wind (in iblank regions)

--- a/unit_tests/multiphase/test_vof_tools.cpp
+++ b/unit_tests/multiphase/test_vof_tools.cpp
@@ -3,6 +3,7 @@
 #include "aw_test_utils/test_utils.H"
 #include "amr-wind/utilities/trig_ops.H"
 #include "amr-wind/equation_systems/vof/volume_fractions.H"
+#include "amr-wind/equation_systems/vof/vof_hybridsolver_ops.H"
 
 namespace amr_wind_tests {
 
@@ -199,6 +200,49 @@ amrex::Real interface_band_test_impl(amr_wind::Field& vof)
     return error_total;
 }
 
+amrex::Real sharpen_test_impl(amr_wind::Field& vof)
+{
+    amrex::Real error_total = 0;
+
+    for (int lev = 0; lev < vof.repo().num_active_levels(); ++lev) {
+
+        error_total += amrex::ReduceSum(
+            vof(lev), 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& bx,
+                amrex::Array4<amrex::Real const> const& vof_arr)
+                -> amrex::Real {
+                amrex::Real error = 0;
+
+                amrex::Loop(bx, [=, &error](int i, int j, int k) noexcept {
+                    // Initial VOF distribution is 0, 0.3, or 1.0
+                    // Expected answer based on implementation of
+                    // amr_wind::multiphase::sharpen_kernel
+                    amrex::Real vof_answer = 0.0;
+                    if (i + j + k > 5) {
+                        // because VOF < 0.5
+                        const amrex::Real sign = -1.0;
+                        const amrex::Real delta = std::abs(0.3 - 0.5);
+                        vof_answer = 0.5 + sign * std::pow(delta, 1.0 / 3.0);
+                    }
+                    // Set up a liquid cell
+                    if (i == 0 && j == 0 && k == 0) {
+                        vof_answer = 1.0;
+                    }
+
+                    // Limit answer to VOF bounds
+                    vof_answer = std::max(0.0, std::min(1.0, vof_answer));
+
+                    // Difference between actual and expected
+                    error += std::abs(vof_arr(i, j, k) - vof_answer);
+                });
+
+                return error;
+            });
+    }
+    return error_total;
+}
+
 } // namespace
 
 TEST_F(VOFToolTest, interface_band)
@@ -257,6 +301,37 @@ TEST_F(VOFToolTest, levelset_to_vof)
     error_total = levelset_to_vof_test_impl(dx, levelset);
     amrex::ParallelDescriptor::ReduceRealSum(error_total);
     EXPECT_NEAR(error_total, 0.0, 0.016);
+}
+
+TEST_F(VOFToolTest, sharpen_acquired_vof)
+{
+
+    populate_parameters();
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<int> periodic{{0, 0, 0}};
+        pp.addarr("is_periodic", periodic);
+    }
+
+    initialize_mesh();
+
+    auto& repo = sim().repo();
+    const int ncomp = 1;
+    const int nghost = 3;
+    const int nghost_int = 1;
+    auto& vof = repo.declare_field("vof", ncomp, nghost);
+    auto& iblank = repo.declare_int_field("iblank_cell", ncomp, nghost_int);
+
+    // Use as if entire domain is from nalu
+    iblank.setVal(-1);
+    // Initialize and sharpen vof
+    init_vof(vof);
+    amr_wind::multiphase::sharpen_acquired_vof(1, iblank, vof);
+
+    // Check results
+    amrex::Real error_total = sharpen_test_impl(vof);
+    amrex::ParallelDescriptor::ReduceRealSum(error_total);
+    EXPECT_NEAR(error_total, 0.0, 1e-15);
 }
 
 } // namespace amr_wind_tests

--- a/unit_tests/multiphase/test_vof_tools.cpp
+++ b/unit_tests/multiphase/test_vof_tools.cpp
@@ -80,6 +80,9 @@ void initialize_volume_fractions(
         if (i + j + k > 5) {
             vof_arr(i, j, k) = 0.3;
         }
+        if (i + j + k > 10) {
+            vof_arr(i, j, k) = 0.7;
+        }
         // Set up a liquid cell
         if (i == 0 && j == 0 && k == 0) {
             vof_arr(i, j, k) = 1.0;
@@ -215,7 +218,7 @@ amrex::Real sharpen_test_impl(amr_wind::Field& vof)
                 amrex::Real error = 0;
 
                 amrex::Loop(bx, [=, &error](int i, int j, int k) noexcept {
-                    // Initial VOF distribution is 0, 0.3, or 1.0
+                    // Initial VOF distribution is 0, 0.3, 0.7, or 1.0
                     // Expected answer based on implementation of
                     // amr_wind::multiphase::sharpen_kernel
                     amrex::Real vof_answer = 0.0;
@@ -223,6 +226,12 @@ amrex::Real sharpen_test_impl(amr_wind::Field& vof)
                         // because VOF < 0.5
                         const amrex::Real sign = -1.0;
                         const amrex::Real delta = std::abs(0.3 - 0.5);
+                        vof_answer = 0.5 + sign * std::pow(delta, 1.0 / 3.0);
+                    }
+                    if (i + j + k > 10) {
+                        // because VOF > 0.5
+                        const amrex::Real sign = 1.0;
+                        const amrex::Real delta = std::abs(0.7 - 0.5);
                         vof_answer = 0.5 + sign * std::pow(delta, 1.0 / 3.0);
                     }
                     // Set up a liquid cell


### PR DESCRIPTION
VOF data from Nalu-Wind is too smoothed out for the methods/assumptions of the AMR-Wind solver. This simple approach, which locally sharpens the VOF distribution acquired from Nalu-Wind (iblank < 0) allows for improved accuracy and can be updated with a more complex kernel in the future.