### PR TITLE
Require density argument for openfast turbine types

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -27,6 +27,8 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         // Check if user wants to override density checks
         bool override_density_check = false;
         pp.query("override_density_check", override_density_check);
+        // Check if simulation is a restart
+        bool is_restart = data.sim().io_manager().is_restart();
 
         // Initialize OpenFAST specific data
         const auto& tinfo = data.info();
@@ -74,7 +76,8 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
 
         perform_checks(data);
 
-        perform_density_checks(tdata.density, override_density_check);
+        perform_density_checks(
+            tdata.density, override_density_check, is_restart);
     }
 
     void perform_checks(typename TurbineFast::DataType& data)
@@ -85,7 +88,8 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
     }
 
     // Check other density parsing arguments against turbine air density
-    void perform_density_checks(const amrex::Real rho_tdef, const bool no_check)
+    void perform_density_checks(
+        const amrex::Real rho_tdef, const bool no_check, const bool is_rst)
     {
         // Check if other arguments are in input file
         amrex::ParmParse pp_incflo("incflo");
@@ -94,7 +98,7 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         bool is_cstdns = pp_cstdns.contains("value");
         // Flags for detecting conflicts
         bool cft_incflo = false;
-        bool cft_cstdens = false;
+        bool cft_cstdns = false;
 
         // Do warnings or aborts depending on values
         const amrex::Real tiny = std::numeric_limits<amrex::Real>::epsilon();
@@ -105,13 +109,14 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
                 cft_incflo = true;
                 if (!no_check) {
                     amrex::Abort(
-                        "Density conflict detected between FAST Turbine "
-                        "density and incflo.density.\n-----Values are " +
+                        "Density conflict detected between TurbineFast "
+                        "density and incflo.density.\n----- Values are " +
                         std::to_string(rho_tdef) + " and " +
                         std::to_string(rho_incflo) +
                         ", respectively. Check the problem setup and the "
                         "turbine definition.\n----- If this difference is "
-                        "intended, set the override_density flag to true.\n");
+                        "intended, set the override_density_check flag to "
+                        "true.\n");
                 } else {
                     amrex::Print()
                         << "WARNING: Density conflict detected between FAST "
@@ -123,46 +128,49 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
                 }
             }
         }
-        if (is_cstdens) {
-            amrex::Real rho_cstdens = 1.0;
-            pp_cstdns.query("value", rho_cstdens);
-            if (std::abs(rho_cstdens - rho_tdef) > tiny) {
-                cft_cstdens = true;
+        if (is_cstdns) {
+            amrex::Real rho_cstdns = 1.0;
+            pp_cstdns.query("value", rho_cstdns);
+            if (std::abs(rho_cstdns - rho_tdef) > tiny) {
+                cft_cstdns = true;
                 if (!no_check) {
                     amrex::Abort(
-                        "Density conflict detected between FAST Turbine "
+                        "Density conflict detected between TurbineFast "
                         "density and ConstValue.density.value.\n----- Values "
                         "are " +
                         std::to_string(rho_tdef) + " and " +
-                        std::to_string(rho_cstdens) +
+                        std::to_string(rho_cstdns) +
                         ", respectively. Check the problem setup and the "
                         "turbine definition.\n----- If this difference is "
-                        "intended, set the override_density flag to true.\n");
+                        "intended, set the override_density_check flag to "
+                        "true.\n");
                 } else {
                     amrex::Print()
-                        << "WARNING: Density conflict detected between FAST "
-                           "Turbine density and "
+                        << "WARNING: Density conflict detected between "
+                           "TurbineFast "
+                           "density and "
                            "ConstValue.density.value.\n----- Values are " +
                                std::to_string(rho_tdef) + " and " +
-                               std::to_string(rho_cstdens) +
+                               std::to_string(rho_cstdns) +
                                ", respectively. Abort overridden by flag.\n";
                 }
             }
         }
         if (!is_incflo && !is_cstdns) {
             amrex::Print()
-                << "FAST Turbine: no density conflict detected, but no density "
-                   "arguments found to check against. This is likely a "
-                   "simulation begun using a checkpoint file, and the user "
-                   "must manually confirm that the precursor simulation used a "
-                   "compatible density.\n";
-        } else if (!cft_incflo && !cft_cstdens) {
+                << "TurbineFast: no density conflict detected, but no density "
+                   "arguments found to check against.\n";
+        } else if (!cft_incflo && !cft_cstdns) {
+            amrex::Print() << "TurbineFast: no density conflict detected.\n";
+        }
+        if (is_rst) {
             amrex::Print()
-                << "FAST Turbine: no density conflict detected. If this is a "
-                   "simulation begun using a checkpoint file, some density "
-                   "arguments may be unused, and the user must manually "
-                   "confirm that the precursor simulation used a compatible "
-                   "density.\n";
+                << "TurbineFast: simulation begins using a checkpoint file, "
+                   "density compatibility must be manually confirmed between "
+                   "the precursor simulation and the specified TurbineFast "
+                   "density, " +
+                       std::to_string(rho_tdef)
+                << ".\n".
         }
     }
 };

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -22,7 +22,7 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         auto& tdata = data.meta();
 
         // Get density value for normalization
-        pp.query("density", tdata.density);
+        pp.get("density", tdata.density);
 
         // Initialize OpenFAST specific data
         const auto& tinfo = data.info();

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -171,7 +171,7 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
                    "the precursor simulation and the specified TurbineFast "
                    "density, " +
                        std::to_string(rho_tdef)
