### PR TITLE
Fix to spinner sampler num_output_points 

### DIFF
--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.H
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.H
@@ -65,7 +65,10 @@ public:
 
     long num_points() const override { return (m_beam_points * m_ntotal); }
 
-    long num_output_points() const override { return (m_beam_points * m_ntotal); }
+    long num_output_points() const override
+    {
+        return (m_beam_points * m_ntotal);
+    }
 
     void
     define_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;

--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.H
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.H
@@ -65,6 +65,8 @@ public:
 
     long num_points() const override { return (m_beam_points * m_ntotal); }
 
+    long num_output_points() const override { return (m_beam_points * m_ntotal); }
+
     void
     define_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
     void

--- a/test/test_files/abl_virtual_lidar/abl_virtual_lidar.inp
+++ b/test/test_files/abl_virtual_lidar/abl_virtual_lidar.inp
@@ -65,13 +65,23 @@ sampling.lidar.azimuth_table= 0 90.0
 sampling.lidar.elevation_table= 0 45.0
 
 sampling.spinner.type       = DTUSpinnerSampler
-sampling.spinner.dt_s = 0.1
-sampling.spinner.num_points = 25
-sampling.spinner.origin = 250.0 250.0 250.0
-sampling.spinner.length= 200.0
-sampling.spinner.time_table= 0 11.0
-sampling.spinner.azimuth_table= 0 90.0
-sampling.spinner.elevation_table= 0 300.0
+sampling.spinner.mode                       = fixed #use "hub" to connect to turbine named below 
+sampling.spinner.turbine                   = WTG01
+sampling.spinner.hub_debug                  = false
+sampling.spinner.inner_prism_theta0       = 90
+sampling.spinner.inner_prism_rotrate        = 3.5
+sampling.spinner.inner_prism_azimuth      = 15.2
+sampling.spinner.outer_prism_theta0      = 90
+sampling.spinner.outer_prism_rotrate      = 6.5
+sampling.spinner.outer_prism_azimuth       = 15.2
+sampling.spinner.lidar_center              = 250.0 250.0 250.0 #this gets ovewritten for "hub"
+sampling.spinner.scan_time                  = 2
+sampling.spinner.num_samples              = 984
+sampling.spinner.beam_length              = 200.0 # test smaller number
+sampling.spinner.beam_points              = 25
+sampling.spinner.fixed_yaw                  = 0
+sampling.spinner.fixed_roll              = 0
+sampling.spinner.fixed_tilt              = 0
 
 
 

--- a/test/test_files/abl_virtual_lidar/abl_virtual_lidar.inp
+++ b/test/test_files/abl_virtual_lidar/abl_virtual_lidar.inp
@@ -64,24 +64,24 @@ sampling.lidar.time_table= 0 10.0
 sampling.lidar.azimuth_table= 0 90.0
 sampling.lidar.elevation_table= 0 45.0
 
-sampling.spinner.type       = DTUSpinnerSampler
-sampling.spinner.mode                       = fixed #use "hub" to connect to turbine named below 
-sampling.spinner.turbine                   = WTG01
-sampling.spinner.hub_debug                  = false
+sampling.spinner.type                     = DTUSpinnerSampler
+sampling.spinner.mode                     = fixed #use "hub" to connect to turbine named below 
+sampling.spinner.turbine                  = WTG01 #ignored if mode=fixed
+sampling.spinner.hub_debug                = false
 sampling.spinner.inner_prism_theta0       = 90
-sampling.spinner.inner_prism_rotrate        = 3.5
+sampling.spinner.inner_prism_rotrate      = 3.5
 sampling.spinner.inner_prism_azimuth      = 15.2
-sampling.spinner.outer_prism_theta0      = 90
+sampling.spinner.outer_prism_theta0       = 90
 sampling.spinner.outer_prism_rotrate      = 6.5
-sampling.spinner.outer_prism_azimuth       = 15.2
-sampling.spinner.lidar_center              = 250.0 250.0 250.0 #this gets ovewritten for "hub"
-sampling.spinner.scan_time                  = 2
+sampling.spinner.outer_prism_azimuth      = 15.2
+sampling.spinner.lidar_center             = 250.0 250.0 250.0 #this gets overwritten for "hub" mode
+sampling.spinner.scan_time                = 2
 sampling.spinner.num_samples              = 984
-sampling.spinner.beam_length              = 200.0 # test smaller number
+sampling.spinner.beam_length              = 100.0
 sampling.spinner.beam_points              = 25
-sampling.spinner.fixed_yaw                  = 0
-sampling.spinner.fixed_roll              = 0
-sampling.spinner.fixed_tilt              = 0
+sampling.spinner.fixed_yaw                = 0
+sampling.spinner.fixed_roll               = 0
+sampling.spinner.fixed_tilt               = 0
 
 
 


### PR DESCRIPTION
This was introduced when radar sampler was introduced and num_points() no longer was assumed as the number of sampler output points. 