### PR TITLE
add (necessary) density argument to parser in OpenFAST unit test

### DIFF
--- a/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
+++ b/unit_tests/wind_energy/actuator/test_turbine_fast.cpp
@@ -50,6 +50,8 @@ protected:
             pp.addarr(
                 "epsilon_chord", amrex::Vector<amrex::Real>{3.0, 3.0, 3.0});
 
+            pp.add("density", 1.0);
+
             pp.add("openfast_input_file", std::string("fast_inp/nrel5mw.fst"));
             pp.add("openfast_start_time", 0.0);
             pp.add("openfast_stop_time", 0.625);


### PR DESCRIPTION
## Summary

A unit test for OpenFAST turbines was missing the density argument, which is now required.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

