### PR TITLE
Added flag to ensure that we are first time-step when using mac velocity

### DIFF
--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -188,7 +188,8 @@ void Actuator::update_positions()
     m_container->update_positions();
 
     // Sample velocities at the new locations
-    if (m_sample_nmhalf) {
+    if (m_sample_nmhalf &
+        (m_sim.time().current_time() > m_sim.time().start_time())) {
         const auto& umac = m_sim.repo().get_field("u_mac");
         const auto& vmac = m_sim.repo().get_field("v_mac");
         const auto& wmac = m_sim.repo().get_field("w_mac");


### PR DESCRIPTION
This ensures that the mac velocities are only used after the first time-step. 
The mac velocities are zero during the first time-step and that has led to problem with the ROSCO turbine controller.

Fixes this bug: https://github.com/Exawind/amr-wind/issues/888