### PR TITLE
Turbulent viscosity Smagorinsky in multiphase

### DIFF
--- a/amr-wind/core/field_ops.H
+++ b/amr-wind/core/field_ops.H
@@ -375,17 +375,17 @@ inline amrex::Real global_min_magnitude(FType& field)
     const auto& repo = field.repo();
     const auto ncomp = field.num_comp();
 
-    amrex::Real minglobal = 0.0;
+    amrex::Real minglobal = 1e9;
     const int nlevels = repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
-        amrex::Real minglobal_lev = 0.0;
+        amrex::Real minglobal_lev = 1e9;
         minglobal_lev = amrex::ReduceMin(
             field(lev), 0.,
             [=] AMREX_GPU_HOST_DEVICE(
                 amrex::Box const& b,
                 amrex::Array4<amrex::Real const> const& field_arr)
                 -> amrex::Real {
-                amrex::Real mx = 0.0;
+                amrex::Real mx = 1e9;
                 amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
                     amrex::Real mag = 0.0;
                     for (int icomp = 0; icomp < ncomp; ++icomp) {

--- a/amr-wind/core/field_ops.H
+++ b/amr-wind/core/field_ops.H
@@ -364,6 +364,46 @@ inline amrex::Real global_max_magnitude(FType& field)
     return maxglobal;
 }
 
+/** Computes the global minimum of a field from all levels
+ *  * \ingroup field_ops
+ *   *
+ *    * \param [in] field we need to compute its global minimum magnitude
+ *     */
+template <typename FType>
+inline amrex::Real global_min_magnitude(FType& field)
+{
+    const auto& repo = field.repo();
+    const auto ncomp = field.num_comp();
+
+    amrex::Real minglobal = 0.0;
+    const int nlevels = repo.num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        amrex::Real minglobal_lev = 0.0;
+        minglobal_lev = amrex::ReduceMin(
+            field(lev), 0.,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& b,
+                amrex::Array4<amrex::Real const> const& field_arr)
+                -> amrex::Real {
+                amrex::Real mx = 0.0;
+                amrex::Loop(b, [=, &mx](int i, int j, int k) noexcept {
+                    amrex::Real mag = 0.0;
+                    for (int icomp = 0; icomp < ncomp; ++icomp) {
+                        mag = mag + field_arr(i, j, k, icomp) *
+                                        field_arr(i, j, k, icomp);
+                    }
+                    mx = amrex::min(std::sqrt(mag), mx);
+                });
+                return mx;
+            });
+        minglobal = amrex::min(minglobal, minglobal_lev);
+    }
+
+    amrex::ParallelAllReduce::Min<amrex::Real>(
+        minglobal, amrex::ParallelContext::CommunicatorSub());
+    return minglobal;
+}
+
 /** Normalizes a field using its magnitude
  * \ingroup field_ops
  *

--- a/amr-wind/fvm/filter_harmonic.H
+++ b/amr-wind/fvm/filter_harmonic.H
@@ -1,0 +1,107 @@
+#ifndef FILTER_HARMONIC_H
+#define FILTER_HARMONIC_H
+
+#include "amr-wind/fvm/fvm_utils.H"
+#include "AMReX_Array4.H"
+#include "AMReX_Geometry.H"
+#include "AMReX_MFIter.H"
+
+namespace amr_wind::fvm {
+
+/** harmonic filter operator
+ *  \ingroup fvm
+ */
+template <typename FTypeIn, typename FTypeOut>
+struct FilterHarmonic
+{
+    /**
+     *  \param filterphi The filter field \f$\widetilde{ \mathbf{\phi}}\f$
+     *  \param phi The input file \f$\phi\f$
+     */
+    FilterHarmonic(FTypeOut& filterphi, const FTypeIn& phi)
+        : m_filterphi(filterphi), m_phi(phi)
+    {
+        AMREX_ALWAYS_ASSERT(filterphi.num_comp() == phi.num_comp());
+    }
+
+    template <typename Stencil>
+    void apply(const int lev, const amrex::MFIter& mfi) const
+    {
+        const int ncomp = m_phi.num_comp();
+        const auto& geom = m_phi.repo().mesh().Geom(lev);
+        const auto& filterphi_arr = m_filterphi(lev).array(mfi);
+        const auto& phi_arr = m_phi(lev).const_array(mfi);
+
+        const auto& bx_in = mfi.tilebox();
+        const auto& bx = Stencil::box(bx_in, geom);
+        if (bx.isEmpty()) {
+            return;
+        }
+
+        amrex::ParallelFor(
+            bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                for (int icomp = 0; icomp < ncomp; icomp++) {
+                    amrex::Real fp1 = Stencil::f00;
+                    amrex::Real f = Stencil::f01;
+                    amrex::Real fm1 = Stencil::f02;
+                    const amrex::Real inv_filx =
+                        (fp1 / phi_arr(i + 1, j, k, icomp) +
+                         f / phi_arr(i, j, k, icomp) +
+                         fm1 / phi_arr(i - 1, j, k, icomp));
+
+                    fp1 = Stencil::f10;
+                    f = Stencil::f11;
+                    fm1 = Stencil::f12;
+                    const amrex::Real inv_fily =
+                        (fp1 / phi_arr(i, j + 1, k, icomp) +
+                         f / phi_arr(i, j, k, icomp) +
+                         fm1 / phi_arr(i, j - 1, k, icomp));
+
+                    fp1 = Stencil::f20;
+                    f = Stencil::f21;
+                    fm1 = Stencil::f22;
+                    const amrex::Real inv_filz =
+                        (fp1 / phi_arr(i, j, k + 1, icomp) +
+                         f / phi_arr(i, j, k, icomp) +
+                         fm1 / phi_arr(i, j, k - 1, icomp));
+                    filterphi_arr(i, j, k, icomp) =
+                        3. / (inv_filx + inv_fily + inv_filz);
+                }
+            });
+    }
+
+    FTypeOut& m_filterphi;
+    const FTypeIn& m_phi;
+};
+
+/** Compute the filtered value of a given field
+ *  \ingroup fvm
+ *
+ *  \param filterphi [inout] Field where the filtered term is populated
+ *  \param phi [in] Field whose filter is computed
+ */
+template <typename FTypeIn, typename FTypeOut>
+inline void filter_harmonic(FTypeOut& filterphi, const FTypeIn& phi)
+{
+    BL_PROFILE("amr-wind::fvm::filter");
+    FilterHarmonic<FTypeIn, FTypeOut> filtering(filterphi, phi);
+    impl::apply(filtering, phi);
+}
+
+/** Compute the filter of a given field and return it as ScratchField
+ *  \ingroup fvm
+ *
+ *  \param phi [in] Field whose filter is computed
+ */
+template <typename FType>
+inline std::unique_ptr<ScratchField> filter_harmonic(const FType& phi)
+{
+    const std::string gname = phi.name() + "_filter";
+    auto filterphi = phi.repo().create_scratch_field(gname, phi.num_comp());
+    filter_harmonic(*filterphi, phi);
+    return filterphi;
+}
+
+} // namespace amr_wind::fvm
+
+#endif /* FILTER_HARMONIC_H */

