### PR TITLE
Fix issue #870

### DIFF
--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -535,7 +535,8 @@ void ABLBoundaryPlane::write_file()
     if (m_out_fmt == "native") {
         if (amrex::ParallelDescriptor::IOProcessor()) {
             std::ofstream oftime(m_time_file, std::ios::out | std::ios::app);
-            oftime << t_step << ' ' << std::fixed << std::setprecision(15) << time << '\n';
+            oftime << t_step << ' ' << std::fixed << std::setprecision(15)
+                   << time << '\n';
             oftime.close();
         }
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -535,7 +535,7 @@ void ABLBoundaryPlane::write_file()
     if (m_out_fmt == "native") {
         if (amrex::ParallelDescriptor::IOProcessor()) {
             std::ofstream oftime(m_time_file, std::ios::out | std::ios::app);
-            oftime << t_step << ' ' << time << '\n';
+            oftime << t_step << ' ' << std::fixed << std::setprecision(15) << time << '\n';
             oftime.close();
         }
 


### PR DESCRIPTION
Fixed issue #870 in ABLBoundaryPlane.cpp.  Now the `time.dat` file should look like
```
0 0.000000000000000
1 0.500000000000000
2 1.000000000000000
3 1.500000000000000
4 2.000000000000000
5 2.500000000000000
6 3.000000000000000
7 3.500000000000000
8 4.000000000000000
9 4.500000000000000
10 5.000000000000000
```
which should have enough precision even when t>10000.

Lawrence