### PR TITLE
Ocean Waves Improvements, esp. Stokes Waves

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
+++ b/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
@@ -18,6 +18,8 @@ struct RelaxZonesBaseData
 
     amrex::Real water_depth{0.5};
 
+    amrex::Real g{9.81};
+
     // Wave generation/absorption parameters
     amrex::Real gen_length{4.0};
 

--- a/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
+++ b/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
@@ -18,7 +18,8 @@ struct RelaxZonesBaseData
 
     amrex::Real water_depth{0.5};
 
-    amrex::Real g{9.81};
+    // Gravitational constant - wave types that use gravity store value here
+    amrex::Real g;
 
     // Wave generation/absorption parameters
     amrex::Real gen_length{4.0};

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -68,20 +68,22 @@ struct InitDataOp<LinearWaves>
                             0.5);
                         const amrex::Real phase = wavenumber * xc;
                         const amrex::Real eta =
-                            waveheight / 2.0 * std::cos(phase);
+                            waveheight / 2.0 * std::cos(phase) + zsl;
 
                         phi(i, j, k) = eta - zc;
 
                         if (phi(i, j, k) >= 0) {
                             vel(i, j, k, 0) =
                                 omega * waveheight / 2.0 *
-                                std::cosh(wavenumber * (zc + waterdepth)) /
+                                std::cosh(
+                                    wavenumber * (zc - zsl + waterdepth)) /
                                 std::sinh(wavenumber * waterdepth) *
                                 std::cos(phase);
                             vel(i, j, k, 1) = 0.0;
                             vel(i, j, k, 2) =
                                 omega * waveheight / 2.0 *
-                                std::sinh(wavenumber * (zc + waterdepth)) /
+                                std::sinh(
+                                    wavenumber * (zc - zsl + waterdepth)) /
                                 std::sinh(wavenumber * waterdepth) *
                                 std::sin(phase);
                         }
@@ -130,6 +132,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
                 const amrex::Real waveheight = wdata.wave_height;
                 const amrex::Real wavelength = wdata.wave_length;
                 const amrex::Real waterdepth = wdata.water_depth;
+                const amrex::Real zsl = wdata.zsl;
                 const amrex::Real g = wdata.g;
 
                 const auto& gbx = mfi.growntilebox(3);
@@ -146,20 +149,22 @@ struct UpdateRelaxZonesOp<LinearWaves>
                             wavenumber * xc - omega * time;
 
                         const amrex::Real eta =
-                            waveheight / 2.0 * std::cos(phase);
+                            waveheight / 2.0 * std::cos(phase) + zsl;
 
                         phi(i, j, k) = eta - zc;
 
                         if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
                             vel(i, j, k, 0) =
                                 omega * waveheight / 2.0 *
-                                std::cosh(wavenumber * (zc + waterdepth)) /
+                                std::cosh(
+                                    wavenumber * (zc - zsl + waterdepth)) /
                                 std::sinh(wavenumber * waterdepth) *
                                 std::cos(phase);
                             vel(i, j, k, 1) = 0.0;
                             vel(i, j, k, 2) =
                                 omega * waveheight / 2.0 *
-                                std::sinh(wavenumber * (zc + waterdepth)) /
+                                std::sinh(
+                                    wavenumber * (zc - zsl + waterdepth)) /
                                 std::sinh(wavenumber * waterdepth) *
                                 std::sin(phase);
                         }

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -64,8 +64,7 @@ struct InitDataOp<LinearWaves>
 
                         const amrex::Real wavenumber = 2. * M_PI / wavelength;
                         const amrex::Real omega = std::pow(
-                            wavenumber * g *
-                                std::tanh(wavenumber * waterdepth),
+                            wavenumber * g * std::tanh(wavenumber * waterdepth),
                             0.5);
                         const amrex::Real phase = wavenumber * xc;
                         const amrex::Real eta =
@@ -141,8 +140,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
 
                         const amrex::Real wavenumber = 2. * M_PI / wavelength;
                         const amrex::Real omega = std::pow(
-                            wavenumber * g *
-                                std::tanh(wavenumber * waterdepth),
+                            wavenumber * g * std::tanh(wavenumber * waterdepth),
                             0.5);
                         const amrex::Real phase =
                             wavenumber * xc - omega * time;

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -19,6 +19,8 @@ struct ReadInputsOp<LinearWaves>
         auto& wdata = data.meta();
         auto& info = data.info();
         relaxation_zones::read_inputs(wdata, info, pp);
+        // Get gravity from MultiPhase physics, assume negative z
+        wdata.g = -data.sim().physics_manager().get<MultiPhase>().gravity()[2];
 
         pp.get("wave_length", wdata.wave_length);
         pp.get("wave_height", wdata.wave_height);
@@ -48,6 +50,7 @@ struct InitDataOp<LinearWaves>
             const auto& vel = m_velocity(level).array(mfi);
 
             const amrex::Real zsl = wdata.zsl;
