### PR TITLE
Fix MOL, BDS, and ScalarAdvection on GPU

### DIFF
--- a/amr-wind/equation_systems/AdvOp_MOL.H
+++ b/amr-wind/equation_systems/AdvOp_MOL.H
@@ -72,15 +72,13 @@ struct AdvectionOp<
                 auto rho_arr = den(lev).const_array(mfi);
                 auto tra_arr = dof_field(lev).const_array(mfi);
                 amrex::FArrayBox rhotracfab;
-                amrex::Elixir eli_rt;
                 amrex::Array4<amrex::Real> rhotrac;
 
                 if (PDE::multiply_rho) {
 
                     amrex::Box rhotrac_box =
                         amrex::grow(bx, fvm::MOL::nghost_state);
-                    rhotracfab.resize(rhotrac_box, PDE::ndim);
-                    eli_rt = rhotracfab.elixir();
+                    rhotracfab.resize(rhotrac_box, PDE::ndim, amrex::The_Async_Arena());
                     rhotrac = rhotracfab.array();
 
                     amrex::ParallelFor(
@@ -98,8 +96,7 @@ struct AdvectionOp<
                     amrex::Box tmpbox = amrex::surroundingNodes(bx);
                     const int tmpcomp = nmaxcomp * AMREX_SPACEDIM;
 
-                    amrex::FArrayBox tmpfab(tmpbox, tmpcomp);
-                    amrex::Elixir eli = tmpfab.elixir();
+                    amrex::FArrayBox tmpfab(tmpbox, tmpcomp, amrex::The_Async_Arena());
 
                     amrex::Array4<amrex::Real> fx = tmpfab.array(0);
                     amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp);

--- a/amr-wind/equation_systems/AdvOp_MOL.H
+++ b/amr-wind/equation_systems/AdvOp_MOL.H
@@ -78,7 +78,8 @@ struct AdvectionOp<
 
                     amrex::Box rhotrac_box =
                         amrex::grow(bx, fvm::MOL::nghost_state);
-                    rhotracfab.resize(rhotrac_box, PDE::ndim, amrex::The_Async_Arena());
+                    rhotracfab.resize(
+                        rhotrac_box, PDE::ndim, amrex::The_Async_Arena());
                     rhotrac = rhotracfab.array();
 
                     amrex::ParallelFor(
@@ -96,7 +97,8 @@ struct AdvectionOp<
                     amrex::Box tmpbox = amrex::surroundingNodes(bx);
                     const int tmpcomp = nmaxcomp * AMREX_SPACEDIM;
 
-                    amrex::FArrayBox tmpfab(tmpbox, tmpcomp, amrex::The_Async_Arena());
+                    amrex::FArrayBox tmpfab(
+                        tmpbox, tmpcomp, amrex::The_Async_Arena());
 
                     amrex::Array4<amrex::Real> fx = tmpfab.array(0);
                     amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp);

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -605,7 +605,8 @@ struct AdvectionOp<ICNS, fvm::MOL>
                 amrex::Box gbx = grow(bx, fvm::MOL::nghost_state);
 
                 // Set up momentum array
-                amrex::FArrayBox qfab(gbx, ICNS::ndim, amrex::The_Async_Arena());
+                amrex::FArrayBox qfab(
+                    gbx, ICNS::ndim, amrex::The_Async_Arena());
                 const auto& q = qfab.array();
                 // Calculate momentum
                 auto rho_arr = rho(lev).const_array(mfi);
@@ -622,7 +623,8 @@ struct AdvectionOp<ICNS, fvm::MOL>
                 amrex::Box tmpbox = amrex::surroundingNodes(bx);
                 const int tmpcomp = nmaxcomp * AMREX_SPACEDIM;
 
-                amrex::FArrayBox tmpfab(tmpbox, tmpcomp, amrex::The_Async_Arena());
+                amrex::FArrayBox tmpfab(
+                    tmpbox, tmpcomp, amrex::The_Async_Arena());
 
                 amrex::Array4<amrex::Real> fx = tmpfab.array(0);
                 amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp);

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -605,7 +605,7 @@ struct AdvectionOp<ICNS, fvm::MOL>
                 amrex::Box gbx = grow(bx, fvm::MOL::nghost_state);
 
                 // Set up momentum array
