### PR TITLE
Add documentation for mesoscale forcing capabilities

### DIFF
--- a/docs/sphinx/theory/theory.rst
+++ b/docs/sphinx/theory/theory.rst
@@ -132,7 +132,7 @@ Often for simulations involving walls, (e.g., channel flows, complex terrains et
 .. toctree::
    :glob:
    :maxdepth: 2
-   
+
    mapping.rst
 
 Multiphase flow modelling
@@ -185,6 +185,36 @@ Using the perturbational form implies that the hydrostatic pressure is removed f
 - reframe in reference to the top boundary, and assume :math:`p(z = z_{max}) = 0`
    
 .. math:: p = p' - \int_z^{z_{max}} \rho_0 g dz + p(z = z_{max}) = p' - \int_z^{z_{max}} \rho_0 g dz
+
+
+Mesoscale Forcing
+~~~~~~~~~~~~~~~~~
+
+To incorporate larger-scale atmospheric dynamics under real conditions,
+`AMR-Wind` offers two approaches. If mesoscale momentum and/or temperature
+source terms are known exactly, e.g., from a numerical weather prediction (NWP)
+model, then these may be directly applied. These mesoscale source terms would
+come from the RHS of the mesoscale equations of motion and may also include the
+effects of additional modeled physics such as radiation or moisture. This
+mesoscale forcing approach is called the "tendencies" (or "mesoscale budget
+components") approach. For more information, see `Draxl et al. (BLM 2021)
+<https://doi.org/10.1007/s10546-020-00584-z>`_
+
+If the mesoscale source terms are not known a priori, they may be derived on
+the fly with a profile assimilation technique. This is an engineering approach
+that applies a proportional controller to drive the instantaneous planar
+averaged wind and/or temperature profiles towards known time--height data. This
+approach can be used with NWP model output or observational data. For more
+information, see `Allaerts et al. (BLM 2020)
+<https://doi.org/10.1007/s10546-020-00538-5>`_
+
+The application of these forcing approaches is detailed in:
+
+.. toctree::
+   :glob:
+   :maxdepth: 2
+   
+   ../user/inputs_ABL_meso_forcing.rst
 
 
 Turbulence Models

--- a/docs/sphinx/user/inputs.rst
+++ b/docs/sphinx/user/inputs.rst
@@ -44,6 +44,7 @@ Section                 Description
 ``transport``           Transport equation controls
 ``turbulence``          Turbulence model controls 
 ``ABL``                 Atmospheric boundary layer (ABL) controls
+``ABLMesoForcing``      Mesoscale ABL forcing controls
 ``SyntheticTurbulence`` Inject turbulence using body forces
 ``Momentum sources``    Activate Momentum source terms and their parameters
 ``Boundary conditions`` Boundary condition types and gradients
@@ -77,6 +78,7 @@ This section documents the parameters available within each section.
    inputs_turbulence.rst
    inputs_Momentum_Sources.rst
    inputs_ABL.rst
+   inputs_ABL_meso_forcing.rst
    inputs_SyntheticTurbulence.rst
    inputs_Static_Refinement.rst
    inputs_Boundary_conditions.rst

--- a/docs/sphinx/user/inputs_ABL_meso_forcing.rst
+++ b/docs/sphinx/user/inputs_ABL_meso_forcing.rst
@@ -74,7 +74,7 @@ temperature, respectively.
    When blending to a constant forcing profile, the slope of the forcing
    profile at the transition height (specified by
    :input_param:`ABLMesoForcing*.constant_transition_height` or provided in the
-   :input_param:`ABL*.mesoscale_forcing` datafile) is linearly reduced to 0 from
+   :input_param:`ABL.mesoscale_forcing` datafile) is linearly reduced to 0 from
    the transition height up to the transition height +
    :input_param:`ABLMesoForcing*.transition_thickness`.
 

--- a/docs/sphinx/user/inputs_ABL_meso_forcing.rst
+++ b/docs/sphinx/user/inputs_ABL_meso_forcing.rst
@@ -1,0 +1,144 @@
+Section: ABLMesoForcing
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This section is for setting mesoscale forcing parameters for
+mesoscale-to-microscale coupling (MMC). With the exception of
+``ABL.mesoscale_forcing`` and ``ABL.tendency_forcing``, the parameters below
+apply to both ``ABLMesoForcingMom`` and ``ABLMesoForcingTemp`` for momentum and
+temperature, respectively.
+
+.. input_param:: ABL.mesoscale_forcing
+
+   **type:** String, optional
+
+   Path to a netcdf file with mesoscale data. This datafile should have
+   dimensions "ntime" and "nheight". Time-height-varying variables include
+   "momentum_u", "momentum_v", and "temperature" (virtual potential
+   temperature); time-varying variables include "tflux" (kinematic heat flux)
+   and "transition_height" (optional, only used if
+   :input_param:`ABLMesoForcing*.forcing_transition` is specified without a
+   :input_param:`ABLMesoForcing*.constant_transition_height`). The time-height
+   data are stored as flattened 1-D arrays, wherein the height dimension
+   changes the fastest.
+
+.. input_param:: ABL.tendency_forcing
+
+   **type:** Boolean, optional, default = false
+   
+   If "true", momentum and temperature source terms are directly provided
+   within the :input_param:`ABL.mesoscale_forcing` netcdf file; 
+   :input_param:`ABLMesoForcing*.forcing_scheme` is ignored. Typically, these
+   source terms are determined from mesoscale model tendencies. 
+   
+   If "false", the input velocity and temperature time-height data are used for
+   profile assimilation forcing schemes.
+   
+.. input_param:: ABLMesoForcing*.forcing_scheme
+
+   **type:** String, mandatory
+
+   Options include: "direct" or "indirect" profile assimilation. **Direct
+   profile assimilation (DPA)** is a strong enforcement of the input mesoscale
+   profiles. Height-varying source terms are calculated at every time step to
+   drive the error between the instantaneous planar-averaged fields and the
+   mesoscale data to zero. This strategy implies a high level of confidence in
+   the specified mesoscale conditions and can result in excessive turbulence
+   resolved in the microscale.
+
+   In comparison, **indirect profile assimilation** weakly enforces the
+   mesoscale profiles by using an approximation to the DPA forcing. This is an
+   engineering approach that allows for local deviation from the mesoscale mean
+   quantities and allows the microscale flow to find its own equilibrium
+   between mean profiles and the associated resolved turbulence. The
+   approximate forcing is derived by applying a polynomial regression to the
+   DPA forcing profile.
+
+.. input_param:: ABLMesoForcing*.control_gain
+
+   **type:** Real, optional, default = 0.2
+
+   A relaxation factor used to scale the magnitude of the source term, which
+   may be interpreted as an inverse time scale with units of 1/s.
+
+.. input_param:: ABLMesoForcing*.forcing_transition
+
+   **type:** String, optional, default = "none"
+
+   Used to specify two forcing schemes for upper and lower regions under more
+   complicated MMC modeling scenarios, e.g., with complex background conditions
+   and/or uncertainty in the mesoscale data. The default is apply the
+   :input_param:`ABLMesoForcing*.forcing_scheme` for the full mesoscale profile
+   over the entire microscale domain. Other options include "indirectToConstant"
+   and "indirectToDirect".
+   
+   When blending to a constant forcing profile, the slope of the forcing
+   profile at the transition height (specified by
+   :input_param:`ABLMesoForcing*.constant_transition_height` or provided in the
+   :input_param:`ABLMesoForcing*.mesoscale_forcing` datafile) is linearly
+   reduced to 0 from the transition height up to the transition height +
+   :input_param:`ABLMesoForcing*.transition_thickness`.
+
+   When blending to the DPA forcing profile (e.g., in the free atmosphere), the
+   two forcing profiles are linearly blended from one to the other over the
+   :input_param:`ABLMesoForcing*.transition_thickness`, starting from the
+   transition height as described above.
+
+
+Indirect Profile Assimilation
+-----------------------------
+The following parameters are specific to the IPA scheme
+(:input_param:`ABLMesoForcing*.forcing_scheme = "indirect"`). At the moment,
+only third-order polynomial regression is supported.
+
+.. input_param:: ABLMesoForcing*.weighting_heights
+
+   **type:** List of Reals (has to be same length as
+   :input_param:`ABLMesoForcing*.weighting_values`), optional
+
+   Height(s) in meters at which IPA regression weights are provided.
+   
+.. input_param:: ABLMesoForcing*.weighting_weights
+
+   **type:** List of Reals (has to be same length as
+   :input_param:`ABLMesoForcing*.weighting_heights`), optional
+
+   IPA regression weights at the corresponding
+   :input_param:`ABLMesoForcing*.weighting_heights`. The default behavior is to
+   use uniform weighting. Nonuniform weighting is generally ill-adivsed as
+   runaway positive or negative forcing values may be possible.
+
+.. input_param:: ABLMesoForcing*.normalize_by_zmax
+
+   **type:** Boolean, optional, default = false
+
+   If "true", the height coordinate is normalized by the domain height when
+   performing the IPA regression. Provided for consistency with a legacy solver
+   implementation to improve conditioning of the regression matrix but should
+   *not* be needed.
+
+
+Partial Profile Assimilation
+-----------------------------
+The following parameters are for "partial" profile assimilation, enabled by
+:input_param:`ABLMesoForcing*.forcing_transition` being not set to "none". This
+will only partially apply the instantaneous IPA forcing profiles over the
+simulation domain. Above a specified transition layer, a secondary forcing
+profiles may be applied.
+
+.. input_param:: ABLMesoForcing*.transition_thickness
+
+   **type:** Real
+
+   The thickness of the layer over which the forcing scheme transitions from
+   the lower scheme to the upper scheme. 
+
+.. input_param:: ABLMesoForcing*.constant_transition_height
+
+   **type:** Real
+
+   The base of the transition layer, which is invariant for the duration of the
+   entirety of the simulation. To specify a time-varying transition layer
+   height that, e.g., tracks the evolution of the ABL height, omit this
+   parameter and include the time-varying ``transition_height`` variable within
+   the :input_param:`ABLMesoForcing*.mesoscale_forcing` datafile.
+

--- a/docs/sphinx/user/inputs_ABL_meso_forcing.rst
+++ b/docs/sphinx/user/inputs_ABL_meso_forcing.rst
@@ -74,8 +74,8 @@ temperature, respectively.
    When blending to a constant forcing profile, the slope of the forcing
    profile at the transition height (specified by
    :input_param:`ABLMesoForcing*.constant_transition_height` or provided in the
-   :input_param:`ABLMesoForcing*.mesoscale_forcing` datafile) is linearly
-   reduced to 0 from the transition height up to the transition height +
+   :input_param:`ABL*.mesoscale_forcing` datafile) is linearly reduced to 0 from
+   the transition height up to the transition height +
    :input_param:`ABLMesoForcing*.transition_thickness`.
 
    When blending to the DPA forcing profile (e.g., in the free atmosphere), the
