### PR TITLE
Make Sampling default to native output

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -136,11 +136,9 @@ private:
 
     //! Format of the data output (native, ascii, netcdf, etc.)
 #ifdef AMR_WIND_USE_NETCDF
-    std::string m_out_fmt{"netcdf"};
     std::string m_ncfile_name;
-#else
-    std::string m_out_fmt{"native"};
 #endif
+    std::string m_out_fmt{"native"};
 
     // Sample initial condition for interpolation consistency
     bool m_restart_sample{false};


### PR DESCRIPTION
## Summary

Make Sampling default to native output, they are much faster: https://github.com/Exawind/amr-wind/issues/971. If users don't have `sampling_label.output_format = netcdf` then they will see a change in behavior (faster runs but native amrex particle files vs netcdf files, this will affect post-processing sampling stuf). Tagging some users for discussion: @lawrenceccheung, @rthedin, @ndevelder, @neilmatula, who else? 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
