### PR TITLE
Fix bug in `ABLFieldInitFile.cpp`

### DIFF
--- a/amr-wind/wind_energy/ABLFieldInitFile.cpp
+++ b/amr-wind/wind_energy/ABLFieldInitFile.cpp
@@ -102,7 +102,7 @@ bool ABLFieldInitFile::operator()(
         amrex::ParallelFor(
             vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 // The counter to go from 3d to 1d vector
-                auto idx = (i - i0) * ct2 * ct1 + (j - j0) * ct1 + (k - k0);
+                auto idx = (i - i0) * ct2 * ct1 + (j - j0) * ct2 + (k - k0);
                 // Pass values from temporary array to the velocity field
                 velocity(i, j, k, 0) = uvel_dptr[idx];
                 velocity(i, j, k, 1) = vvel_dptr[idx];


### PR DESCRIPTION
There's a bug in `ABLFieldInitFile` which causes it to fail when the level 0 dimensions are unequal.  Things work out very well when Ny==Nz, such as this case for (Nx, Ny, Nz) = (32, 64, 64)
![image](https://github.com/Exawind/amr-wind/assets/15526007/149121b1-82c1-42cd-b4e2-698dd55bbd9a)

But when Ny != Nz, for instance when (Nx, Ny, Nz) = (64,32,64) you see this striping
![image](https://github.com/Exawind/amr-wind/assets/15526007/10a2828c-39fa-4733-981c-bdc467f782ab)

Problem was tracked down to https://github.com/Exawind/amr-wind/blob/main/amr-wind/wind_energy/ABLFieldInitFile.cpp#L105, the 1d indexing counter should use 
```c++
(j - j0) * ct2
```
instead of `ct1`.

Lawrence