### PR TITLE
Remove duplicates from IO

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -384,8 +384,7 @@ struct InitDataOp<W2AWaves>
 {
     void
     // cppcheck-suppress constParameterReference
-    operator()(
-        W2AWaves::DataType & data, int level, const amrex::Geometry & geom)
+    operator()(W2AWaves::DataType& data, int level, const amrex::Geometry& geom)
     {
 
 #ifdef AMR_WIND_USE_W2A

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -384,7 +384,8 @@ struct InitDataOp<W2AWaves>
 {
     void
     // cppcheck-suppress constParameterReference
-    operator()(W2AWaves::DataType& data, int level, const amrex::Geometry& geom)
+    operator()(
+        W2AWaves::DataType & data, int level, const amrex::Geometry & geom)
     {
 
 #ifdef AMR_WIND_USE_W2A

--- a/amr-wind/utilities/DerivedQuantity.H
+++ b/amr-wind/utilities/DerivedQuantity.H
@@ -53,6 +53,10 @@ public:
     void
     var_names(amrex::Vector<std::string>& /*plt_var_names*/) const noexcept;
 
+    void filter(const std::set<std::string>& /*erase*/);
+
+    void filter(const amrex::Vector<std::string>& /*erase*/);
+
 private:
     const FieldRepo& m_repo;
 

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -114,6 +114,7 @@ void IOManager::initialize_io()
 
     if (!out_derived_vars.empty()) {
         m_derived_mgr->create(out_derived_vars);
+        m_derived_mgr->filter(outputs);
         m_plt_num_comp += m_derived_mgr->num_comp();
         m_derived_mgr->var_names(m_plt_var_names);
     }

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -61,6 +61,7 @@ void Sampling::initialize()
     // Process derived field information
     if (!derived_field_names.empty()) {
         m_derived_mgr->create(derived_field_names);
+        m_derived_mgr->filter(field_names);
         m_ndcomp = m_derived_mgr->num_comp();
         m_derived_mgr->var_names(m_var_names);
     }

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -313,8 +313,9 @@ void Sampling::impl_write_native()
 void Sampling::write_ascii()
 {
     BL_PROFILE("amr-wind::Sampling::write_ascii");
-    amrex::Print() << "WARNING: Sampling: ASCII output will impact performance"
-                   << std::endl;
+    amrex::Print()
+        << "WARNING: Sampling: ASCII output will negatively impact performance"
+        << std::endl;
 
     const std::string post_dir = "post_processing";
     const std::string sname =
@@ -404,6 +405,9 @@ void Sampling::write_netcdf()
 {
 #ifdef AMR_WIND_USE_NETCDF
     if (!amrex::ParallelDescriptor::IOProcessor()) return;
+    amrex::Print()
+        << "WARNING: Sampling: netcdf output will negatively impact performance"
+        << std::endl;
     auto ncf = ncutils::NCFile::open(m_ncfile_name, NC_WRITE);
     const std::string nt_name = "num_time_steps";
     // Index of the next timestep


### PR DESCRIPTION
## Summary

If using derived fields it is possible to end up with a bunch of duplicate fields in the output. This attempts to fix that.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The existing `abl_sampling` regression test had duplicate fields, now it doesnt. So we can consider that the reg test.

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->