### PR TITLE
Fix typo in hypre option

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -7,3 +7,4 @@ vell
 nd
 fo
 ue
+structed

--- a/amr-wind/core/MLMGOptions.cpp
+++ b/amr-wind/core/MLMGOptions.cpp
@@ -96,7 +96,7 @@ void MLMGOptions::operator()(amrex::MLMG& mlmg)
         else if (hypre_interface == "semi_structured")
             mlmg.setHypreInterface(amrex::Hypre::Interface::semi_structed);
         else if (hypre_interface == "structured")
-            mlmg.setHypreInterface(amrex::Hypre::Interface::structured);
+            mlmg.setHypreInterface(amrex::Hypre::Interface::structed);
         else
             amrex::Abort(
                 "Invalid hypre interface. Valid options: ij semi_structured "


### PR DESCRIPTION
This is a (slightly) better fix to #914. #912 introduced some automated spelling fixes that triggered an actual typo in using hypre. This fixes that erroneous typo and prevents the check from re-introducing it again.

We would have caught this if we built with hypre in the CI...

Closes #914 