+            const amrex::Real g = wdata.g;
             const auto& gbx3 = mfi.growntilebox(3);
 
             if (wdata.init_wave_field) {
@@ -61,7 +64,7 @@ struct InitDataOp<LinearWaves>
 
                         const amrex::Real wavenumber = 2. * M_PI / wavelength;
                         const amrex::Real omega = std::pow(
-                            wavenumber * 9.81 *
+                            wavenumber * g *
                                 std::tanh(wavenumber * waterdepth),
                             0.5);
                         const amrex::Real phase = wavenumber * xc;
@@ -128,6 +131,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
                 const amrex::Real waveheight = wdata.wave_height;
                 const amrex::Real wavelength = wdata.wave_length;
                 const amrex::Real waterdepth = wdata.water_depth;
+                const amrex::Real g = wdata.g;
 
                 const auto& gbx = mfi.growntilebox(3);
                 amrex::ParallelFor(
@@ -137,7 +141,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
 
                         const amrex::Real wavenumber = 2. * M_PI / wavelength;
                         const amrex::Real omega = std::pow(
-                            wavenumber * 9.81 *
+                            wavenumber * g *
                                 std::tanh(wavenumber * waterdepth),
                             0.5);
                         const amrex::Real phase =

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -35,10 +35,9 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
     if (k < tol || iter >= iter_max || std::isnan(k)) {
         // Return negative wavelength if faulty result
         return -1;
-    } else {
-        // Return wavelength calculated from wavenumber
-        return 2.0 * M_PI / k;
     }
+    // Return wavelength calculated from wavenumber
+    return 2.0 * M_PI / k;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_coefficients(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -108,9 +108,15 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
         f -= omega * omega;
     }
 
-    if (k < tol || iter >= iter_max || std::isnan(k)) {
+    if (k < tol) {
         // Return negative wavelength if faulty result
         return -1;
+    }
+    if (std::isnan(k)) {
+        return -2;
+    }
+    if (iter == iter_max) {
+        return -3;
     }
     // Return wavelength calculated from wavenumber
     return 2.0 * M_PI / k;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -234,7 +234,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
     }
 
     return std::pow(eps, m) * D * n * wavenumber *
-           std::cosh(m * wavenumber * (waterdepth + z)) * std::cos(n * phase);
+           std::cosh(n * wavenumber * (waterdepth + z)) * std::cos(n * phase);
 }
 
 // Based on Fenton 1985
@@ -262,7 +262,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
 
     stokes_coefficients(
         StokesOrder, wavenumber, waterdepth, c0, a11, a22, b22, c2, d2, e2, a31,
-        a33, b31, a42, a44, b42, b44, c4, d4, e4, a51, b53, a55, b53, b55);
+        a33, b31, a42, a44, b42, b44, c4, d4, e4, a51, a53, a55, b53, b55);
 
     const amrex::Real eps = wavenumber * waveheight / 2.; // Steepness (ka)
     const amrex::Real c = (c0 + std::pow(eps, 2) * c2 + std::pow(eps, 4) * c4) *

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -401,7 +401,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
              (std::cos(2. * phase) + b44 * std::cos(4. * phase)) +
          std::pow(eps, 5) *
              (-(b53 + b55) * std::cos(phase) + b53 * std::cos(3 * phase) +
-              b55 * std::cos(5 * phase)));
+              b55 * std::cos(5 * phase))) + zsl;
 
     // Compute cosines
     const amrex::Real cc11 = stokes_cosh_cos(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -216,7 +216,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_sinh_sin(
     }
 
     return std::pow(eps, m) * D * n * wavenumber *
-           std::sinh(n * wavenumber * (waterdepth + (z - zsl))) * std::sin(n * phase);
+           std::sinh(n * wavenumber * (waterdepth + (z - zsl))) *
+           std::sin(n * phase);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
@@ -268,7 +269,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
     }
 
     return std::pow(eps, m) * D * n * wavenumber *
