### PR TITLE
Better structure for native sampling output

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -283,12 +283,13 @@ void Sampling::impl_write_native()
     BL_PROFILE("amr-wind::Sampling::write_native");
 
     const std::string post_dir = "post_processing";
-    const std::string name =
+    const std::string sampling_name =
         amrex::Concatenate(m_label, m_sim.time().time_index());
+    const std::string name(post_dir + "/" + sampling_name);
     amrex::Vector<std::string> int_var_names{"uid", "set_id", "probe_id"};
 
     m_scontainer->WritePlotFile(
-        post_dir, name, m_var_names, int_var_names,
+        name, "particles", m_var_names, int_var_names,
         [=] AMREX_GPU_HOST_DEVICE(
             const SamplingContainer::SuperParticleType& p) {
             return p.id() > 0;


### PR DESCRIPTION
## Summary

This new folder structure makes it so the native sampling output (which uses particles) is natively read by typical viz programs, e.g., paraview.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

NA, this only affects the folder structure of the native sampling output.

## Additional background

Paraview can now easily load these particles up for quick visualization

![Screenshot 2024-04-24 at 9 48 34 AM](https://github.com/Exawind/amr-wind/assets/15038415/c7ba6abe-240f-4c84-938c-64dd9a863d18)

Old folder structure:
```
post_processing
├── abl_statistics00000.txt
├── othersampling00000
│   ├── Header
│   └── Level_0
│       ├── DATA_00000
│       └── Particle_H
├── othersampling00001
│   ├── Header
│   └── Level_0
│       ├── DATA_00000
│       └── Particle_H
├── othersampling00002
│   ├── Header
│   └── Level_0
│       ├── DATA_00000
│       └── Particle_H
├── sampling00000
│   ├── Header
│   └── Level_0
│       ├── DATA_00000
│       └── Particle_H
├── sampling00001
│   ├── Header
│   └── Level_0
│       ├── DATA_00000
│       └── Particle_H
└── sampling00002
    ├── Header
    └── Level_0
        ├── DATA_00000
        └── Particle_H
```

New folder structure:
```
post_processing
├── abl_statistics00000.txt
├── othersampling00000
│   └── particles
│       ├── Header
│       └── Level_0
│           ├── DATA_00000
│           └── Particle_H
├── othersampling00001
│   └── particles
│       ├── Header
│       └── Level_0
│           ├── DATA_00000
│           └── Particle_H
├── othersampling00002
│   └── particles
│       ├── Header
│       └── Level_0
│           ├── DATA_00000
│           └── Particle_H
├── sampling00000
│   └── particles
│       ├── Header
│       └── Level_0
│           ├── DATA_00000
│           └── Particle_H
├── sampling00001
│   └── particles
│       ├── Header
│       └── Level_0
│           ├── DATA_00000
│           └── Particle_H
└── sampling00002
    └── particles
        ├── Header
        └── Level_0
            ├── DATA_00000
            └── Particle_H
```
