### PR TITLE
git ignore build*, because of exawind-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ settings.json
 .cache*
 .ccls
 .ccls-cache/
-build/
+build*


### PR DESCRIPTION
## Summary

exawind-manager makes build directories with the prefix "build-", and it is best to ignore these from git tracking

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