-                << ".\n".
+                << ".\n";
         }
     }
 };

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -24,6 +24,10 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         // Get density value for normalization
         pp.get("density", tdata.density);
 
+        // Check if user wants to override density checks
+        bool override_density_check = false;
+        pp.query("override_density_check", override_density_check);
+
         // Initialize OpenFAST specific data
         const auto& tinfo = data.info();
         auto& tf = data.meta().fast_data;
@@ -69,6 +73,8 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         tf.chkpt_interval = time.chkpt_interval();
 
         perform_checks(data);
+
+        perform_density_checks(tdata.density, override_density_check);
     }
 
     void perform_checks(typename TurbineFast::DataType& data)
@@ -76,6 +82,88 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         const auto& time = data.sim().time();
         // Ensure that we are using fixed timestepping scheme
         AMREX_ALWAYS_ASSERT(!time.adaptive_timestep());
+    }
+
+    // Check other density parsing arguments against turbine air density
+    void perform_density_checks(const amrex::Real rho_tdef, const bool no_check)
+    {
+        // Check if other arguments are in input file
+        amrex::ParmParse pp_incflo("incflo");
+        amrex::ParmParse pp_cstdns("ConstValue.density");
+        bool is_incflo = pp_incflo.contains("density");
+        bool is_cstdns = pp_cstdns.contains("value");
+        // Flags for detecting conflicts
+        bool cft_incflo = false;
+        bool cft_cstdens = false;
+
+        // Do warnings or aborts depending on values
+        const amrex::Real tiny = std::numeric_limits<amrex::Real>::epsilon();
+        if (is_incflo) {
+            amrex::Real rho_incflo = 1.0;
+            pp_incflo.query("density", rho_incflo);
+            if (std::abs(rho_incflo - rho_tdef) > tiny) {
+                cft_incflo = true;
+                if (!no_check) {
+                    amrex::Abort(
+                        "Density conflict detected between FAST Turbine "
+                        "density and incflo.density.\n-----Values are " +
+                        std::to_string(rho_tdef) + " and " +
+                        std::to_string(rho_incflo) +
+                        ", respectively. Check the problem setup and the "
+                        "turbine definition.\n----- If this difference is "
+                        "intended, set the override_density flag to true.\n");
+                } else {
+                    amrex::Print()
+                        << "WARNING: Density conflict detected between FAST "
+                           "Turbine density and incflo.density.\n----- Values "
+                           "are " +
+                               std::to_string(rho_tdef) + " and " +
+                               std::to_string(rho_incflo) +
+                               ", respectively. Abort overridden by flag.\n";
+                }
+            }
+        }
+        if (is_cstdens) {
+            amrex::Real rho_cstdens = 1.0;
+            pp_cstdns.query("value", rho_cstdens);
+            if (std::abs(rho_cstdens - rho_tdef) > tiny) {
+                cft_cstdens = true;
+                if (!no_check) {
+                    amrex::Abort(
+                        "Density conflict detected between FAST Turbine "
+                        "density and ConstValue.density.value.\n----- Values "
+                        "are " +
+                        std::to_string(rho_tdef) + " and " +
+                        std::to_string(rho_cstdens) +
+                        ", respectively. Check the problem setup and the "
+                        "turbine definition.\n----- If this difference is "
+                        "intended, set the override_density flag to true.\n");
+                } else {
+                    amrex::Print()
+                        << "WARNING: Density conflict detected between FAST "
+                           "Turbine density and "
+                           "ConstValue.density.value.\n----- Values are " +
+                               std::to_string(rho_tdef) + " and " +
+                               std::to_string(rho_cstdens) +
+                               ", respectively. Abort overridden by flag.\n";
+                }
+            }
+        }
+        if (!is_incflo && !is_cstdns) {
+            amrex::Print()
+                << "FAST Turbine: no density conflict detected, but no density "
+                   "arguments found to check against. This is likely a "
+                   "simulation begun using a checkpoint file, and the user "
+                   "must manually confirm that the precursor simulation used a "
+                   "compatible density.\n";
+        } else if (!cft_incflo && !cft_cstdens) {
+            amrex::Print()
+                << "FAST Turbine: no density conflict detected. If this is a "
+                   "simulation begun using a checkpoint file, some density "
+                   "arguments may be unused, and the user must manually "
+                   "confirm that the precursor simulation used a compatible "
+                   "density.\n";
+        }
     }
 };
 

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -6,6 +6,7 @@
 #include "amr-wind/wind_energy/actuator/actuator_ops.H"
 #include "amr-wind/wind_energy/actuator/actuator_utils.H"
 #include "amr-wind/wind_energy/actuator/FLLCOp.H"
+#include "amr-wind/utilities/IOManager.H"
 
 namespace amr_wind {
 namespace actuator {


### PR DESCRIPTION
## Summary

Require density argument for openfast turbine types to prevent default density being used unintentionally

## Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Additional background

OpenFAST-coupled turbine types have an input argument for the density. This is intended to be the same as the density specified in the OpenFAST turbine definition because this density is used to divide the forces from OpenFAST (amr-wind source terms are in units of force/density, i.e. m/s^2). This is a quick way to address the fact that density can be omitted from the input file and users will unintentionally use a default density of 1.0.

Unit tests and documentation do not really apply to this change, and the reg tests are not coupled with OpenFAST.

Issue Number: #1009
