### PR TITLE
Hurricane Temperature forcing

### DIFF
--- a/amr-wind/equation_systems/temperature/source_terms/CMakeLists.txt
+++ b/amr-wind/equation_systems/temperature/source_terms/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(${amr_wind_lib_name} PRIVATE
 ABLMesoForcingTemp.cpp BodyForce.cpp
+HurricaneTempForcing.cpp
   )

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H
@@ -40,7 +40,10 @@ private:
     int m_axis{2};
 
     //! Temperature radial decay
-    amrex::Real m_dTdR{0.00};
+    amrex::Real m_dTdR{0.001};
+
+    //! Zero Temperature height
+    amrex::Real m_dTzh{18000.};
 };
 
 } // namespace amr_wind::pde::temperature

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H
@@ -1,0 +1,48 @@
+#ifndef HURRICANE_TEMP_FORCING_H
+#define HURRICANE_TEMP_FORCING_H
+
+#include "amr-wind/core/FieldRepo.H"
+#include "amr-wind/equation_systems/temperature/TemperatureSource.H"
+#include "amr-wind/utilities/FieldPlaneAveraging.H"
+
+namespace amr_wind::pde::temperature {
+
+class HurricaneTempForcing
+    : public TemperatureSource::Register<HurricaneTempForcing>
+{
+
+public:
+    static std::string identifier() { return "HurricaneTempForcing"; }
+
+    explicit HurricaneTempForcing(const CFDSim& /*sim*/);
+
+    ~HurricaneTempForcing() override;
+
+    void operator()(
+        const int lev,
+        const amrex::MFIter& /*mfi*/,
+        const amrex::Box& bx,
+        const FieldState /*fstate*/,
+        const amrex::Array4<amrex::Real>& src_term) const override;
+
+    void mean_velocity_init(const VelPlaneAveraging& /*vavg*/);
+
+    void mean_velocity_update(const VelPlaneAveraging& /*vavg*/);
+
+private:
+    //! Mesh
+    const amrex::AmrCore& m_mesh;
+
+    amrex::Gpu::DeviceVector<amrex::Real> m_vel_ht;
+    amrex::Gpu::DeviceVector<amrex::Real> m_vel_vals;
+
+    //! Axis over which averages are computed
+    int m_axis{2};
+
+    //! Temperature radial decay
+    amrex::Real m_dTdR{0.00};
+};
+
+} // namespace amr_wind::pde::temperature
+
+#endif

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
@@ -70,7 +70,7 @@ void HurricaneTempForcing::operator()(
                                 (heights[ir] - heights[il])) *
                                    (ht - heights[il]);
 
-        src_term(i, j, k, 0) += vmean * dTdR;
+        src_term(i, j, k) += vmean * dTdR;
     });
 }
 

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
@@ -1,0 +1,106 @@
+#include "amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H"
+#include "amr-wind/CFDSim.H"
+#include "amr-wind/utilities/trig_ops.H"
+#include "amr-wind/core/vs/vstraits.H"
+#include "amr-wind/wind_energy/ABL.H"
+#include "amr-wind/core/FieldUtils.H"
+
+#include "AMReX_ParmParse.H"
+#include "AMReX_Gpu.H"
+
+namespace amr_wind::pde::temperature {
+
+HurricaneTempForcing::HurricaneTempForcing(const CFDSim& sim)
+    : m_mesh(sim.mesh())
+{
+
+    const auto& abl = sim.physics_manager().get<amr_wind::ABL>();
+    // NO need to re-register the hurricane forcing
+    abl.register_hurricane_temp_forcing(this);
+    // Read the Hurricane Temperature Forcing
+    {
+        amrex::ParmParse pp("HurricaneTempForcing");
+        pp.query("radial_decay", m_dTdR);
+
+        mean_velocity_init(abl.abl_statistics().vel_profile_coarse());
+    }
+}
+
+HurricaneTempForcing::~HurricaneTempForcing() = default;
+
+void HurricaneTempForcing::operator()(
+    const int lev,
+    const amrex::MFIter& /*mfi*/,
+    const amrex::Box& bx,
+    const FieldState /*fstate*/,
+    const amrex::Array4<amrex::Real>& src_term) const
+
+{
+    const auto& problo = m_mesh.Geom(lev).ProbLoArray();
+    const auto& dx = m_mesh.Geom(lev).CellSizeArray();
+
+    const amrex::Real dTdR = m_dTdR;
+
+    // Mean velocity profile used to compute background hurricane forcing term
+    //
+    // Assumes that the velocity profile is at the cell-centers of the finest
+    // level grid. For finer meshes, it will extrapolate beyond the Level0
+    // cell-centers for the lo/hi cells.
+
+    const int idir = m_axis;
+    const int nh_max = static_cast<int>(m_vel_ht.size()) - 2;
+    const int lp1 = lev + 1;
+    const amrex::Real* heights = m_vel_ht.data();
+    const amrex::Real* vals = m_vel_vals.data();
+
+    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        amrex::IntVect iv(i, j, k);
+        const amrex::Real ht = problo[idir] + (iv[idir] + 0.5) * dx[idir];
+
+        const int il = amrex::min(k / lp1, nh_max);
+        const int ir = il + 1;
+
+        /*const amrex::Real umean =
+            vals[3 * il + 0] + ((vals[3 * ir + 0] - vals[3 * il + 0]) /
+                                (heights[ir] - heights[il])) *
+                                   (ht - heights[il]);
+        */
+        const amrex::Real vmean =
+            vals[3 * il + 1] + ((vals[3 * ir + 1] - vals[3 * il + 1]) /
+                                (heights[ir] - heights[il])) *
+                                   (ht - heights[il]);
+
+        src_term(i, j, k, 0) += vmean * dTdR;
+    });
+}
+
+void HurricaneTempForcing::mean_velocity_init(const VelPlaneAveraging& vavg)
+{
+    m_axis = vavg.axis();
+
+    // The implementation depends the assumption that the ABL statistics
+    // class computes statistics at the cell-centeres only on level 0. If
+    // this assumption changes in future, the implementation will break...
+    // so put in a check here to catch this.
+    AMREX_ALWAYS_ASSERT(
+        m_mesh.Geom(0).Domain().length(m_axis) ==
+        static_cast<int>(vavg.line_centroids().size()));
+
+    m_vel_ht.resize(vavg.line_centroids().size());
+    m_vel_vals.resize(vavg.line_average().size());
+
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, vavg.line_centroids().begin(),
+        vavg.line_centroids().end(), m_vel_ht.begin());
+
+    mean_velocity_update(vavg);
+}
+
+void HurricaneTempForcing::mean_velocity_update(const VelPlaneAveraging& vavg)
+{
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, vavg.line_average().begin(),
+        vavg.line_average().end(), m_vel_vals.begin());
+}
+
+} // namespace amr_wind::pde::temperature

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
@@ -21,6 +21,7 @@ HurricaneTempForcing::HurricaneTempForcing(const CFDSim& sim)
     {
         amrex::ParmParse pp("HurricaneTempForcing");
         pp.query("radial_decay", m_dTdR);
+        pp.query("radial_decay_zero_height", m_dTzh);
 
         mean_velocity_init(abl.abl_statistics().vel_profile_coarse());
     }
