### PR TITLE
Fix box type in abl boundary plane input for MAC vel

### DIFF
--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -905,6 +905,9 @@ void ABLBoundaryPlane::populate_data(
             auto sbx = mfi.growntilebox(1);
             if (!sbx.cellCentered()) {
                 sbx.enclosedCells();
+                if (ori.isHigh()) {
+                    sbx += amrex::IntVect::TheDimensionVector(ori.coordDir());
+                }
             }
             const auto& src = m_in_data.interpolate_data(ori, lev);
             const auto& bx = sbx & src.box();

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -902,7 +902,10 @@ void ABLBoundaryPlane::populate_data(
         for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();
              ++mfi) {
 
-            const auto& sbx = mfi.growntilebox(1);
+            auto sbx = mfi.growntilebox(1);
+            if (!sbx.cellCentered()) {
+                sbx.enclosedCells();
+            }
             const auto& src = m_in_data.interpolate_data(ori, lev);
             const auto& bx = sbx & src.box();
             if (bx.isEmpty()) {

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -894,6 +894,11 @@ void ABLBoundaryPlane::populate_data(
             amrex::Abort("No inflow data at this level.");
         }
 
+        if (ori.isHigh()) {
+            amrex::Warning(
+                "We typically don't inflow boundary planes on the high side.");
+        }
+
         const size_t nc = mfab.nComp();
 
 #ifdef AMREX_USE_OMP
@@ -905,9 +910,6 @@ void ABLBoundaryPlane::populate_data(
             auto sbx = mfi.growntilebox(1);
             if (!sbx.cellCentered()) {
                 sbx.enclosedCells();
-                if (ori.isHigh()) {
-                    sbx += amrex::IntVect::TheDimensionVector(ori.coordDir());
-                }
             }
             const auto& src = m_in_data.interpolate_data(ori, lev);
             const auto& bx = sbx & src.box();


### PR DESCRIPTION
MAC vel aren't cell centered so when using `fillpatch_sibling_fields`, the mfab for the mac vel wouldn't have the right box type compared to the inflow data. This would only get caught on a debug build and, because of the way we run things, I expect this to have no effect on current solutions.