### PR TITLE
Fix typo (?) in Hypre::Interface

### DIFF
--- a/amr-wind/core/MLMGOptions.cpp
+++ b/amr-wind/core/MLMGOptions.cpp
@@ -94,7 +94,7 @@ void MLMGOptions::operator()(amrex::MLMG& mlmg)
         if (hypre_interface == "ij")
             mlmg.setHypreInterface(amrex::Hypre::Interface::ij);
         else if (hypre_interface == "semi_structured")
-            mlmg.setHypreInterface(amrex::Hypre::Interface::semi_structed);
+            mlmg.setHypreInterface(amrex::Hypre::Interface::semi_structured);
         else if (hypre_interface == "structured")
             mlmg.setHypreInterface(amrex::Hypre::Interface::structured);
         else


### PR DESCRIPTION
This PR corrects a presumed typo in line 97:   `semi_structed`to `semi_structured`, as in line 96.  This failure surfaced in an attempted spack build / install of `amr-wind` in container (Ubuntu:jammy base image) build on Perlmutter, but not in the "bare metal" build in spack-manager project. 

@lastephey and @wyphan are also aware of the issue.

## Install command executed from within spack-manager in a running container on Perlmutter

 `spack install amr-wind%gcc~cuda`
 
or

`spack install amr-wind%gcc+hypre~cuda`

## Error observed with Ubuntu:jammy base image running container on Perlmutter

```
  >> 615    /tmp/root/spack-stage/spack-stage-amr-wind-main-lgzyabqtiprxx3qamajbrdhl7hilfd6n/spack-src/amr-wind/core/MLMGOptions.cpp:99:61: error: 'st
            ructured' is not a member of 'amrex::Hypre::Interface'; did you mean 'structed'?
     616       99 |             mlmg.setHypreInterface(amrex::Hypre::Interface::structured);
     617          |                                                             ^~~~~~~~~~
     618          |                                                             structed
```