@@ -40,6 +41,7 @@ void HurricaneTempForcing::operator()(
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
 
     const amrex::Real dTdR = m_dTdR;
+    const amrex::Real dTzh = m_dTzh;
 
     // Mean velocity profile used to compute background hurricane forcing term
     //
@@ -65,12 +67,13 @@ void HurricaneTempForcing::operator()(
                                 (heights[ir] - heights[il])) *
                                    (ht - heights[il]);
         */
+        const amrex::Real dTdR_z = dTdR * (dTzh - ht) / dTzh;
         const amrex::Real vmean =
             vals[3 * il + 1] + ((vals[3 * ir + 1] - vals[3 * il + 1]) /
                                 (heights[ir] - heights[il])) *
                                    (ht - heights[il]);
 
-        src_term(i, j, k) -= vmean * dTdR;
+        src_term(i, j, k) -= vmean * dTdR_z;
     });
 }
 

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
@@ -70,7 +70,7 @@ void HurricaneTempForcing::operator()(
                                 (heights[ir] - heights[il])) *
                                    (ht - heights[il]);
 
-        src_term(i, j, k) += vmean * dTdR;
+        src_term(i, j, k) -= vmean * dTdR;
     });
 }
 

--- a/amr-wind/wind_energy/ABL.H
+++ b/amr-wind/wind_energy/ABL.H
@@ -46,7 +46,8 @@ class HurricaneForcing;
 
 namespace pde::temperature {
 class ABLMesoForcingTemp;
-}
+class HurricaneTempForcing;
+} // namespace pde::temperature
 
 /** Atmospheric Boundary Layer physics
  *  \ingroup we_abl
@@ -105,6 +106,12 @@ public:
         m_hurricane_forcing = forcing;
     }
 
+    void register_hurricane_temp_forcing(
+        pde::temperature::HurricaneTempForcing* forcing) const
+    {
+        m_hurricane_temp_forcing = forcing;
+    }
+
     const ABLBoundaryPlane& bndry_plane() const { return *m_bndry_plane; }
     const ABLModulatedPowerLaw& abl_mpl() const { return *m_abl_mpl; }
 
@@ -154,7 +161,8 @@ private:
     std::unique_ptr<ABLMesoscaleInput> m_meso_file;
 
     mutable pde::icns::HurricaneForcing* m_hurricane_forcing{nullptr};
-
+    mutable pde::temperature::HurricaneTempForcing* m_hurricane_temp_forcing{
+        nullptr};
     //! Default value set based on https://turbmodels.larc.nasa.gov/sst.html
     amrex::Real m_init_sdr{25.0};
 

--- a/amr-wind/wind_energy/ABL.cpp
+++ b/amr-wind/wind_energy/ABL.cpp
@@ -8,6 +8,7 @@
 #include "amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.H"
 #include "amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.H"
 #include "amr-wind/equation_systems/icns/source_terms/HurricaneForcing.H"
+#include "amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.H"
 #include "amr-wind/incflo.H"
 #include "amr-wind/wind_energy/ABLMesoscaleForcing.H"
 #include "amr-wind/wind_energy/ABLMesoscaleInput.H"
@@ -229,6 +230,11 @@ void ABL::pre_advance_work()
 
     if (m_hurricane_forcing != nullptr) {
         m_hurricane_forcing->mean_velocity_update(
+            m_stats->vel_profile_coarse());
+    }
+
+    if (m_hurricane_temp_forcing != nullptr) {
+        m_hurricane_temp_forcing->mean_velocity_update(
             m_stats->vel_profile_coarse());
     }
 


### PR DESCRIPTION
Implementing a hurricane forcing term for the temperature equation

- This PR includes a unit-test. Current unit-tests passes because it calculates everything to zero. Need to revisit the golds.