@@ -87,7 +87,7 @@ temperature, respectively.
 Indirect Profile Assimilation
 -----------------------------
 The following parameters are specific to the IPA scheme
-(:input_param:`ABLMesoForcing*.forcing_scheme = "indirect"`). At the moment,
+(:input_param:`ABLMesoForcing*.forcing_scheme` = "indirect"). At the moment,
 only third-order polynomial regression is supported.
 
 .. input_param:: ABLMesoForcing*.weighting_heights
@@ -97,7 +97,7 @@ only third-order polynomial regression is supported.
 
    Height(s) in meters at which IPA regression weights are provided.
    
-.. input_param:: ABLMesoForcing*.weighting_weights
+.. input_param:: ABLMesoForcing*.weighting_values
 
    **type:** List of Reals (has to be same length as
    :input_param:`ABLMesoForcing*.weighting_heights`), optional
@@ -140,5 +140,5 @@ profiles may be applied.
    entirety of the simulation. To specify a time-varying transition layer
    height that, e.g., tracks the evolution of the ABL height, omit this
    parameter and include the time-varying ``transition_height`` variable within
-   the :input_param:`ABLMesoForcing*.mesoscale_forcing` datafile.
+   the :input_param:`ABL.mesoscale_forcing` datafile.
 

--- a/docs/sphinx/user/inputs_ABL_meso_forcing.rst
+++ b/docs/sphinx/user/inputs_ABL_meso_forcing.rst
@@ -68,8 +68,8 @@ temperature, respectively.
    complicated MMC modeling scenarios, e.g., with complex background conditions
    and/or uncertainty in the mesoscale data. The default is apply the
    :input_param:`ABLMesoForcing*.forcing_scheme` for the full mesoscale profile
-   over the entire microscale domain. Other options include "indirectToConstant"
-   and "indirectToDirect".
+   over the entire microscale domain. Other options include "directToConstant",
+   "indirectToConstant", and "indirectToDirect".
    
    When blending to a constant forcing profile, the slope of the forcing
    profile at the transition height (specified by


### PR DESCRIPTION
This PR documents the mesoscale-to-microscale coupling strategies that were introduced by https://github.com/Exawind/amr-wind/pull/652. These strategies provide mesoscale forcing through source terms based on:
1. Tendencies (or mesoscale budget components) 
2. Profile assimilation — generalized to include "direct" and "indirect" forcing schemes, applied to the full simulation domain or a portion thereof.