### PR TITLE
Cleaner vector/array initializations

### DIFF
--- a/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
+++ b/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
@@ -17,7 +17,7 @@ WallFunction::WallFunction(CFDSim& sim)
 {
     {
         amrex::ParmParse pp("BodyForce");
-        amrex::Vector<amrex::Real> body_force{{0.0, 0.0, 0.0}};
+        amrex::Vector<amrex::Real> body_force{0.0, 0.0, 0.0};
         pp.getarr("magnitude", body_force);
         m_log_law.utau_mean = std::sqrt(std::sqrt(
             body_force[0] * body_force[0] + body_force[1] * body_force[1]));

--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -90,7 +90,7 @@ private:
     int m_n_band{2};
 
     //! ABL forcing terms
-    amrex::RealArray m_abl_forcing{{0.0, 0.0, 0.0}};
+    amrex::RealArray m_abl_forcing{0.0, 0.0, 0.0};
 
     //! File name for velocity forcing time table
     std::string m_vel_timetable;
@@ -114,10 +114,10 @@ private:
     amrex::Vector<amrex::Real> m_direction_table;
 
     //! Target velocity
-    amrex::Vector<amrex::Real> m_target_vel{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_target_vel{0.0, 0.0, 0.0};
 
     //! Current mean vel
-    amrex::RealArray m_mean_vel{{0.0, 0.0, 0.0}};
+    amrex::RealArray m_mean_vel{0.0, 0.0, 0.0};
 
     //! Height at which the velocities are forcing
     amrex::Real m_forcing_height;

--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -90,7 +90,7 @@ private:
     int m_n_band{2};
 
     //! ABL forcing terms
-    amrex::RealArray m_abl_forcing{0.0, 0.0, 0.0};
+    amrex::RealArray m_abl_forcing{0.0};
 
     //! File name for velocity forcing time table
     std::string m_vel_timetable;

--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -117,7 +117,7 @@ private:
     amrex::Vector<amrex::Real> m_target_vel{0.0, 0.0, 0.0};
 
     //! Current mean vel
-    amrex::RealArray m_mean_vel{0.0, 0.0, 0.0};
+    amrex::RealArray m_mean_vel{0.0};
 
     //! Height at which the velocities are forcing
     amrex::Real m_forcing_height;

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.H
@@ -37,7 +37,7 @@ public:
 private:
     const amrex::AmrCore& m_mesh;
 
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     amrex::Gpu::DeviceVector<amrex::Real> m_theta_ht;
     amrex::Gpu::DeviceVector<amrex::Real> m_theta_vals;

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -65,7 +65,7 @@ void ABLMeanBoussinesq::operator()(
     const amrex::Real T0 = m_ref_theta;
     const amrex::Real beta = m_beta;
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
 
     // Mean temperature profile used to compute background forcing term
     //

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -120,7 +120,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     // First the index in time
     m_idx_time = closest_index(ncfile->meso_times(), currtime);
 
-    amrex::Array<amrex::Real, 2> coeff_interp{{0.0, 0.0}};
+    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
     amrex::Real denom =
         ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
@@ -172,7 +172,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     // First the index in time
     m_idx_time = closest_index(ncfile->meso_times(), currtime);
 
-    amrex::Array<amrex::Real, 2> coeff_interp{{0.0, 0.0}};
+    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
     amrex::Real denom =
         ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];

--- a/amr-wind/equation_systems/icns/source_terms/BodyForce.H
+++ b/amr-wind/equation_systems/icns/source_terms/BodyForce.H
@@ -42,7 +42,7 @@ private:
     const amrex::AmrCore& m_mesh;
 
     //! Forcing source term (pressure gradient)
-    amrex::Vector<amrex::Real> m_body_force{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_body_force{0.0, 0.0, 0.0};
 
     //! Body Force Type
     std::string m_type{"uniform_constant"};

--- a/amr-wind/equation_systems/icns/source_terms/BodyForce.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/BodyForce.cpp
@@ -154,7 +154,7 @@ void BodyForce::operator()(
     } else {
 
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> forcing{
-            {m_body_force[0], m_body_force[1], m_body_force[2]}};
+            m_body_force[0], m_body_force[1], m_body_force[2]};
 
         if (!m_utt_file.empty()) {
             // Populate forcing from file if supplied

--- a/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.H
+++ b/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.H
@@ -33,7 +33,7 @@ private:
     const Field& m_temperature;
     const Field* m_vof;
 
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     //! Reference temperature (Kelvin)
     amrex::Real m_ref_theta{300.0};

--- a/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/BoussinesqBuoyancy.cpp
@@ -52,7 +52,7 @@ void BoussinesqBuoyancy::operator()(
     const amrex::Real T0 = m_ref_theta;
     const amrex::Real beta = m_beta;
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
 
     const bool ivf = is_vof;
     const auto& vof_arr = (*m_vof)(lev).const_array(mfi);

--- a/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.H
@@ -32,9 +32,9 @@ private:
     ///@{
     /** Orientation of the grid w.r.t. to planetary coordinate system
      */
-    amrex::Vector<amrex::Real> m_east{{1.0, 0.0, 0.0}};
-    amrex::Vector<amrex::Real> m_north{{0.0, 1.0, 0.0}};
-    amrex::Vector<amrex::Real> m_up{{0.0, 0.0, 1.0}};
+    amrex::Vector<amrex::Real> m_east{1.0, 0.0, 0.0};
+    amrex::Vector<amrex::Real> m_north{0.0, 1.0, 0.0};
+    amrex::Vector<amrex::Real> m_up{0.0, 0.0, 1.0};
     ///@}
 
     //! Latitude where the Coriolis forcing is computed (+ve northern

--- a/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/CoriolisForcing.cpp
@@ -63,11 +63,10 @@ void CoriolisForcing::operator()(
     const amrex::Array4<amrex::Real>& src_term) const
 {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> east{
-        {m_east[0], m_east[1], m_east[2]}};
+        m_east[0], m_east[1], m_east[2]};
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> north{
-        {m_north[0], m_north[1], m_north[2]}};
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> up{
-        {m_up[0], m_up[1], m_up[2]}};
+        m_north[0], m_north[1], m_north[2]};
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> up{m_up[0], m_up[1], m_up[2]};
 
     const auto sinphi = m_sinphi;
     const auto cosphi = m_cosphi;

--- a/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.H
+++ b/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.H
@@ -33,7 +33,7 @@ public:
         const amrex::Array4<amrex::Real>& vel_forces) const override;
 
 private:
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     amrex::Real rho_0{1.0};
 

--- a/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DensityBuoyancy.cpp
@@ -49,7 +49,7 @@ void DensityBuoyancy::operator()(
 {
     const amrex::Real density_0 = rho_0;
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
 
     FieldState den_state = field_impl::phi_state(fstate);
     const auto& density = m_density.state(den_state)(lev).const_array(mfi);

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.H
@@ -51,10 +51,10 @@ private:
     int m_n_band{2};
 
     //! Target velocity
-    amrex::Vector<amrex::Real> m_target_vel{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_target_vel{0.0, 0.0, 0.0};
 
     //! Forcing source term (pressure gradient)
-    amrex::Vector<amrex::Real> m_g_forcing{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_g_forcing{0.0, 0.0, 0.0};
 
     bool m_is_horizontal{false};
 

--- a/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GeostrophicForcing.cpp
@@ -116,7 +116,7 @@ void GeostrophicForcing::operator()(
     const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> forcing{
-        {m_g_forcing[0], m_g_forcing[1], m_g_forcing[2]}};
+        m_g_forcing[0], m_g_forcing[1], m_g_forcing[2]};
 
     // Calculate forcing values if target velocity is a function of time
     if (!m_vel_timetable.empty()) {

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.H
@@ -26,7 +26,7 @@ public:
         const amrex::Array4<amrex::Real>& vel_forces) const override;
 
 private:
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     Field* m_rho{nullptr};
     Field* m_rho0{nullptr};

--- a/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/GravityForcing.cpp
@@ -48,7 +48,7 @@ void GravityForcing::operator()(
     const amrex::Array4<amrex::Real>& vel_forces) const
 {
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
 
     const auto& rho_arr =
         ((*m_rho).state(field_impl::phi_state(fstate)))(lev).const_array(mfi);

--- a/amr-wind/equation_systems/icns/source_terms/RayleighDamping.H
+++ b/amr-wind/equation_systems/icns/source_terms/RayleighDamping.H
@@ -35,7 +35,7 @@ private:
     const Field& m_velocity;
 
     //! Reference velocity defined as an input
-    amrex::Vector<amrex::Real> m_ref_vel{{15.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_ref_vel{15.0, 0.0, 0.0};
 
     //! Full length of the damping layer
     amrex::Real m_dRD{500.};
@@ -47,7 +47,7 @@ private:
     amrex::Real m_tau{5.0};
 
     //! Which coordinate directions are forced
-    amrex::Vector<int> m_fcoord{{1, 1, 1}};
+    amrex::Vector<int> m_fcoord{1, 1, 1};
 };
 
 } // namespace amr_wind::pde::icns

--- a/amr-wind/equation_systems/icns/source_terms/RayleighDamping.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/RayleighDamping.cpp
@@ -43,7 +43,7 @@ void RayleighDamping::operator()(
 
     const amrex::Real tau = m_tau;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> ref_vel{
-        {m_ref_vel[0], m_ref_vel[1], m_ref_vel[2]}};
+        m_ref_vel[0], m_ref_vel[1], m_ref_vel[2]};
     const auto& vel =
         m_velocity.state(field_impl::dof_state(fstate))(lev).const_array(mfi);
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -107,7 +107,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     // First the index in time
     m_idx_time = closest_index(ncfile->meso_times(), currtime);
 
-    amrex::Array<amrex::Real, 2> coeff_interp{{0.0, 0.0}};
+    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
     amrex::Real denom =
         ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
@@ -159,7 +159,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     // First the index in time
     m_idx_time = closest_index(ncfile->meso_times(), currtime);
 
-    amrex::Array<amrex::Real, 2> coeff_interp{{0.0, 0.0}};
+    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
     amrex::Real denom =
         ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];

--- a/amr-wind/immersed_boundary/bluff_body/BluffBody.H
+++ b/amr-wind/immersed_boundary/bluff_body/BluffBody.H
@@ -20,10 +20,10 @@ struct BluffBodyBaseData
 
     bool has_wall_model{false};
 
-    amrex::Vector<amrex::Real> vel_bc{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> vel_bc{0.0, 0.0, 0.0};
 
     //! Total integrated forces on the immersed body
-    amrex::Vector<amrex::Real> frc{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> frc{0.0, 0.0, 0.0};
 };
 
 struct BluffBodyType : public IBType

--- a/amr-wind/mesh_mapping_models/ChannelFlowMap.H
+++ b/amr-wind/mesh_mapping_models/ChannelFlowMap.H
@@ -31,7 +31,7 @@ public:
 
 private:
     //! User input parameters
-    amrex::Vector<amrex::Real> m_beta{{0.0, 3.0, 0.0}};
+    amrex::Vector<amrex::Real> m_beta{0.0, 3.0, 0.0};
 
     amrex::Real m_eps{1e-11};
 };

--- a/amr-wind/mesh_mapping_models/ChannelFlowMap.cpp
+++ b/amr-wind/mesh_mapping_models/ChannelFlowMap.cpp
@@ -59,7 +59,7 @@ void ChannelFlowMap::create_map(int lev, const amrex::Geometry& geom)
 void ChannelFlowMap::create_cell_node_map(int lev, const amrex::Geometry& geom)
 {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> beta{
-        {m_beta[0], m_beta[1], m_beta[2]}};
+        m_beta[0], m_beta[1], m_beta[2]};
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
@@ -67,8 +67,8 @@ void ChannelFlowMap::create_cell_node_map(int lev, const amrex::Geometry& geom)
     const auto& prob_hi = geom.ProbHiArray();
 
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
-        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
-         prob_hi[2] - prob_lo[2]}};
+        prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+        prob_hi[2] - prob_lo[2]};
 
     for (amrex::MFIter mfi((*m_mesh_scale_fac_cc)(lev)); mfi.isValid(); ++mfi) {
 
@@ -138,7 +138,7 @@ void ChannelFlowMap::create_cell_node_map(int lev, const amrex::Geometry& geom)
 void ChannelFlowMap::create_face_map(int lev, const amrex::Geometry& geom)
 {
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> beta{
-        {m_beta[0], m_beta[1], m_beta[2]}};
+        m_beta[0], m_beta[1], m_beta[2]};
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
@@ -146,8 +146,8 @@ void ChannelFlowMap::create_face_map(int lev, const amrex::Geometry& geom)
     const auto& prob_hi = geom.ProbHiArray();
 
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
-        {prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
-         prob_hi[2] - prob_lo[2]}};
+        prob_hi[0] - prob_lo[0], prob_hi[1] - prob_lo[1],
+        prob_hi[2] - prob_lo[2]};
 
     for (amrex::MFIter mfi((*m_mesh_scale_fac_xf)(lev)); mfi.isValid(); ++mfi) {
 
@@ -253,7 +253,7 @@ void ChannelFlowMap::create_face_map(int lev, const amrex::Geometry& geom)
 void ChannelFlowMap::create_non_uniform_mesh(
     int lev, const amrex::Geometry& geom)
 {
-    amrex::Vector<amrex::Real> probhi_physical{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> probhi_physical{0.0, 0.0, 0.0};
     {
         amrex::ParmParse pp("geometry");
         if (pp.contains("prob_hi_physical")) {
@@ -266,7 +266,7 @@ void ChannelFlowMap::create_non_uniform_mesh(
     }
 
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> beta{
-        {m_beta[0], m_beta[1], m_beta[2]}};
+        m_beta[0], m_beta[1], m_beta[2]};
     const auto eps = m_eps;
 
     const auto& dx = geom.CellSizeArray();
@@ -274,8 +274,8 @@ void ChannelFlowMap::create_non_uniform_mesh(
     const auto& prob_hi = geom.ProbHiArray();
 
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> len{
-        {probhi_physical[0] - prob_lo[0], probhi_physical[1] - prob_lo[1],
-         probhi_physical[2] - prob_lo[2]}};
+        probhi_physical[0] - prob_lo[0], probhi_physical[1] - prob_lo[1],
+        probhi_physical[2] - prob_lo[2]};
 
     for (amrex::MFIter mfi((*m_non_uniform_coord_cc)(lev)); mfi.isValid();
          ++mfi) {

--- a/amr-wind/mesh_mapping_models/ConstantMap.H
+++ b/amr-wind/mesh_mapping_models/ConstantMap.H
@@ -31,7 +31,7 @@ public:
 
 private:
     //! Factor to scale the mesh by
-    amrex::Vector<amrex::Real> m_fac{{1.0, 1.0, 1.0}};
+    amrex::Vector<amrex::Real> m_fac{1.0, 1.0, 1.0};
 };
 
 } // namespace amr_wind::const_map

--- a/amr-wind/physics/BoussinesqBubbleFieldInit.H
+++ b/amr-wind/physics/BoussinesqBubbleFieldInit.H
@@ -30,7 +30,7 @@ public:
 
 private:
     //! Initial bubble location
-    amrex::Vector<amrex::Real> m_loc{{0.25, 0.25, 0.5}};
+    amrex::Vector<amrex::Real> m_loc{0.25, 0.25, 0.5};
 
     //! Initial density field
     amrex::Real m_rho{1.0};

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -231,7 +231,7 @@ amrex::Real ChannelFlow::compute_error(const IndexSelector& idxOp)
 
     amrex::Real dpdx = 0;
     {
-        amrex::Vector<amrex::Real> body_force{{0.0, 0.0, 0.0}};
+        amrex::Vector<amrex::Real> body_force{0.0, 0.0, 0.0};
         amrex::ParmParse pp("BodyForce");
         pp.queryarr("magnitude", body_force, 0, AMREX_SPACEDIM);
         dpdx = body_force[flow_dir];
@@ -240,7 +240,7 @@ amrex::Real ChannelFlow::compute_error(const IndexSelector& idxOp)
     const auto& problo = m_mesh.Geom(0).ProbLoArray();
     amrex::Real ht = 0.0;
     {
-        amrex::Vector<amrex::Real> probhi_physical{{0.0, 0.0, 0.0}};
+        amrex::Vector<amrex::Real> probhi_physical{0.0, 0.0, 0.0};
         amrex::ParmParse pp("geometry");
         if (pp.contains("prob_hi_physical")) {
             pp.getarr("prob_hi_physical", probhi_physical);

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -50,7 +50,7 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
                     pp.query("C1", m_C1);
                     {
                         amrex::ParmParse ppb("BodyForce");
-                        amrex::Vector<amrex::Real> body_force{{0.0, 0.0, 0.0}};
+                        amrex::Vector<amrex::Real> body_force{0.0, 0.0, 0.0};
                         ppb.queryarr("magnitude", body_force);
                         m_dpdx = -body_force[0];
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/amr-wind/physics/EkmanSpiral.cpp
+++ b/amr-wind/physics/EkmanSpiral.cpp
@@ -67,7 +67,7 @@ EkmanSpiral::EkmanSpiral(const CFDSim& sim)
 
     {
         amrex::ParmParse pp("GeostrophicForcing");
-        amrex::Vector<amrex::Real> gwind{{15.0, 0.0, 0.0}};
+        amrex::Vector<amrex::Real> gwind{15.0, 0.0, 0.0};
         pp.getarr("geostrophic_wind", gwind);
         m_vel = gwind[0];
 

--- a/amr-wind/physics/SyntheticTurbulence.cpp
+++ b/amr-wind/physics/SyntheticTurbulence.cpp
@@ -161,9 +161,9 @@ void load_turb_plane_data(
     auto ncf = ncutils::NCFile::open(turb_filename, NC_NOWRITE);
 
     // clang-format off
-    std::vector<size_t> start{{static_cast<size_t>(il), 0, 0}};
-    std::vector<size_t> count{{2, static_cast<size_t>(turb_grid.box_dims[1]),
-                               static_cast<size_t>(turb_grid.box_dims[2])}};
+    std::vector<size_t> start{static_cast<size_t>(il), 0, 0};
+    std::vector<size_t> count{2, static_cast<size_t>(turb_grid.box_dims[1]),
+                               static_cast<size_t>(turb_grid.box_dims[2])};
     // clang-format on
 
     auto uvel = ncf.var("uvel");
@@ -373,7 +373,7 @@ SyntheticTurbulence::SyntheticTurbulence(const CFDSim& sim)
     // Load position and orientation of the grid
     amrex::Real wind_direction{270.};
     pp.query("wind_direction", wind_direction);
-    amrex::Vector<amrex::Real> location{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> location{0.0, 0.0, 0.0};
     pp.queryarr("grid_location", location);
 
     std::string mean_wind_type = "ConstValue";

--- a/amr-wind/physics/VortexDipole.H
+++ b/amr-wind/physics/VortexDipole.H
@@ -36,10 +36,10 @@ private:
     amrex::Real m_rho{1.0};
 
     //! Initial location of the left vortex
-    amrex::Vector<amrex::Real> m_loc_left{{-0.1, 0., 0.}};
+    amrex::Vector<amrex::Real> m_loc_left{-0.1, 0., 0.};
 
     //! Initial location of the right vortex
-    amrex::Vector<amrex::Real> m_loc_right{{0.1, 0., 0.}};
+    amrex::Vector<amrex::Real> m_loc_right{0.1, 0., 0.};
 
     //! Initial vorticity
     amrex::Real m_omegaEmag{299.5283853752};

--- a/amr-wind/physics/multiphase/DamBreak.H
+++ b/amr-wind/physics/multiphase/DamBreak.H
@@ -40,7 +40,7 @@ private:
     Field& m_density;
 
     //! Initial DamBreak location
-    amrex::Vector<amrex::Real> m_loc{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_loc{0.0, 0.0, 0.0};
 
     //! dam width value
     amrex::Real m_width{0.1};

--- a/amr-wind/physics/multiphase/MultiPhase.H
+++ b/amr-wind/physics/multiphase/MultiPhase.H
@@ -94,7 +94,7 @@ private:
     // Info to create rho0
     amrex::Real water_level0{0.0};
     // Info to reconstruct true pressure
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     bool m_interface_smoothing{false};
 

--- a/amr-wind/physics/multiphase/RainDrop.H
+++ b/amr-wind/physics/multiphase/RainDrop.H
@@ -42,10 +42,10 @@ private:
     CFDSim& m_sim;
 
     //! Initial Rain Drop location
-    amrex::Vector<amrex::Real> m_loc{{0.006, 0.006, 0.006}};
+    amrex::Vector<amrex::Real> m_loc{0.006, 0.006, 0.006};
 
     //! Initial Rain Drop velocity
-    amrex::Vector<amrex::Real> m_vel{{0.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_vel{0.0, 0.0, 0.0};
 
     //! Raindrop radius value
     amrex::Real m_radius{0.003};

--- a/amr-wind/physics/multiphase/VortexPatch.H
+++ b/amr-wind/physics/multiphase/VortexPatch.H
@@ -43,7 +43,7 @@ private:
     Field& m_density;
 
     //! Initial VortexPatch location
-    amrex::Vector<amrex::Real> m_loc{{0.35, 0.35, 0.35}};
+    amrex::Vector<amrex::Real> m_loc{0.35, 0.35, 0.35};
 
     //! vortex patch radius value
     amrex::Real m_radius{0.15};

--- a/amr-wind/physics/multiphase/VortexPatchScalarVel.H
+++ b/amr-wind/physics/multiphase/VortexPatchScalarVel.H
@@ -50,7 +50,7 @@ private:
     Field& m_density;
 
     //! Initial VortexPatchScalarVel location
-    amrex::Vector<amrex::Real> m_loc{{0.35, 0.35, 0.35}};
+    amrex::Vector<amrex::Real> m_loc{0.35, 0.35, 0.35};
 
     //! vortex patch radius value
     amrex::Real m_radius{0.15};

--- a/amr-wind/physics/multiphase/ZalesakDisk.H
+++ b/amr-wind/physics/multiphase/ZalesakDisk.H
@@ -44,7 +44,7 @@ private:
     Field& m_density;
 
     //! Initial ZalesakDisk location
-    amrex::Vector<amrex::Real> m_loc{{0.5, 0.72, 0.24}};
+    amrex::Vector<amrex::Real> m_loc{0.5, 0.72, 0.24};
 
     //! sphere radius value
     amrex::Real m_radius{0.16};

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
@@ -63,7 +63,7 @@ private:
     Field& m_density;
 
     //! Initial ZalesakDiskScalarVel location
-    amrex::Vector<amrex::Real> m_loc{{0.5, 0.72, 0.24}};
+    amrex::Vector<amrex::Real> m_loc{0.5, 0.72, 0.24};
 
     //! sphere radius value
     amrex::Real m_radius{0.16};

--- a/amr-wind/physics/udfs/BurggrafLid.H
+++ b/amr-wind/physics/udfs/BurggrafLid.H
@@ -32,7 +32,7 @@ struct BurggrafLid
             const auto x = problo[idir] + (iv[idir] + 0.5) * dx[idir];
             amrex::Real val =
                 16 * (std::pow(x, 4) - 2 * std::pow(x, 3) + std::pow(x, 2));
-            amrex::RealArray uvec = {val, 0.0, 0.0};
+            amrex::RealArray uvec = {val};
 
             field(iv[0], iv[1], iv[2], dcomp + comp) = uvec[orig_comp + comp];
         }

--- a/amr-wind/physics/udfs/BurggrafLid.H
+++ b/amr-wind/physics/udfs/BurggrafLid.H
@@ -32,7 +32,7 @@ struct BurggrafLid
             const auto x = problo[idir] + (iv[idir] + 0.5) * dx[idir];
             amrex::Real val =
                 16 * (std::pow(x, 4) - 2 * std::pow(x, 3) + std::pow(x, 2));
-            amrex::RealArray uvec = {{val, 0.0, 0.0}};
+            amrex::RealArray uvec = {val, 0.0, 0.0};
 
             field(iv[0], iv[1], iv[2], dcomp + comp) = uvec[orig_comp + comp];
         }

--- a/amr-wind/turbulence/LES/AMD.H
+++ b/amr-wind/turbulence/LES/AMD.H
@@ -60,7 +60,7 @@ private:
     const Field& m_temperature;
     const Field& m_rho;
     FieldPlaneAveraging m_pa_temp;
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 };
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real amd_muvel(

--- a/amr-wind/turbulence/LES/OneEqKsgs.H
+++ b/amr-wind/turbulence/LES/OneEqKsgs.H
@@ -78,7 +78,7 @@ private:
     Field& m_temperature;
 
     //! Gravity vector (m/s^2)
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     //! Reference temperature (Kelvin)
     amrex::Real m_ref_theta{300.0};

--- a/amr-wind/turbulence/LES/OneEqKsgs.cpp
+++ b/amr-wind/turbulence/LES/OneEqKsgs.cpp
@@ -100,7 +100,7 @@ void OneEqKsgsM84<Transport>::update_turbulent_viscosity(
     fvm::strainrate(this->m_shear_prod, vel);
 
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
     const amrex::Real beta = 1.0 / m_ref_theta;
 
     auto& mu_turb = this->mu_turb();

--- a/amr-wind/turbulence/RANS/KOmegaSST.H
+++ b/amr-wind/turbulence/RANS/KOmegaSST.H
@@ -93,7 +93,7 @@ protected:
     bool m_include_buoyancy{false};
     amrex::Real m_buoyancy_factor = 0.0;
     amrex::Real m_sigma_t{0.85};
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 };
 
 } // namespace amr_wind::turbulence

--- a/amr-wind/turbulence/RANS/KOmegaSST.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSST.cpp
@@ -107,7 +107,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
 
     const amrex::Real deltaT = (this->m_sim).time().deltaT();
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
-        {m_gravity[0], m_gravity[1], m_gravity[2]}};
+        m_gravity[0], m_gravity[1], m_gravity[2]};
     const amrex::Real Bfac = this->m_buoyancy_factor;
     const amrex::Real sigmat = this->m_sigma_t;
 

--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -214,36 +214,31 @@ void SamplingContainer::interpolate(
 
         switch (floc) {
         case FieldLoc::NODE: {
-            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{
-                {0.0, 0.0, 0.0}};
+            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{0.0, 0.0, 0.0};
             sample_field(np, ic, pvec, parr, farr, plo, dxi, dx, offset);
             break;
         }
 
         case FieldLoc::CELL: {
-            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{
-                {0.5, 0.5, 0.5}};
+            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{0.5, 0.5, 0.5};
             sample_field(np, ic, pvec, parr, farr, plo, dxi, dx, offset);
             break;
         }
 
         case FieldLoc::XFACE: {
-            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{
-                {0.0, 0.5, 0.5}};
+            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{0.0, 0.5, 0.5};
             sample_field(np, ic, pvec, parr, farr, plo, dxi, dx, offset);
             break;
         }
 
         case FieldLoc::YFACE: {
-            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{
-                {0.5, 0.0, 0.5}};
+            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{0.5, 0.0, 0.5};
             sample_field(np, ic, pvec, parr, farr, plo, dxi, dx, offset);
             break;
         }
 
         case FieldLoc::ZFACE: {
-            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{
-                {0.5, 0.5, 0.0}};
+            amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> offset{0.5, 0.5, 0.0};
             sample_field(np, ic, pvec, parr, farr, plo, dxi, dx, offset);
             break;
         }

--- a/amr-wind/utilities/sampling/WaveEnergy.H
+++ b/amr-wind/utilities/sampling/WaveEnergy.H
@@ -84,7 +84,7 @@ private:
     const Field& m_vof;
 
     //! gravity vector
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     //! offset for potential energy calculation
     amrex::Real m_pe_off = 0.0;

--- a/amr-wind/wind_energy/ABLAnelastic.H
+++ b/amr-wind/wind_energy/ABLAnelastic.H
@@ -29,7 +29,7 @@ private:
 
     bool m_is_anelastic{false};
 
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     amrex::Real m_rho0_const{1.0};
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -176,8 +176,8 @@ private:
     int m_write_frequency{1};
 
     //! Plane names
-    amrex::Vector<std::string> m_plane_names{
-        {"xlo", "ylo", "zlo", "xhi", "yhi", "zhi"}};
+    amrex::Vector<std::string> m_plane_names{"xlo", "ylo", "zlo",
+                                             "xhi", "yhi", "zhi"};
 
     //! IO boundary planes
     amrex::Vector<std::string> m_planes;

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -451,16 +451,15 @@ void ABLBoundaryPlane::write_header()
                 const amrex::Box& minBox = m_mesh.boxArray(lev).minimalBox();
                 const auto& lo = minBox.loVect();
                 const auto& hi = minBox.hiVect();
-                const amrex::Vector<amrex::Real> pdx{
-                    {dx[perp[0]], dx[perp[1]]}};
+                const amrex::Vector<amrex::Real> pdx{dx[perp[0]], dx[perp[1]]};
                 const amrex::Vector<amrex::Real> los{
-                    {lo[perp[0]] * dx[perp[0]], lo[perp[1]] * dx[perp[1]]}};
+                    lo[perp[0]] * dx[perp[0]], lo[perp[1]] * dx[perp[1]]};
                 const amrex::Vector<amrex::Real> his{
-                    {(hi[perp[0]] + 1) * dx[perp[0]],
-                     (hi[perp[1]] + 1) * dx[perp[1]]}};
+                    (hi[perp[0]] + 1) * dx[perp[0]],
+                    (hi[perp[1]] + 1) * dx[perp[1]]};
                 const amrex::Vector<amrex::Real> lengths{
-                    {minBox.length(perp[0]) * dx[perp[0]],
-                     minBox.length(perp[1]) * dx[perp[1]]}};
+                    minBox.length(perp[0]) * dx[perp[0]],
+                    minBox.length(perp[1]) * dx[perp[1]]};
 
                 lev_grp.var("lengths").put(lengths.data());
                 lev_grp.var("lo").put(los.data());
@@ -645,17 +644,16 @@ void ABLBoundaryPlane::read_header()
                 const auto& lo = minBox.loVect();
                 const auto& hi = minBox.hiVect();
                 const auto& dx = m_mesh.Geom(lev).CellSizeArray();
-                const amrex::Vector<amrex::Real> pdx{
-                    {dx[perp[0]], dx[perp[1]]}};
+                const amrex::Vector<amrex::Real> pdx{dx[perp[0]], dx[perp[1]]};
                 const amrex::Vector<amrex::Real> los{
-                    {lo[perp[0]] * pdx[0], lo[perp[1]] * pdx[1]}};
+                    lo[perp[0]] * pdx[0], lo[perp[1]] * pdx[1]};
                 const amrex::Vector<amrex::Real> his{
-                    {(hi[perp[0]] + 1) * pdx[0], (hi[perp[1]] + 1) * pdx[1]}};
+                    (hi[perp[0]] + 1) * pdx[0], (hi[perp[1]] + 1) * pdx[1]};
                 const amrex::Vector<amrex::Real> lengths{
-                    {minBox.length(perp[0]) * pdx[0],
-                     minBox.length(perp[1]) * pdx[1]}};
+                    minBox.length(perp[0]) * pdx[0],
+                    minBox.length(perp[1]) * pdx[1]};
 
-                amrex::Vector<amrex::Real> nc_dat{{0, 0}};
+                amrex::Vector<amrex::Real> nc_dat{0, 0};
                 lev_grp.var("lengths").get(nc_dat.data());
                 AMREX_ALWAYS_ASSERT(nc_dat == lengths);
                 lev_grp.var("lo").get(nc_dat.data());

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -117,10 +117,10 @@ private:
     amrex::Real m_tke_cutoff_height{250.};
 
     //! Top velocity
-    amrex::RealArray m_top_vel{20.0, 0.0, 0.0};
+    amrex::RealArray m_top_vel{20.0};
 
     //! Bottom velocity
-    amrex::RealArray m_bottom_vel{4.0, 0.0, 0.0};
+    amrex::RealArray m_bottom_vel{4.0};
 
     //! Initial linear velocity profile boolean
     bool m_linear_profile{false};

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -117,10 +117,10 @@ private:
     amrex::Real m_tke_cutoff_height{250.};
 
     //! Top velocity
-    amrex::RealArray m_top_vel{{20.0, 0.0, 0.0}};
+    amrex::RealArray m_top_vel{20.0, 0.0, 0.0};
 
     //! Bottom velocity
-    amrex::RealArray m_bottom_vel{{4.0, 0.0, 0.0}};
+    amrex::RealArray m_bottom_vel{4.0, 0.0, 0.0};
 
     //! Initial linear velocity profile boolean
     bool m_linear_profile{false};

--- a/amr-wind/wind_energy/ABLFieldInitFile.cpp
+++ b/amr-wind/wind_energy/ABLFieldInitFile.cpp
@@ -59,12 +59,12 @@ bool ABLFieldInitFile::operator()(
         // from the input file
         // start is the first index from where to read data
         amrex::Vector<size_t> start{
-            {static_cast<size_t>(i0), static_cast<size_t>(j0),
-             static_cast<size_t>(k0)}};
+            static_cast<size_t>(i0), static_cast<size_t>(j0),
+            static_cast<size_t>(k0)};
         // count is the total number of elements to read in each direction
         amrex::Vector<size_t> count{
-            {static_cast<size_t>(i1 - i0 + 1), static_cast<size_t>(j1 - j0 + 1),
-             static_cast<size_t>(k1 - k0 + 1)}};
+            static_cast<size_t>(i1 - i0 + 1), static_cast<size_t>(j1 - j0 + 1),
+            static_cast<size_t>(k1 - k0 + 1)};
 
         // Working vector to read data onto host
         const auto dlen = count[0] * count[1] * count[2];

--- a/amr-wind/wind_energy/ABLModulatedPowerLaw.H
+++ b/amr-wind/wind_energy/ABLModulatedPowerLaw.H
@@ -59,7 +59,7 @@ private:
     amrex::Real m_shearlayer_smear_thickness{30.0};
     amrex::Real m_wind_speed{8.0};
     amrex::Real m_wind_direction{270.0};
-    amrex::Vector<amrex::Real> m_uvec{{8.0, 0.0, 0.0}};
+    amrex::Vector<amrex::Real> m_uvec{8.0, 0.0, 0.0};
 
     amrex::Real m_start_time{0.0};
     amrex::Real m_stop_time{std::numeric_limits<amrex::Real>::max()};

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -327,7 +327,7 @@ void ABLStats::write_ascii()
         return;
     }
 
-    amrex::RealArray abl_forcing = {0.0, 0.0, 0.0};
+    amrex::RealArray abl_forcing = {0.0};
     if (m_abl_forcing != nullptr) {
         abl_forcing = m_abl_forcing->abl_forcing();
     }
@@ -537,7 +537,7 @@ void ABLStats::write_netcdf()
         ncf.var("L").put(&L, {nt}, {1});
         ncf.var("zi").put(&m_zi, {nt}, {1});
 
-        amrex::RealArray abl_forcing = {0.0, 0.0, 0.0};
+        amrex::RealArray abl_forcing = {0.0};
         if (m_abl_forcing != nullptr) {
             abl_forcing = m_abl_forcing->abl_forcing();
         }

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -55,7 +55,7 @@ void ABLStats::initialize()
         pp.query("normal_direction", m_normal_dir);
         AMREX_ASSERT((0 <= m_normal_dir) && (m_normal_dir < AMREX_SPACEDIM));
         pp.query("kappa", m_kappa);
-        amrex::Vector<amrex::Real> gravity{{0.0, 0.0, -9.81}};
+        amrex::Vector<amrex::Real> gravity{0.0, 0.0, -9.81};
         pp.queryarr("gravity", gravity);
         m_gravity = utils::vec_mag(gravity.data());
         pp.get("reference_temperature", m_ref_theta);
@@ -327,7 +327,7 @@ void ABLStats::write_ascii()
         return;
     }
 
-    amrex::RealArray abl_forcing = {{0.0, 0.0, 0.0}};
+    amrex::RealArray abl_forcing = {0.0, 0.0, 0.0};
     if (m_abl_forcing != nullptr) {
         abl_forcing = m_abl_forcing->abl_forcing();
     }
@@ -537,7 +537,7 @@ void ABLStats::write_netcdf()
         ncf.var("L").put(&L, {nt}, {1});
         ncf.var("zi").put(&m_zi, {nt}, {1});
 
-        amrex::RealArray abl_forcing = {{0.0, 0.0, 0.0}};
+        amrex::RealArray abl_forcing = {0.0, 0.0, 0.0};
         if (m_abl_forcing != nullptr) {
             abl_forcing = m_abl_forcing->abl_forcing();
         }

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -50,7 +50,7 @@ private:
     int m_direction{2};   ///< Direction normal to wall
     bool m_use_fch{true}; ///< Use first cell height?
 
-    amrex::Vector<amrex::Real> m_gravity{{0.0, 0.0, -9.81}};
+    amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};
 
     bool m_tempflux{true};
     amrex::Real m_surf_temp_rate{0.0};
@@ -59,7 +59,7 @@ private:
 
     bool m_inflow_outflow{false};
     amrex::Real m_wf_vmag{0.0};
-    amrex::Array<amrex::Real, 2> m_wf_vel{{0.0, 0.0}};
+    amrex::Array<amrex::Real, 2> m_wf_vel{0.0, 0.0};
     amrex::Real m_wf_theta{300.0};
 };
 

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -109,7 +109,7 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
             problo[2] + (k + 0.5) * dx[2],
         };
 
-        amrex::RealArray src_force = {0.0, 0.0, 0.0};
+        amrex::RealArray src_force = {0.0};
         for (int ip = 0; ip < npts; ++ip) {
             // Put force at n+1/2 location for Godunov
             constexpr amrex::Real wt = 0.5;

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -68,7 +68,7 @@ public:
                     problo[2] + (k + 0.5) * dx[2],
                 };
 
-                amrex::RealArray src_force = {0.0, 0.0, 0.0};
+                amrex::RealArray src_force = {0.0};
                 for (int ip = 0; ip < npts; ++ip) {
                     const auto& pforce = force[ip] / nForceTheta;
                     const auto pLoc = pos[ip];

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -123,7 +123,7 @@ public:
                     problo[2] + (k + 0.5) * dx[2],
                 };
 
-                amrex::RealArray src_force = {0.0, 0.0, 0.0};
+                amrex::RealArray src_force = {0.0};
                 for (int ip = 0; ip < npts; ++ip) {
                     const auto R = utils::delta_pnts_cyl(
                                        m_origin, m_normal, m_origin, pos[ip])
@@ -182,7 +182,7 @@ public:
                     problo[2] + (k + 0.5) * dx[2],
                 };
 
-                amrex::RealArray src_force = {0.0, 0.0, 0.0};
+                amrex::RealArray src_force = {0.0};
                 for (int ip = 0; ip < npts; ++ip) {
                     const auto radius =
                         utils::delta_pnts_cyl(

--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
@@ -110,7 +110,7 @@ operator()(const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom)
             problo[2] + (k + 0.5) * dx[2],
         };
 
-        amrex::RealArray src_force = {0.0, 0.0, 0.0};
+        amrex::RealArray src_force = {0.0};
         for (int ib = 0; ib < nBlades; ++ib) {
             // blade/disk contribution
             {


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
Cleaner/consistent initialization of vectors and arrays, `amrex::Vector<amrex::Real> foo {0.0,0.0}` is a lot cleaner than `amrex::Vector<amrex::Real> foo{{0.0,0.0}}`. 
## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
