### PR TITLE
Addressing stability issues with introducing refinement levels on a restart

### DIFF
--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -71,6 +71,9 @@ public:
             m_fields, m_sim.has_overset(), variable_density,
             m_sim.has_mesh_mapping()));
         m_src_op.init_source_terms(m_sim);
+
+        // clip (if needed) and fillpatch
+        m_post_solve_op(m_time.current_time());
     }
 
     //! Perform update actions after a regrid is performed
@@ -90,6 +93,9 @@ public:
         m_adv_op.reset(new AdvectionOp<PDE, Scheme>(
             m_fields, m_sim.has_overset(), variable_density,
             m_sim.has_mesh_mapping()));
+
+        // clip (if needed) and fillpatch
+        m_post_solve_op(m_time.current_time());
     }
 
     //! Return the object holding the fields necessary for solving this PDE

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -72,7 +72,7 @@ public:
             m_sim.has_mesh_mapping()));
         m_src_op.init_source_terms(m_sim);
 
-        // clip (if needed) and fillpatch
+        // Post-solve operations should also apply after initialization
         m_post_solve_op(m_time.current_time());
     }
 
@@ -94,7 +94,7 @@ public:
             m_fields, m_sim.has_overset(), variable_density,
             m_sim.has_mesh_mapping()));
 
-        // clip (if needed) and fillpatch
+        // Post-solve operations should also apply after a regrid
         m_post_solve_op(m_time.current_time());
     }
 

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -107,7 +107,7 @@ void incflo::init_amr_wind_modules()
         eqn->initialize();
     }
 
-    // m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
+    m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
     m_sim.post_manager().post_init_actions();
 }
 
@@ -201,7 +201,7 @@ bool incflo::regrid_and_update()
             mask_node.setVal(1);
         }
 
-        // m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
+        m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
 
         icns().post_regrid_actions();
         for (auto& eqn : scalar_eqns()) {

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -107,7 +107,8 @@ void incflo::init_amr_wind_modules()
         eqn->initialize();
     }
 
-    m_sim.pde_manager().fillpatch_state_fields(m_time.current_time()); // may be unnecessary
+    m_sim.pde_manager().fillpatch_state_fields(
+        m_time.current_time()); // may be unnecessary
     m_sim.post_manager().post_init_actions();
 }
 
@@ -201,7 +202,8 @@ bool incflo::regrid_and_update()
             mask_node.setVal(1);
         }
 
-        m_sim.pde_manager().fillpatch_state_fields(m_time.current_time()); // may be unnecessary
+        m_sim.pde_manager().fillpatch_state_fields(
+            m_time.current_time()); // may be unnecessary
 
         icns().post_regrid_actions();
         for (auto& eqn : scalar_eqns()) {

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -107,7 +107,7 @@ void incflo::init_amr_wind_modules()
         eqn->initialize();
     }
 
-    m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
+    m_sim.pde_manager().fillpatch_state_fields(m_time.current_time()); // may be unnecessary
     m_sim.post_manager().post_init_actions();
 }
 
@@ -201,7 +201,7 @@ bool incflo::regrid_and_update()
             mask_node.setVal(1);
         }
 
-        m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
+        m_sim.pde_manager().fillpatch_state_fields(m_time.current_time()); // may be unnecessary
 
         icns().post_regrid_actions();
         for (auto& eqn : scalar_eqns()) {

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -107,8 +107,7 @@ void incflo::init_amr_wind_modules()
         eqn->initialize();
     }
 
-    m_sim.pde_manager().fillpatch_state_fields(
-        m_time.current_time()); // may be unnecessary
+    // m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
     m_sim.post_manager().post_init_actions();
 }
 
@@ -202,8 +201,7 @@ bool incflo::regrid_and_update()
             mask_node.setVal(1);
         }
 
-        m_sim.pde_manager().fillpatch_state_fields(
-            m_time.current_time()); // may be unnecessary
+        // m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
 
         icns().post_regrid_actions();
         for (auto& eqn : scalar_eqns()) {


### PR DESCRIPTION
- some turbulence models feature quantities (with their own PDEs) that must remain positive, such as tke and sdr
- if the values go negative, NaNs will result, due to the square root of a negative number, etc.
- these models have "post-solve" operations that clip the values to guarantee their boundedness during a simulation
- but upon restart, when new levels are introduced, these values are not guaranteed to remain bounded when being interpolated to finer levels and this can be exacerbated at the wall, especially for walls BCs with extrapolation for scalars, such as slip_wall
- this PR puts the post-solve operations for all PDEs into their initialization (active on a restart) and into the post_regrid actions, which could have the same behavior as introducing finer levels to a restart
- this PR should eliminate issues with having refinement zones extend all the way to the lower boundary in turbine simulations that follow a coarser precursor simulation, such as #515 and #857.