-           std::cosh(n * wavenumber * (waterdepth + (z - zsl))) * std::cos(n * phase);
+           std::cosh(n * wavenumber * (waterdepth + (z - zsl))) *
+           std::cos(n * phase);
 }
 
 // Based on Fenton 1985

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -167,7 +167,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_coefficients(
     }
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_sinh_sin(
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real stokes_sinh_sin(
     int m,
     int n,
     amrex::Real phase,
@@ -220,7 +220,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_sinh_sin(
            std::sin(n * phase);
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real stokes_cosh_cos(
     int m,
     int n,
     amrex::Real phase,
@@ -324,60 +324,60 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
               b55 * std::cos(5 * phase)));
 
     // Compute cosines
-    const amrex::Real cc11 = my_cosh_cos(
+    const amrex::Real cc11 = stokes_cosh_cos(
         1, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc22 = my_cosh_cos(
+    const amrex::Real cc22 = stokes_cosh_cos(
         2, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc31 = my_cosh_cos(
+    const amrex::Real cc31 = stokes_cosh_cos(
         3, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc33 = my_cosh_cos(
+    const amrex::Real cc33 = stokes_cosh_cos(
         3, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc42 = my_cosh_cos(
+    const amrex::Real cc42 = stokes_cosh_cos(
         4, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc44 = my_cosh_cos(
+    const amrex::Real cc44 = stokes_cosh_cos(
         4, 4, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc51 = my_cosh_cos(
+    const amrex::Real cc51 = stokes_cosh_cos(
         5, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc53 = my_cosh_cos(
+    const amrex::Real cc53 = stokes_cosh_cos(
         5, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real cc55 = my_cosh_cos(
+    const amrex::Real cc55 = stokes_cosh_cos(
         5, 5, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
 
     // Compute sines
-    const amrex::Real ss11 = my_sinh_sin(
+    const amrex::Real ss11 = stokes_sinh_sin(
         1, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss22 = my_sinh_sin(
+    const amrex::Real ss22 = stokes_sinh_sin(
         2, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss31 = my_sinh_sin(
+    const amrex::Real ss31 = stokes_sinh_sin(
         3, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss33 = my_sinh_sin(
+    const amrex::Real ss33 = stokes_sinh_sin(
         3, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss42 = my_sinh_sin(
+    const amrex::Real ss42 = stokes_sinh_sin(
         4, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss44 = my_sinh_sin(
+    const amrex::Real ss44 = stokes_sinh_sin(
         4, 4, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss51 = my_sinh_sin(
+    const amrex::Real ss51 = stokes_sinh_sin(
         5, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss53 = my_sinh_sin(
+    const amrex::Real ss53 = stokes_sinh_sin(
         5, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
-    const amrex::Real ss55 = my_sinh_sin(
+    const amrex::Real ss55 = stokes_sinh_sin(
         5, 5, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
         wavenumber, waterdepth, zsl, z);
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -10,6 +10,38 @@
 
 namespace amr_wind::ocean_waves::relaxation_zones {
 
+// Compute wavelength as a function of wave period, water depth, and g
+AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
+    const amrex::Real T, const amrex::Real d, const amrex::Real g)
+{
+    const amrex::Real omega = 2.0 * M_PI / T;
+    const amrex::Real lambda0 = (g * T * T) / 2.0 / M_PI;
+
+    // Begin Newton-Raphson iterations
+    constexpr amrex::Real tol = 1e-10;
+    constexpr int iter_max = 20;
+    int iter = 0;
+    amrex::Real k = omega / std::sqrt(g);
+    amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
+    while (f > 1e-10 && iter < iter_max) {
+        const amrex::Real dfdk =
+            g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
+            g * std::tanh(k * d);
+        k = k - f / dfdk;
+
+        iter += 1;
+        f = g * k * std::tanh(k * d) - omega * omega;
+    }
+
+    if (k < tol || iter >= iter_max || isnan(k)) {
+        // Return negative wavelength if faulty result
+        return -1;
+    } else {
+        // Return wavelength calculated from wavenumber
+        return 2.0 * M_PI / k;
+    }
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_coefficients(
     int StokesOrder,
     amrex::Real wavenumber,

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -16,15 +16,15 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
     const amrex::Real d,
     const amrex::Real H,
     const int order,
-    const amrex::Real g)
+    const amrex::Real g,
+    const amrex::Real tol,
+    const int iter_max)
 {
     // Calculate constants and derivatives that do not change with iteration
     const amrex::Real omega = 2.0 * M_PI / T;
     const amrex::Real depsdk = H / 2.0;
 
     // Begin Newton-Raphson iterations
-    constexpr amrex::Real tol = 1e-10;
-    constexpr int iter_max = 40;
     int iter = 0;
     // First guess is first-order
     amrex::Real k = omega / std::sqrt(g);

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -15,7 +15,6 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
     const amrex::Real T, const amrex::Real d, const amrex::Real g)
 {
     const amrex::Real omega = 2.0 * M_PI / T;
-    const amrex::Real lambda0 = (g * T * T) / 2.0 / M_PI;
 
     // Begin Newton-Raphson iterations
     constexpr amrex::Real tol = 1e-10;
@@ -33,7 +32,7 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
         f = g * k * std::tanh(k * d) - omega * omega;
     }
 
-    if (k < tol || iter >= iter_max || isnan(k)) {
+    if (k < tol || iter >= iter_max || std::isnan(k)) {
         // Return negative wavelength if faulty result
         return -1;
     } else {

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -12,24 +12,100 @@ namespace amr_wind::ocean_waves::relaxation_zones {
 
 // Compute wavelength as a function of wave period, water depth, and g
 AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
-    const amrex::Real T, const amrex::Real d, const amrex::Real g)
+    const amrex::Real T,
+    const amrex::Real d,
+    const amrex::Real H,
+    const int order,
+    const amrex::Real g)
 {
+    // Calculate constants and derivatives that do not change with iteration
     const amrex::Real omega = 2.0 * M_PI / T;
+    const amrex::Real depsdk = H / 2.0;
 
     // Begin Newton-Raphson iterations
     constexpr amrex::Real tol = 1e-10;
-    constexpr int iter_max = 20;
+    constexpr int iter_max = 40;
     int iter = 0;
+    // First guess is first-order
     amrex::Real k = omega / std::sqrt(g);
-    amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
-    while (f > tol && iter < iter_max) {
-        const amrex::Real dfdk =
-            g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
-            g * std::tanh(k * d);
+    // Cannot skip loop
+    amrex::Real f = tol + 1.0;
+    while (std::abs(f) > tol && iter < iter_max) {
+        // Calculate current constants
+        const amrex::Real S = 1.0 / std::cosh(2.0 * k * d);
+        const amrex::Real C = 1.0 - S;
+        const amrex::Real eps = k * H / 2.0;
+        const amrex::Real C0 = std::sqrt(std::tanh(k * d));
+        const amrex::Real C2 = C0 * (2.0 + 7.0 * S * S) / (4.0 * C * C);
+        const amrex::Real numterm_C4 =
+            (4.0 + 32.0 * S - 116.0 * std::pow(S, 2) - 400.0 * std::pow(S, 3) -
+             71.0 * std::pow(S, 4) + 146.0 * std::pow(S, 5));
+        const amrex::Real C4 = C0 * numterm_C4 / (32.0 * std::pow(C, 5));
+        // Calculate pure derivates
+        const amrex::Real dSdk = -2.0 * d * std::sinh(2.0 * k * d) /
+                                 std::pow(std::cosh(2.0 * k * d), 2);
+        const amrex::Real dCdk = -dSdk;
+        const amrex::Real dC0dk =
+            d / (2.0 * C0 * std::pow(std::cosh(k * d), 2));
+        // Calculate derivatives with products
+        const amrex::Real dC2dk =
+            (4 * std::pow(C, 2) *
+                 (dC0dk * (2.0 + 7.0 * std::pow(S, 2)) + C0 * 14.0 * S * dSdk) -
+             C0 * (2.0 + 7.0 * std::pow(S, 2)) * 8.0 * C * dCdk) /
+            (16.0 * std::pow(C, 4));
+        const amrex::Real dC4dk =
+            (32.0 * std::pow(C, 5) *
+                 (dC0dk * numterm_C4 +
+                  C0 * (32.0 * dSdk - 232.0 * S * dSdk -
+                        1200 * std::pow(S, 2) * dSdk -
+                        284.0 * std::pow(S, 3) * dSdk + 730 * std::pow(S, 4))) -
+             C0 * numterm_C4 * 160.0 * std::pow(C, 4) * dCdk) /
+            (1024.0 * std::pow(C, 10));
+
+        // Calculate derivative for loop convergence
+        amrex::Real dfdk = g * std::pow(C0, 2) + g * k * 2.0 * C0 * dC0dk;
+        // Add additional terms depending on order
+        if (order >= 2) {
+            dfdk +=
+                g * (2.0 * C0 * std::pow(eps, 2) * C2 +
+                     std::pow(eps, 4) * std::pow(C2, 2)) +
+                g * k *
+                    (2.0 * dC0dk * std::pow(eps, 2) * C2 +
+                     2.0 * C0 *
+                         (2.0 * eps * depsdk * C2 + std::pow(eps, 2) * dC2dk) +
+                     4.0 * std::pow(eps, 3) * std::pow(C2, 2) * depsdk +
+                     std::pow(eps, 4) * 2.0 * C2 * dC2dk);
+        }
+        if (order >= 4) {
+            dfdk += g * (2.0 * std::pow(eps, 4) * C0 * C4 +
+                         2.0 * std::pow(eps, 6) * C2 * C4 +
+                         std::pow(eps, 8) * std::pow(C4, 2)) +
+                    g * k *
+                        (8.0 * std::pow(eps, 3) * depsdk * C0 * C4 +
+                         2.0 * std::pow(eps, 4) * (C0 * dC4dk + C4 * dC0dk) +
+                         12 * std::pow(eps, 5) * depsdk * C2 * C4 +
+                         2.0 * std::pow(eps, 6) * (C2 * dC4dk + C4 * dC2dk) +
+                         8.0 * std::pow(eps, 7) * depsdk * std::pow(C4, 2) +
+                         std::pow(eps, 8) * 2.0 * C4 * dC4dk);
+        }
         k = k - f / dfdk;
 
         iter += 1;
-        f = g * k * std::tanh(k * d) - omega * omega;
+        f = g * k * std::pow(C0, 2);
+        // Add additional terms depending on order
+        if (order >= 2) {
+            f += g * k *
+                 (2.0 * C0 * std::pow(eps, 2) * C2 +
+                  std::pow(eps, 4) * std::pow(C2, 2));
+        }
+        if (order >= 4) {
+            f += g * k *
+                 (2.0 * std::pow(eps, 4) * C0 * C4 +
+                  2.0 * std::pow(eps, 6) * C2 * C4 +
+                  std::pow(eps, 8) * std::pow(C4, 2));
+        }
+        // Subtract omega^2 to measure convergence
+        f -= omega * omega;
     }
 
     if (k < tol || iter >= iter_max || std::isnan(k)) {

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -4,6 +4,10 @@
 #include <AMReX_FArrayBox.H>
 #include <cmath>
 
+// Stokes waves theory adapted from
+// Fenton, J., Fifth Order Stokes Theory for Steady Waves
+// Journal of Waterway, Port, Coastal and Ocean Engineering, 1985, 111, 216-234
+
 namespace amr_wind::ocean_waves::relaxation_zones {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_coefficients(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -23,7 +23,7 @@ AMREX_FORCE_INLINE amrex::Real stokes_wave_length(
     int iter = 0;
     amrex::Real k = omega / std::sqrt(g);
     amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
-    while (f > 1e-10 && iter < iter_max) {
+    while (f > tol && iter < iter_max) {
         const amrex::Real dfdk =
             g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
             g * std::tanh(k * d);

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -393,15 +393,15 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     const amrex::Real omega = c * wavenumber;
     const amrex::Real phase = wavenumber * x - omega * time;
 
-    eta =
-        (eps * std::cos(phase)                           // first order term
-         + std::pow(eps, 2) * b22 * std::cos(2. * phase) // second order term
-         + std::pow(eps, 3) * b31 * (std::cos(phase) - std::cos(3. * phase)) +
-         std::pow(eps, 4) * b42 *
-             (std::cos(2. * phase) + b44 * std::cos(4. * phase)) +
-         std::pow(eps, 5) *
-             (-(b53 + b55) * std::cos(phase) + b53 * std::cos(3 * phase) +
-              b55 * std::cos(5 * phase))) + zsl;
+    eta = (eps * std::cos(phase)                           // first order term
+           + std::pow(eps, 2) * b22 * std::cos(2. * phase) // second order term
+           + std::pow(eps, 3) * b31 * (std::cos(phase) - std::cos(3. * phase)) +
+           std::pow(eps, 4) * b42 *
+               (std::cos(2. * phase) + b44 * std::cos(4. * phase)) +
+           std::pow(eps, 5) *
+               (-(b53 + b55) * std::cos(phase) + b53 * std::cos(3 * phase) +
+                b55 * std::cos(5 * phase))) +
+          zsl;
 
     // Compute cosines
     const amrex::Real cc11 = stokes_cosh_cos(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -183,6 +183,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_sinh_sin(
     amrex::Real eps,
     amrex::Real wavenumber,
     amrex::Real waterdepth,
+    amrex::Real zsl,
     amrex::Real z)
 {
     amrex::Real D = 0.0;
@@ -215,7 +216,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_sinh_sin(
     }
 
     return std::pow(eps, m) * D * n * wavenumber *
-           std::sinh(n * wavenumber * (waterdepth + z)) * std::sin(n * phase);
+           std::sinh(n * wavenumber * (waterdepth + (z - zsl))) * std::sin(n * phase);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
@@ -234,6 +235,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
     amrex::Real eps,
     amrex::Real wavenumber,
     amrex::Real waterdepth,
+    amrex::Real zsl,
     amrex::Real z)
 {
     amrex::Real D = 0.0;
@@ -266,7 +268,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real my_cosh_cos(
     }
 
     return std::pow(eps, m) * D * n * wavenumber *
-           std::cosh(n * wavenumber * (waterdepth + z)) * std::cos(n * phase);
+           std::cosh(n * wavenumber * (waterdepth + (z - zsl))) * std::cos(n * phase);
 }
 
 // Based on Fenton 1985
@@ -275,6 +277,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     amrex::Real wavelength,
     amrex::Real waterdepth,
     amrex::Real waveheight,
+    amrex::Real zsl,
+    amrex::Real g,
     amrex::Real x,
     amrex::Real z,
     amrex::Real time,
@@ -298,11 +302,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
 
     const amrex::Real eps = wavenumber * waveheight / 2.; // Steepness (ka)
     const amrex::Real c = (c0 + std::pow(eps, 2) * c2 + std::pow(eps, 4) * c4) *
-                          std::sqrt(9.81 / wavenumber);
+                          std::sqrt(g / wavenumber);
     // const amrex::Real Q =
-    //    c * waterdepth * std::sqrt(std::pow(k, 3) / 9.81) +
+    //    c * waterdepth * std::sqrt(std::pow(k, 3) / g) +
     //    d2 * std::pow(eps, 2) +
-    //    d4 * std::pow(eps, 4) * std::sqrt(9.81 / std::pow(k, 3));
+    //    d4 * std::pow(eps, 4) * std::sqrt(g / std::pow(k, 3));
 
     const amrex::Real omega = c * wavenumber;
     const amrex::Real phase = wavenumber * x - omega * time;
@@ -320,65 +324,65 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     // Compute cosines
     const amrex::Real cc11 = my_cosh_cos(
         1, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc22 = my_cosh_cos(
         2, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc31 = my_cosh_cos(
         3, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc33 = my_cosh_cos(
         3, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc42 = my_cosh_cos(
         4, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc44 = my_cosh_cos(
         4, 4, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc51 = my_cosh_cos(
         5, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc53 = my_cosh_cos(
         5, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real cc55 = my_cosh_cos(
         5, 5, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
 
     // Compute sines
     const amrex::Real ss11 = my_sinh_sin(
         1, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss22 = my_sinh_sin(
         2, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss31 = my_sinh_sin(
         3, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss33 = my_sinh_sin(
         3, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss42 = my_sinh_sin(
         4, 2, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss44 = my_sinh_sin(
         4, 4, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss51 = my_sinh_sin(
         5, 1, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss53 = my_sinh_sin(
         5, 3, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
     const amrex::Real ss55 = my_sinh_sin(
         5, 5, phase, a11, a22, a31, a33, a42, a44, a51, a53, a55, eps,
-        wavenumber, waterdepth, z);
+        wavenumber, waterdepth, zsl, z);
 
-    u_w = c0 * std::sqrt(9.81 / std::pow(wavenumber, 3)) *
+    u_w = c0 * std::sqrt(g / std::pow(wavenumber, 3)) *
           (cc11 + cc22 + cc31 + cc33 + cc42 + cc44 + cc51 + cc53 + cc55);
     v_w = 0.0;
-    w_w = c0 * std::sqrt(9.81 / std::pow(wavenumber, 3)) *
+    w_w = c0 * std::sqrt(g / std::pow(wavenumber, 3)) *
           (ss11 + ss22 + ss31 + ss33 + ss42 + ss44 + ss51 + ss53 + ss55);
 }
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -9,6 +9,42 @@
 #include "amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.H"
 #include "amr-wind/equation_systems/vof/volume_fractions.H"
 
+namespace amr_wind::ocean_waves::relaxation_zones {
+
+// Compute wavelength as a function of wave period, water depth, and g
+amrex::Real stokes_wave_length(
+    const amrex::Real T, const amrex::Real d, const amrex::Real g)
+{
+    const amrex::Real omega = 2.0 * M_PI / T;
+    const amrex::Real lambda0 = (g * T * T) / 2.0 / M_PI;
+
+    // Begin Newton-Raphson iterations
+    constexpr amrex::Real tol = 1e-10;
+    constexpr int iter_max = 20;
+    int iter = 0;
+    amrex::Real k = omega / std::sqrt(g);
+    amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
+    while (f > 1e-10 || iter < iter_max) {
+        const amrex::Real dfdk =
+            g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
+            g * std::tanh(k * d);
+        k = k - f / dfdk;
+
+        iter += 1;
+        f = g * k * std::tanh(k * d) - omega * omega;
+    }
+
+    if (k < tol || iter >= iter_max || isnan(k)) {
+        // Return negative wavelength if faulty result
+        return -1;
+    } else {
+        // Return wavelength calculated from wavenumber
+        return 2.0 * M_PI / k;
+    }
+}
+
+} // namespace amr_wind::ocean_waves::relaxation_zones
+
 namespace amr_wind::ocean_waves::ops {
 
 template <>
@@ -21,9 +57,29 @@ struct ReadInputsOp<StokesWaves>
         auto& info = data.info();
         relaxation_zones::read_inputs(wdata, info, pp);
 
-        pp.get("wave_length", wdata.wave_length);
         pp.get("wave_height", wdata.wave_height);
         pp.get("order", wdata.order);
+        if (pp.contains("wave_length")) {
+            pp.get("wave_length", wdata.wave_length);
+        } else {
+            // Wave length will be calculated using wave period
+            amrex::Real wave_period = 1.0;
+            pp.get("wave_period", wave_period);
+            // Get gravity from MultiPhase physics
+            const amrex::Real g = std::abs(
+                data.sim().physics_manager().get<MultiPhase>().gravity()[2]);
+            wdata.wave_length = relaxation_zones::stokes_wave_length(
+                wave_period, wdata.water_depth, g);
+            // Abort if wave length is negative
+            if (wdata.wave_length < 0.0) {
+                amrex::Abort(
+                    "Failed to properly calculate a wave length in "
+                    "stokes_waves_ops.H");
+            } else {
+                amrex::Print() << "Stokes wave length calculated to be "
+                               << wdata.wave_length << " m.\n";
+            }
+        }
     }
 };
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -29,11 +29,11 @@ struct ReadInputsOp<StokesWaves>
             // Wave length will be calculated using wave period
             amrex::Real wave_period = 1.0;
             pp.get("wave_period", wave_period);
-            // Get gravity from MultiPhase physics
-            const amrex::Real g = std::abs(
-                data.sim().physics_manager().get<MultiPhase>().gravity()[2]);
+            // Get gravity from MultiPhase physics, assume z
+            wdata.g =
+                -data.sim().physics_manager().get<MultiPhase>().gravity()[2];
             wdata.wave_length = relaxation_zones::stokes_wave_length(
-                wave_period, wdata.water_depth, g);
+                wave_period, wdata.water_depth, wdata.g);
             // Abort if wave length is negative
             if (wdata.wave_length < 0.0) {
                 amrex::Abort(
@@ -110,6 +110,8 @@ struct UpdateRelaxZonesOp<StokesWaves>
                 const amrex::Real waveheight = wdata.wave_height;
                 const amrex::Real wavelength = wdata.wave_length;
                 const amrex::Real waterdepth = wdata.water_depth;
+                const amrex::Real zero_sea_level = wdata.zsl;
+                const amrex::Real g = wdata.g;
                 const int order = wdata.order;
 
                 const auto& gbx = mfi.growntilebox();
@@ -121,8 +123,8 @@ struct UpdateRelaxZonesOp<StokesWaves>
                         amrex::Real eta{0.0}, u_w{0.0}, v_w{0.0}, w_w{0.0};
 
                         relaxation_zones::stokes_waves(
-                            order, wavelength, waterdepth, waveheight, x, z,
-                            time, eta, u_w, v_w, w_w);
+                            order, wavelength, waterdepth, waveheight,
+                            zero_sea_level, g, x, z, time, eta, u_w, v_w, w_w);
 
                         phi(i, j, k) = eta - z;
                         if (phi(i, j, k) + 0.5 * dx[2] >= 0) {

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -9,42 +9,6 @@
 #include "amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.H"
 #include "amr-wind/equation_systems/vof/volume_fractions.H"
 
-namespace amr_wind::ocean_waves::relaxation_zones {
-
-// Compute wavelength as a function of wave period, water depth, and g
-amrex::Real stokes_wave_length(
-    const amrex::Real T, const amrex::Real d, const amrex::Real g)
-{
-    const amrex::Real omega = 2.0 * M_PI / T;
-    const amrex::Real lambda0 = (g * T * T) / 2.0 / M_PI;
-
-    // Begin Newton-Raphson iterations
-    constexpr amrex::Real tol = 1e-10;
-    constexpr int iter_max = 20;
-    int iter = 0;
-    amrex::Real k = omega / std::sqrt(g);
-    amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
-    while (f > 1e-10 && iter < iter_max) {
-        const amrex::Real dfdk =
-            g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
-            g * std::tanh(k * d);
-        k = k - f / dfdk;
-
-        iter += 1;
-        f = g * k * std::tanh(k * d) - omega * omega;
-    }
-
-    if (k < tol || iter >= iter_max || isnan(k)) {
-        // Return negative wavelength if faulty result
-        return -1;
-    } else {
-        // Return wavelength calculated from wavenumber
-        return 2.0 * M_PI / k;
-    }
-}
-
-} // namespace amr_wind::ocean_waves::relaxation_zones
-
 namespace amr_wind::ocean_waves::ops {
 
 template <>

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -33,7 +33,7 @@ struct ReadInputsOp<StokesWaves>
             amrex::Real wave_period = 1.0;
             pp.get("wave_period", wave_period);
             wdata.wave_length = relaxation_zones::stokes_wave_length(
-                wave_period, wdata.water_depth, wdata.g);
+                wave_period, wdata.water_depth, wdata.wave_height, wdata.order, wdata.g);
             // Abort if wave length is negative
             if (wdata.wave_length < 0.0) {
                 amrex::Abort(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -32,8 +32,14 @@ struct ReadInputsOp<StokesWaves>
             // Wave length will be calculated using wave period
             amrex::Real wave_period = 1.0;
             pp.get("wave_period", wave_period);
+            // Get user-specified convergence criteria, if supplied
+            amrex::Real tol_lambda = 1e-10;
+            int itmax_lambda = 40;
+            pp.query("stokes_wavelength_tolerance", tol_lambda);
+            pp.query("stokes_wavelength_iter_max", itmax_lambda);
             wdata.wave_length = relaxation_zones::stokes_wave_length(
-                wave_period, wdata.water_depth, wdata.wave_height, wdata.order, wdata.g);
+                wave_period, wdata.water_depth, wdata.wave_height, wdata.order,
+                wdata.g, tol_lambda, itmax_lambda);
             // Abort if wave length is negative
             if (wdata.wave_length < 0.0) {
                 amrex::Abort(

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -21,6 +21,9 @@ struct ReadInputsOp<StokesWaves>
         auto& info = data.info();
         relaxation_zones::read_inputs(wdata, info, pp);
 
+        // Get gravity from MultiPhase physics, assume negative z
+        wdata.g = -data.sim().physics_manager().get<MultiPhase>().gravity()[2];
+        // Get wave attributes
         pp.get("wave_height", wdata.wave_height);
         pp.get("order", wdata.order);
         if (pp.contains("wave_length")) {
@@ -29,9 +32,6 @@ struct ReadInputsOp<StokesWaves>
             // Wave length will be calculated using wave period
             amrex::Real wave_period = 1.0;
             pp.get("wave_period", wave_period);
-            // Get gravity from MultiPhase physics, assume z
-            wdata.g =
-                -data.sim().physics_manager().get<MultiPhase>().gravity()[2];
             wdata.wave_length = relaxation_zones::stokes_wave_length(
                 wave_period, wdata.water_depth, wdata.g);
             // Abort if wave length is negative

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -32,13 +32,18 @@ struct ReadInputsOp<StokesWaves>
             // Wave length will be calculated using wave period
             amrex::Real wave_period = 1.0;
             pp.get("wave_period", wave_period);
+            // User can specify a different order for wavelength calculation,
+            // e.g., an order of 1 will use the linear dispersion relation.
+            // Default is to use the same order as the waves themselves.
+            int order_lambda = wdata.order;
+            pp.query("stokes_wavelength_order", order_lambda);
             // Get user-specified convergence criteria, if supplied
             amrex::Real tol_lambda = 1e-10;
             int itmax_lambda = 40;
             pp.query("stokes_wavelength_tolerance", tol_lambda);
             pp.query("stokes_wavelength_iter_max", itmax_lambda);
             wdata.wave_length = relaxation_zones::stokes_wave_length(
-                wave_period, wdata.water_depth, wdata.wave_height, wdata.order,
+                wave_period, wdata.water_depth, wdata.wave_height, order_lambda,
                 wdata.g, tol_lambda, itmax_lambda);
             // Abort if wave length is negative
             if (wdata.wave_length < 0.0) {

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -42,6 +42,16 @@ struct ReadInputsOp<StokesWaves>
                 wdata.g, tol_lambda, itmax_lambda);
             // Abort if wave length is negative
             if (wdata.wave_length < 0.0) {
+                if (wdata.wave_length == -1) {
+                    amrex::Print() << "Stokes wave length too close to 0.\n";
+                }
+                if (wdata.wave_length == -2) {
+                    amrex::Print() << "Stokes wave length is not a number.\n";
+                }
+                if (wdata.wave_length == -3) {
+                    amrex::Print() << "Stokes wave length calculation used "
+                                      "maximum iterations before converging.\n";
+                }
                 amrex::Abort(
                     "Failed to properly calculate a wave length in "
                     "stokes_waves_ops.H");

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -24,7 +24,7 @@ amrex::Real stokes_wave_length(
     int iter = 0;
     amrex::Real k = omega / std::sqrt(g);
     amrex::Real f = g * k * std::tanh(k * d) - omega * omega;
-    while (f > 1e-10 || iter < iter_max) {
+    while (f > 1e-10 && iter < iter_max) {
         const amrex::Real dfdk =
             g * k * d * std::pow(1.0 / (std::cosh(k * d)), 2) +
             g * std::tanh(k * d);

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -63,6 +63,8 @@ public:
 
     amrex::Real rho2() const { return m_rho2; }
 
+    amrex::Vector<amrex::Real> gravity() const { return m_gravity; }
+
     amrex::Real water_level() const { return water_level0; }
 
 private:

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -73,6 +73,8 @@ MultiPhase::MultiPhase(CFDSim& sim)
         amrex::Print() << "WARNING: single-phase density has been specified "
                           "but will not be used! (MultiPhase physics)\n";
     }
+    // Always populate gravity
+    pp_incflo.queryarr("gravity", m_gravity);
 }
 
 InterfaceCapturingMethod MultiPhase::interface_capturing_method()
@@ -123,8 +125,6 @@ void MultiPhase::post_init_actions()
         // Make p0 field if requested
         if (m_reconstruct_true_pressure) {
             // Initialize p0 field for reconstructing p
-            amrex::ParmParse pp("incflo");
-            pp.queryarr("gravity", m_gravity);
             auto& p0 = m_sim.repo().get_field("reference_pressure");
             hydrostatic::define_p0(
                 p0, m_rho1, m_rho2, water_level0, m_gravity[2],

--- a/unit_tests/ocean_waves/test_wave_theories.cpp
+++ b/unit_tests/ocean_waves/test_wave_theories.cpp
@@ -82,9 +82,11 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
     amrex::Real water_depth = 5.0;
     int wave_order = 5;
     constexpr amrex::Real g = 9.81;
+    constexpr amrex::Real tol_lambda = 1e-10;
     amrex::Real lambda =
         amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
-            wave_period, water_depth, wave_height, wave_order, g);
+            wave_period, water_depth, wave_height, wave_order, g, tol_lambda,
+            20);
 
     // Relation to check is from course notes:
     // https://www.caee.utexas.edu/prof/kinnas/ce358/oenotes/kinnas_stokes11.pdf
@@ -111,7 +113,7 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
     water_depth = 0.9;
     wave_order = 3;
     lambda = amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
-        wave_period, water_depth, wave_height, wave_order, g);
+        wave_period, water_depth, wave_height, wave_order, g, tol_lambda, 31);
 
     k = 2.0 * M_PI / lambda;
     const amrex::Real RHS2 = 2.0 * M_PI / (wave_period * std::sqrt(g * k));

--- a/unit_tests/ocean_waves/test_wave_theories.cpp
+++ b/unit_tests/ocean_waves/test_wave_theories.cpp
@@ -74,4 +74,58 @@ TEST_F(WaveTheoriesTest, StokesWaves)
     EXPECT_NEAR(gold_E4, e4, CoeffTol);
 }
 
+TEST_F(WaveTheoriesTest, StokesWaveLength)
+{
+
+    amrex::Real wave_height = 0.2;
+    amrex::Real wave_period = 2.2;
+    amrex::Real water_depth = 5.0;
+    constexpr amrex::Real g = 9.81;
+    amrex::Real lambda =
+        amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
+            wave_period, water_depth, g);
+
+    // Relation to check is from course notes:
+    // https://www.caee.utexas.edu/prof/kinnas/ce358/oenotes/kinnas_stokes11.pdf
+    amrex::Real k = 2.0 * M_PI / lambda;
+    const amrex::Real RHS1 = 2.0 * M_PI / (wave_period * std::sqrt(g * k));
+
+    amrex::Real S = 1.0 / std::cosh(2.0 * k * water_depth);
+    amrex::Real C = 1.0 - S;
+    amrex::Real eps = k * wave_height / 2.0;
+
+    amrex::Real C0 = std::sqrt(std::tanh(k * water_depth));
+    amrex::Real C2 = C0 * (2.0 + 7.0 * S * S) / (4.0 * C * C);
+    amrex::Real C4 =
+        C0 *
+        (4.0 + 32.0 * S - 116.0 * std::pow(S, 2) - 400.0 * std::pow(S, 3) -
+         71.0 * std::pow(S, 4) + 146.0 * std::pow(S, 5)) /
+        (32.0 * std::pow(C, 5));
+    const amrex::Real LHS1 = C0 + std::pow(eps, 2) * C2 + std::pow(eps, 4) * C4;
+    EXPECT_NEAR(LHS1, RHS1, 1e-8);
+
+    // Reevaluate with a new set of conditions
+    wave_height = 0.05;
+    wave_period = 1.5;
+    water_depth = 0.9;
+    lambda = amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
+        wave_period, water_depth, g);
+
+    k = 2.0 * M_PI / lambda;
+    const amrex::Real RHS2 = 2.0 * M_PI / (wave_period * std::sqrt(g * k));
+
+    S = 1.0 / std::cosh(2.0 * k * water_depth);
+    C = 1.0 - S;
+    eps = k * wave_height / 2.0;
+
+    C0 = std::sqrt(std::tanh(k * water_depth));
+    C2 = C0 * (2.0 + 7.0 * S * S) / (4.0 * C * C);
+    C4 = C0 *
+         (4.0 + 32.0 * S - 116.0 * std::pow(S, 2) - 400.0 * std::pow(S, 3) -
+          71.0 * std::pow(S, 4) + 146.0 * std::pow(S, 5)) /
+         (32.0 * std::pow(C, 5));
+    const amrex::Real LHS2 = C0 + std::pow(eps, 2) * C2 + std::pow(eps, 4) * C4;
+    EXPECT_NEAR(LHS2, RHS2, 1e-8);
+}
+
 } // namespace amr_wind_tests

--- a/unit_tests/ocean_waves/test_wave_theories.cpp
+++ b/unit_tests/ocean_waves/test_wave_theories.cpp
@@ -80,10 +80,11 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
     amrex::Real wave_height = 0.2;
     amrex::Real wave_period = 2.2;
     amrex::Real water_depth = 5.0;
+    int wave_order = 5;
     constexpr amrex::Real g = 9.81;
     amrex::Real lambda =
         amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
-            wave_period, water_depth, g);
+            wave_period, water_depth, wave_height, wave_order, g);
 
     // Relation to check is from course notes:
     // https://www.caee.utexas.edu/prof/kinnas/ce358/oenotes/kinnas_stokes11.pdf
@@ -96,7 +97,7 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
 
     amrex::Real C0 = std::sqrt(std::tanh(k * water_depth));
     amrex::Real C2 = C0 * (2.0 + 7.0 * S * S) / (4.0 * C * C);
-    amrex::Real C4 =
+    const amrex::Real C4 =
         C0 *
         (4.0 + 32.0 * S - 116.0 * std::pow(S, 2) - 400.0 * std::pow(S, 3) -
          71.0 * std::pow(S, 4) + 146.0 * std::pow(S, 5)) /
@@ -108,8 +109,9 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
     wave_height = 0.05;
     wave_period = 1.5;
     water_depth = 0.9;
+    wave_order = 3;
     lambda = amr_wind::ocean_waves::relaxation_zones::stokes_wave_length(
-        wave_period, water_depth, g);
+        wave_period, water_depth, wave_height, wave_order, g);
 
     k = 2.0 * M_PI / lambda;
     const amrex::Real RHS2 = 2.0 * M_PI / (wave_period * std::sqrt(g * k));
@@ -120,11 +122,7 @@ TEST_F(WaveTheoriesTest, StokesWaveLength)
 
     C0 = std::sqrt(std::tanh(k * water_depth));
     C2 = C0 * (2.0 + 7.0 * S * S) / (4.0 * C * C);
-    C4 = C0 *
-         (4.0 + 32.0 * S - 116.0 * std::pow(S, 2) - 400.0 * std::pow(S, 3) -
-          71.0 * std::pow(S, 4) + 146.0 * std::pow(S, 5)) /
-         (32.0 * std::pow(C, 5));
-    const amrex::Real LHS2 = C0 + std::pow(eps, 2) * C2 + std::pow(eps, 4) * C4;
+    const amrex::Real LHS2 = C0 + std::pow(eps, 2) * C2;
     EXPECT_NEAR(LHS2, RHS2, 1e-8);
 }
 


### PR DESCRIPTION
## Summary

Bug fix for stokes waves, adding feature of wave length calculation, generalizing and de-hardcoding ocean waves code

## Pull request type

Bugfix + Feature

Please check the type of change your PR introduces:

## Checklist

The following should accompany this PR:

- [ x] new unit-test(s)
- [ x] new regression test(s) pass

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

With small water depths, the stokes waves velocities seemed reasonable before the bug fix, but with a depth of 10 m, the velocities in x were on the order of 1e20, due to the mix-up of variables m and n.

Issue Number: N/A
