### PR TITLE
Limiting option for IDDES-SDR production term

### DIFF
--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -94,8 +94,6 @@ protected:
     amrex::Real m_buoyancy_factor = 0.0;
     amrex::Real m_sigma_t{0.85};
     amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
-
-    DiffusionType m_diff_type = DiffusionType::Crank_Nicolson;
 };
 
 } // namespace amr_wind::turbulence

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.H
@@ -60,6 +60,7 @@ protected:
     amrex::Real m_Ct{1.87};
     amrex::Real m_Cw{0.15};
     amrex::Real m_kappa{0.41};
+    amrex::Real m_sdr_prod_clip_factor{10.0};
 };
 
 } // namespace amr_wind::turbulence

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -38,6 +38,7 @@ void KOmegaSSTIDDES<Transport>::parse_model_coeffs()
     pp.query("Ct", this->m_Ct);
     pp.query("Cw", this->m_Cw);
     pp.query("kappa", this->m_kappa);
+    pp.query("sdr_prod_clip_factor", this->m_sdr_prod_clip_factor);
 }
 
 template <typename Transport>
@@ -63,7 +64,8 @@ TurbulenceModel::CoeffsDictType KOmegaSSTIDDES<Transport>::model_coeffs() const
         {"Cl", this->m_Cl},
         {"Ct", this->m_Ct},
         {"Cw", this->m_Cw},
-        {"kappa", this->m_kappa}};
+        {"kappa", this->m_kappa},
+        {"sdr_prod_clip_factor", this->m_sdr_prod_clip_factor}};
 }
 
 template <typename Transport>
@@ -90,6 +92,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
     const amrex::Real Ct = this->m_Ct;
     const amrex::Real Cw = this->m_Cw;
     const amrex::Real kappa = this->m_kappa;
+    const amrex::Real sdr_prod_clip_factor = this->m_sdr_prod_clip_factor;
 
     auto& mu_turb = this->mu_turb();
     auto lam_mu = (this->m_transport).mu();
@@ -260,7 +263,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                         rho_arr(i, j, k) * alpha *
                         amrex::min<amrex::Real>(
                             tmp4 * tmp4,
-                            10.0 *
+                            sdr_prod_clip_factor *
                                 amrex::max<amrex::Real>(sdr_arr(i, j, k), 0.0) *
                                 std::sqrt(tke_arr(i, j, k)) / l_iddes);
 


### PR DESCRIPTION
A user-defined clipping parameter option(epsilon) is introduced into the omega production term:
<img width="196" alt="image" src="https://github.com/Exawind/amr-wind/assets/96149491/57ea620f-aeeb-4b1f-b0d4-137a64951a8b">

It can be set as follows:
`KOmegaSSTIDDES_coeffs.sdr_prod_clip_factor = 10.0`

Advantages:
- Using values less than 10.0 (default) provides additional stability to the solver by lowering the threshold of production term. 
- Based on numerical experiments, the clipping needs to be activated for deep stall turbine simulations combined with highly refined meshes. 
- Activating the clipping did not have an effect on the magnitude of kinetic energy production and overall solution.

Recommendation:
- For runs with convergence issues, the recommendation is to repeatedly lower the factor by an order of magnitude until SDR residuals converge.
