### PR TITLE
FastIFace: check for positive chkpt_interval before output

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -160,7 +160,8 @@ void FastIface::advance_turbine(const int local_id)
         fast_func(FAST_OpFM_Step, &fi.tid_local);
     }
 
-    if ((fi.time_index / fi.num_substeps) % fi.chkpt_interval == 0) {
+    if (fi.chkpt_interval > 0 &&
+        (fi.time_index / fi.num_substeps) % fi.chkpt_interval == 0) {
         char rst_file[fast_strlen()];
         copy_filename(" ", rst_file);
         fast_func(FAST_CreateCheckpoint, &fi.tid_local, rst_file);


### PR DESCRIPTION
allows checkpointing to be properly turned off if desired. a future PR should also allow for use of checkpoint time interval.