### PR TITLE
Implicit treatment of source terms for SST and IDDES

### DIFF
--- a/amr-wind/turbulence/RANS/KOmegaSST.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSST.cpp
@@ -197,12 +197,13 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
 
                     const amrex::Real diss_amb =
                         beta_star * rho_arr(i, j, k) * sdr_amb * tke_amb;
+
                     diss_arr(i, j, k) = -beta_star * rho_arr(i, j, k) *
                                             tke_arr(i, j, k) *
                                             sdr_arr(i, j, k) +
                                         diss_amb;
 
-                    tke_lhs_arr(i, j, k) = 0.5 * beta_star * rho_arr(i, j, k) *
+                    tke_lhs_arr(i, j, k) = beta_star * rho_arr(i, j, k) *
                                            sdr_arr(i, j, k) * deltaT;
 
                     // For SDR equation:
@@ -221,6 +222,8 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
 
                     if (diff_type == DiffusionType::Crank_Nicolson) {
 
+                        tke_lhs_arr(i, j, k) = 0.5 * tke_lhs_arr(i, j, k);
+
                         sdr_src_arr(i, j, k) = production_omega;
 
                         sdr_diss_arr(i, j, k) = cross_diffusion;
@@ -230,8 +233,21 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                              0.5 * std::abs(cross_diffusion) /
                                  (sdr_arr(i, j, k) + 1e-15)) *
                             deltaT;
-                    } else {
+                    } else if (diff_type == DiffusionType::Implicit) {
 
+                        diss_arr(i, j, k) = 0.0;
+
+                        sdr_src_arr(i, j, k) = production_omega;
+
+                        sdr_diss_arr(i, j, k) = 0.0;
+
+                        sdr_lhs_arr(i, j, k) =
+                            (2.0 * rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
+                             std::abs(cross_diffusion) /
+                                 (sdr_arr(i, j, k) + 1e-15)) *
+                            deltaT;
+
+                    } else {
                         sdr_src_arr(i, j, k) =
                             production_omega + cross_diffusion;
 

--- a/amr-wind/turbulence/RANS/KOmegaSST.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSST.cpp
@@ -234,7 +234,8 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                                  (sdr_arr(i, j, k) + 1e-15)) *
                             deltaT;
                     } else if (diff_type == DiffusionType::Implicit) {
-
+                        /* Source term linearization is based on Florian
+                           Menter's (1993) AIAA paper */
                         diss_arr(i, j, k) = 0.0;
 
                         sdr_src_arr(i, j, k) = production_omega;

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -286,7 +286,8 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                             deltaT;
 
                     } else if (diff_type == DiffusionType::Implicit) {
-
+                        /* Source term linearization is based on Florian
+                           Menter's (1993) AIAA paper */
                         diss_arr(i, j, k) = 0.0;
 
                         sdr_src_arr(i, j, k) = production_omega;

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -251,7 +251,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                                             tke_arr(i, j, k) / l_iddes +
                                         diss_amb;
 
-                    tke_lhs_arr(i, j, k) = 0.5 * rho_arr(i, j, k) *
+                    tke_lhs_arr(i, j, k) = rho_arr(i, j, k) *
                                            std::sqrt(tke_arr(i, j, k)) /
                                            l_iddes * deltaT;
 
@@ -273,6 +273,8 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
 
                     if (diff_type == DiffusionType::Crank_Nicolson) {
 
+                        tke_lhs_arr(i, j, k) = 0.5 * tke_lhs_arr(i, j, k);
+
                         sdr_src_arr(i, j, k) = production_omega;
 
                         sdr_diss_arr(i, j, k) = cross_diffusion;
@@ -283,6 +285,19 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                                  (sdr_arr(i, j, k) + 1e-15)) *
                             deltaT;
 
+                    } else if (diff_type == DiffusionType::Implicit) {
+
+                        diss_arr(i, j, k) = 0.0;
+
+                        sdr_src_arr(i, j, k) = production_omega;
+
+                        sdr_diss_arr(i, j, k) = 0.0;
+
+                        sdr_lhs_arr(i, j, k) =
+                            (2.0 * rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
+                             std::abs(cross_diffusion) /
+                                 (sdr_arr(i, j, k) + 1e-15)) *
+                            deltaT;
                     } else {
                         sdr_src_arr(i, j, k) =
                             production_omega + cross_diffusion;


### PR DESCRIPTION
Modified _KOmegaSST.cpp_ and _KOmegaSSTIDDES.cpp_ files to incorporate fully implicit treatment of source terms. The formulation is based on Menter's 1993 paper.
[Implicit_Source_Terms_for_RANS.pdf](https://github.com/Exawind/amr-wind/files/11900129/Implicit_Source_Terms_for_RANS.pdf)