-                amrex::FArrayBox qfab(gbx, ICNS::ndim);
+                amrex::FArrayBox qfab(gbx, ICNS::ndim, amrex::The_Async_Arena());
                 const auto& q = qfab.array();
                 // Calculate momentum
                 auto rho_arr = rho(lev).const_array(mfi);
@@ -618,13 +618,11 @@ struct AdvectionOp<ICNS, fvm::MOL>
                 // Doing this explicitly, instead of through a Multiply command,
                 // helps avoid floating-point errors with intel compilers and
                 // mimics the implementation in equation_systems/AdvOp_MOL.H
-                amrex::Gpu::streamSynchronize();
 
                 amrex::Box tmpbox = amrex::surroundingNodes(bx);
                 const int tmpcomp = nmaxcomp * AMREX_SPACEDIM;
 
-                amrex::FArrayBox tmpfab(tmpbox, tmpcomp);
-                amrex::Elixir eli = tmpfab.elixir();
+                amrex::FArrayBox tmpfab(tmpbox, tmpcomp, amrex::The_Async_Arena());
 
                 amrex::Array4<amrex::Real> fx = tmpfab.array(0);
                 amrex::Array4<amrex::Real> fy = tmpfab.array(nmaxcomp);

--- a/amr-wind/physics/ScalarAdvection.cpp
+++ b/amr-wind/physics/ScalarAdvection.cpp
@@ -252,7 +252,6 @@ ScalarAdvection::compute_error(const Shape& scalar_function)
     amrex::Vector<amrex::Real> err(nlevels + 1, 0.0);
 
     for (int level = 0; level < nlevels; ++level) {
-        amrex::Real err_lev = 0.0;
         amrex::iMultiFab level_mask;
         if (level < nlevels - 1) {
             level_mask = makeFineMask(
@@ -271,29 +270,29 @@ ScalarAdvection::compute_error(const Shape& scalar_function)
         const amrex::Real cell_vol = dx[0] * dx[1] * dx[2];
 
         const auto& scalar = (*m_scalar)(level);
-        for (amrex::MFIter mfi(scalar); mfi.isValid(); ++mfi) {
-            const auto& vbx = mfi.validbox();
-            const auto& scalar_arr = scalar.array(mfi);
-            const auto& mask_arr = level_mask.array(mfi);
-
-            amrex::Real err_fab = 0.0;
-            amrex::LoopOnCpu(vbx, [=, &err_fab](int i, int j, int k) noexcept {
+        auto const& scalar_arr = scalar.const_arrays();
+        auto const& mask_arr = level_mask.const_arrays();
+        amrex::Real err_lev = amrex::ParReduce(
+            amrex::TypeList<amrex::ReduceOpSum>{},
+            amrex::TypeList<amrex::Real>{}, scalar, amrex::IntVect(0),
+            [=] AMREX_GPU_HOST_DEVICE(int box_no, int i, int j, int k)
+                -> amrex::GpuTuple<amrex::Real> {
                 const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
                 const amrex::Real y = problo[1] + (j + 0.5) * dx[1];
-                const amrex::Real s = scalar_arr(i, j, k, 0);
+                auto const& scalar_bx = scalar_arr[box_no];
+                auto const& mask_bx = mask_arr[box_no];
+                const amrex::Real s = scalar_bx(i, j, k, 0);
                 const amrex::Real s_exact = scalar_function(
                     x - x_conv_dist, y - y_conv_dist, dx[0], dx[1], x0, y0,
                     amplitude, x_width, y_width, x_wavenumber, y_wavenumber);
-                err_fab += cell_vol * mask_arr(i, j, k) * (s - s_exact) *
+                return cell_vol * mask_bx(i, j, k) * (s - s_exact) *
                            (s - s_exact);
             });
-            err_lev += err_fab;
-        }
         amrex::ParallelDescriptor::ReduceRealSum(err_lev);
         err[level] = err_lev;
         err[nlevels] += err_lev;
     }
-
+    
     for (int level = 0; level < nlevels + 1; ++level) {
         err[level] = std::sqrt(err[level] / total_vol);
     }

--- a/amr-wind/physics/ScalarAdvection.cpp
+++ b/amr-wind/physics/ScalarAdvection.cpp
@@ -286,13 +286,13 @@ ScalarAdvection::compute_error(const Shape& scalar_function)
                     x - x_conv_dist, y - y_conv_dist, dx[0], dx[1], x0, y0,
                     amplitude, x_width, y_width, x_wavenumber, y_wavenumber);
                 return cell_vol * mask_bx(i, j, k) * (s - s_exact) *
-                           (s - s_exact);
+                       (s - s_exact);
             });
         amrex::ParallelDescriptor::ReduceRealSum(err_lev);
         err[level] = err_lev;
         err[nlevels] += err_lev;
     }
