### PR TITLE
Modifying abl_sampling reg test to avoid NetCDF error

### DIFF
--- a/test/test_files/abl_sampling/abl_sampling.inp
+++ b/test/test_files/abl_sampling/abl_sampling.inp
@@ -22,7 +22,7 @@ time.checkpoint_interval      =  5       # Steps between checkpoint files
 incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
 incflo.density             = 1.0          # Reference density
 
-io.derived_outputs = mag_vorticity "components(gp,0,1)" "grad(temperature)"
+io.derived_outputs = mag_vorticity "components(velocity,0,1)" "grad(temperature)"
 
 incflo.use_godunov = 1
 incflo.diffusion_type = 2

--- a/test/test_files/abl_sampling/abl_sampling.inp
+++ b/test/test_files/abl_sampling/abl_sampling.inp
@@ -22,7 +22,7 @@ time.checkpoint_interval      =  5       # Steps between checkpoint files
 incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
 incflo.density             = 1.0          # Reference density
 
-io.derived_outputs = mag_vorticity "components(velocity,0,1)" "grad(temperature)"
+io.derived_outputs = mag_vorticity "components(gp,0,1)" "grad(temperature)"
 
 incflo.use_godunov = 1
 incflo.diffusion_type = 2
@@ -79,7 +79,7 @@ incflo.verbose          =   0          # incflo_level
 incflo.post_processing       = sampling sampling2
 sampling.output_frequency    = 1
 sampling.fields              = velocity
-sampling.derived_fields      = mag_vorticity "components(velocity,0,1)" "grad(temperature)" "grad(density)"
+sampling.derived_fields      = mag_vorticity "components(gp,0,1)" "grad(temperature)" "grad(density)"
 sampling.labels              = volume1
 sampling.volume1.type        = VolumeSampler
 sampling.volume1.lo          = 200.0 200.0 200.0


### PR DESCRIPTION
## Summary

Specifying velocity as a sampling field and velocity components as derived fields doesn't produce issues in the mechanics of AMR-Wind, but it creates redundant variable names that produce a conflict in NetCDF. "NetCDF: String match to name in use". This avoids that error

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
