### PR TITLE
Fix erroneous parsing of time table.

### DIFF
--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -73,6 +73,7 @@ void ABLFieldInit::initialize_from_inputfile()
                 "Cannot find ABLForcing velocity_timetable file: " +
                 m_vel_timetable);
         }
+        ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         amrex::Real m_vel_time;
         amrex::Real m_vel_ang;
         ifh >> m_vel_time >> m_vel_speed >> m_vel_ang;

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -74,10 +74,10 @@ void ABLFieldInit::initialize_from_inputfile()
                 m_vel_timetable);
         }
         ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        amrex::Real m_vel_time;
-        amrex::Real m_vel_ang;
-        ifh >> m_vel_time >> m_vel_speed >> m_vel_ang;
-        m_vel_dir = utils::radians(m_vel_ang);
+        amrex::Real vel_time;
+        amrex::Real vel_ang;
+        ifh >> vel_time >> m_vel_speed >> vel_ang;
+        m_vel_dir = utils::radians(vel_ang);
     } else {
         pp_incflo.getarr("velocity", m_vel);
     }


### PR DESCRIPTION
## Summary

This was a weird one and threw me for a loop. Basically I was getting non-deterministic FPEs (nan) when running the regression tests with MPI. Wouldn't show up in debug, single rank builds (probably wasn't trying enough). Turns out we were trying to parse the header of the time table (strings) into reals. This meant that `m_vel_speed` would sometimes be a valid real and sometimes it would be a nan. Not sure what the deal is there. The fix is to skip the header and read the data in properly. We do this in other file reads so this should have been done here as well. But the problem wouldn't show up consistently so it wasnt caught.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

[gpu_tests.txt](https://github.com/Exawind/amr-wind/files/15237484/gpu_tests.txt)
[cpu_tests.txt](https://github.com/Exawind/amr-wind/files/15237485/cpu_tests.txt)