--- a/amr-wind/fvm/fvm.H
+++ b/amr-wind/fvm/fvm.H
@@ -10,6 +10,7 @@
 #include "amr-wind/fvm/vorticity_mag.H"
 #include "amr-wind/fvm/qcriterion.H"
 #include "amr-wind/fvm/filter.H"
+#include "amr-wind/fvm/filter_harmonic.H"
 
 /**
  *  \defgroup fvm Finite-Volume Operators

--- a/amr-wind/turbulence/LES/Smagorinsky.cpp
+++ b/amr-wind/turbulence/LES/Smagorinsky.cpp
@@ -34,7 +34,7 @@ void Smagorinsky<Transport>::update_turbulent_viscosity(
     const amrex::Real Cs_sqr = this->m_Cs * this->m_Cs;
 
     const bool is_vof = this->m_sim.repo().field_exists("vof");
-    amrex::Real rho_min=0.;
+    amrex::Real rho_min = 1e9;
 
     const auto& vof = this->m_sim.repo().get_field("vof");
     if (is_vof) {

--- a/unit_tests/fvm/CMakeLists.txt
+++ b/unit_tests/fvm/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(
   ${amr_wind_unit_test_exe_name} PRIVATE 
   test_fvm_filtering.cpp
+  test_fvm_filtering_harmonic.cpp
   test_fvm_curvature.cpp
   test_fvm_operators.cpp
   test_fvm_ops.cpp

--- a/unit_tests/fvm/test_fvm_filtering_harmonic.cpp
+++ b/unit_tests/fvm/test_fvm_filtering_harmonic.cpp
@@ -1,0 +1,120 @@
+#include "aw_test_utils/MeshTest.H"
+#include "amr-wind/fvm/filter_harmonic.H"
+#include "aw_test_utils/iter_tools.H"
+#include "aw_test_utils/test_utils.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind_tests {
+
+class FvmOpTestFilteringHarmonic : public MeshTest
+{};
+
+namespace {
+
+void initialize_scalar(
+    const amrex::Box& bx, const amrex::Array4<amrex::Real>& scalar_arr)
+{
+    // grow the box by 1 so that x,y,z go out of bounds and min(max())
+    // corrects it and it fills the ghosts with wall values
+    amrex::ParallelFor(grow(bx, 1), [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        scalar_arr(i, j, k) = (amrex::Real)3 + i + 2 * j + 3 * k;
+    });
+}
+
+amrex::Real filtering_test_impl(amr_wind::Field& scalar, const int pdegree)
+{
+    const int ncoeff = (pdegree + 1) * (pdegree + 1) * (pdegree + 1);
+
+    amrex::Gpu::DeviceVector<amrex::Real> coeff(ncoeff, 0.00123);
+
+    const auto& geom = scalar.repo().mesh().Geom();
+
+    run_algorithm(scalar, [&](const int lev, const amrex::MFIter& mfi) {
+        auto scalar_arr = scalar(lev).array(mfi);
+        const auto& bx = mfi.validbox();
+        initialize_scalar(bx, scalar_arr);
+    });
+
+    auto filtered_scalar = amr_wind::fvm::filter_harmonic(scalar);
+
+    const int nlevels = scalar.repo().num_active_levels();
+    amrex::Real error_total = 0.0;
+    const amrex::Real* coeff_ptr = coeff.data();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+
+        error_total += amrex::ReduceSum(
+            (*filtered_scalar)(lev), 0,
+            [=] AMREX_GPU_HOST_DEVICE(
+                amrex::Box const& bx,
+                amrex::Array4<amrex::Real const> const& filter_arr)
+                -> amrex::Real {
+                amrex::Real error = 0.0;
+
+                amrex::Loop(bx, [=, &error](int i, int j, int k) noexcept {
+                    const amrex::Real ph111 =
+                        (amrex::Real)3 + i + 2 * j + 3 * k;
+                    const amrex::Real ph011 =
+                        (amrex::Real)3 + (i - 1) + 2 * j + 3 * k;
+                    const amrex::Real ph211 =
+                        (amrex::Real)3 + (i + 1) + 2 * j + 3 * k;
+                    const amrex::Real ph101 =
+                        (amrex::Real)3 + i + 2 * (j - 1) + 3 * k;
+                    const amrex::Real ph121 =
+                        (amrex::Real)3 + i + 2 * (j + 1) + 3 * k;
+                    const amrex::Real ph110 =
+                        (amrex::Real)3 + i + 2 * j + 3 * (k - 1);
+                    const amrex::Real ph112 =
+                        (amrex::Real)3 + i + 2 * j + 3 * (k + 1);
+
+                    const amrex::Real inv_filx =
+                        0.25 / ph011 + 0.5 / ph111 + 0.25 / ph211;
+                    const amrex::Real inv_fily =
+                        0.25 / ph101 + 0.5 / ph111 + 0.25 / ph121;
+                    const amrex::Real inv_filz =
+                        0.25 / ph110 + 0.5 / ph111 + 0.25 / ph112;
+
+                    const amrex::Real phi_fil =
+                        3.0 / (inv_filx + inv_fily + inv_filz);
+
+                    error += std::abs(filter_arr(i, j, k) - phi_fil);
+                });
+
+                return error;
+            });
+    }
+
+    return error_total;
+}
+
+} // namespace
+
+TEST_F(FvmOpTestFilteringHarmonic, filter)
+{
+    // This test only evaluates the expected behavior in the bulk
+    // -- relying on ordinary filter unit test for bc behavior
+
+    constexpr double tol = 1.0e-11;
+
+    populate_parameters();
+    {
+        amrex::ParmParse pp("geometry");
+        amrex::Vector<int> periodic{{1, 1, 1}};
+        pp.addarr("is_periodic", periodic);
+    }
+
+    initialize_mesh();
+
+    auto& repo = sim().repo();
+    const int ncomp = 1;
+    const int nghost = 1;
+    auto& scalar = repo.declare_field("scalar", ncomp, nghost);
+    const int pdegree = 1;
+    auto error_total = filtering_test_impl(scalar, pdegree);
+
+    amrex::ParallelDescriptor::ReduceRealSum(error_total);
+
+    EXPECT_NEAR(error_total, 0.0, tol);
+}
+
+} // namespace amr_wind_tests


### PR DESCRIPTION
When conducting wave simulations in AMR-Wind involving sea surface interactions, the viscosity near the interaction region can exhibit unusually high values. This phenomenon arises from the Volume of Fluid (VOF) method, where viscosity is multiplied by density. Given that water density is approximately 1000 times that of air, this multiplication significantly amplifies the turbulent viscosity. Simulations of ABL + waves with the Smagorinsky model do not work because the high values of viscosity require too small a time-step, and the simulation becomes unstable and crashes. 

The main challenge comes from separating the two phases for density and viscosity but using the gradients of the entire flow field.  In the case of volume fractions between 0 and 1, the gradients of the flow will be dominated by the fastest moving flow (the air). The high gradients will create an artificially high turbulent viscosity that will get multiplied by the artificially high turbulent viscosity. For this reason, it makes more sense to only use the turbulent viscosity for air whenever the volume fraction is less than one. This will ensure that the turbulent viscosity will not be artificially higher when there is water in the cell.

This code is one of the ideas I have to mitigate this problem. 
It involves finding the minimum density in the flow and assigning it whenever the volume fraction is less than one. 

I am looking to start a conversation around solving this issue and we can come up with other approaches as well. 