-    
+
     for (int level = 0; level < nlevels + 1; ++level) {
         err[level] = std::sqrt(err[level] / total_vol);
     }

--- a/test/test_files/abl_bds/abl_bds.inp
+++ b/test/test_files/abl_bds/abl_bds.inp
@@ -71,3 +71,10 @@ zhi.temperature = 0.003 # tracer is used to specify potential temperature gradie
 #              VERBOSITY                #
 #.......................................#
 incflo.verbose          =   0          # incflo_level
+
+amrex.abort_on_out_of_memory=1
+amrex.the_arena_is_managed=1
+amrex.async_out=0
+# needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)
+# This is not needed for a non-debug build
+amrex.the_arena_init_size=4500000000

--- a/test/test_files/freestream_bds/freestream_bds.inp
+++ b/test/test_files/freestream_bds/freestream_bds.inp
@@ -57,3 +57,10 @@ zhi.type =   "slip_wall"
 
 incflo.verbose          =   0          # incflo_level
 nodal_proj.verbose = 0
+
+amrex.abort_on_out_of_memory=1
+amrex.the_arena_is_managed=1
+amrex.async_out=0
+# needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)
+# This is not needed for a non-debug build
+amrex.the_arena_init_size=4500000000

--- a/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
+++ b/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
@@ -59,6 +59,9 @@ amr.n_error_buf = 2
 amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
+# needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)
+# This is not needed for a non-debug build
+amrex.the_arena_init_size=4500000000
 
 amr.max_level = 2
 tagging.labels = static

--- a/test/test_files/linear_bds_amr/linear_bds_amr.inp
+++ b/test/test_files/linear_bds_amr/linear_bds_amr.inp
@@ -63,3 +63,10 @@ amr.max_level = 2
 tagging.labels = static
 tagging.static.type = "CartBoxRefinement"
 tagging.static.static_refinement_def = "static_box.txt"
+
+amrex.abort_on_out_of_memory=1
+amrex.the_arena_is_managed=1
+amrex.async_out=0
+# needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)
+# This is not needed for a non-debug build
+amrex.the_arena_init_size=4500000000


### PR DESCRIPTION
To be explicit: at this point, a GPU debug build with cuda/11.2.2 on a single V100 on Eagle gives the following:
```
$ ctest -j 1
[...]
100% tests passed, 0 tests failed out of 81

Label Time Summary:
no_ci         = 3278.09 sec*proc (75 tests)
regression    = 3404.36 sec*proc (80 tests)
unit          =   7.60 sec*proc (1 test
``` 