### PR TITLE
Fix diagnostic behavior (maximum velocity, MAC velocity) on GPUs

### DIFF
--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -17,8 +17,10 @@ amrex::Real amr_wind::diagnostics::get_vel_max(
             amrex::Array4<int const> const& mask_arr) -> amrex::Real {
             amrex::Real max_fab = -1e8;
             amrex::Loop(bx, [=, &max_fab](int i, int j, int k) noexcept {
-                max_fab = amrex::max(max_fab, factor * vel_arr(i, j, k, vdir)) *
-                          (mask_arr(i, j, k) > 0 ? 1.0 : -1.0);
+                max_fab = amrex::max(
+                    max_fab, mask_arr(i, j, k) > 0
+                                 ? factor * vel_arr(i, j, k, vdir)
+                                 : -std::numeric_limits<amrex::Real>::max());
             });
             return max_fab;
         });
@@ -89,9 +91,10 @@ amrex::Real amr_wind::diagnostics::get_macvel_max(
                 int ii = i - (vdir == 0 ? 1 : 0);
                 int jj = j - (vdir == 1 ? 1 : 0);
                 int kk = k - (vdir == 2 ? 1 : 0);
-                max_fab =
-                    amrex::max(max_fab, factor * mvel_arr(i, j, k)) *
-                    (mask_arr(i, j, k) + mask_arr(ii, jj, kk) > 0 ? 1.0 : -1.0);
+                max_fab = amrex::max(
+                    max_fab, (mask_arr(i, j, k) + mask_arr(ii, jj, kk)) > 0
+                                 ? factor * mvel_arr(i, j, k)
+                                 : -std::numeric_limits<amrex::Real>::max());
             });
             return max_fab;
         });

--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -20,7 +20,7 @@ amrex::Real amr_wind::diagnostics::get_vel_max(
                 max_fab = amrex::max(
                     max_fab, mask_arr(i, j, k) > 0
                                  ? factor * vel_arr(i, j, k, vdir)
-                                 : -std::numeric_limits<amrex::Real>::max());
+                                 : std::numeric_limits<amrex::Real>::lowest());
             });
             return max_fab;
         });
@@ -94,7 +94,7 @@ amrex::Real amr_wind::diagnostics::get_macvel_max(
                 max_fab = amrex::max(
                     max_fab, (mask_arr(i, j, k) + mask_arr(ii, jj, kk)) > 0
                                  ? factor * mvel_arr(i, j, k)
-                                 : -std::numeric_limits<amrex::Real>::max());
+                                 : std::numeric_limits<amrex::Real>::lowest());
             });
             return max_fab;
         });


### PR DESCRIPTION
## Summary

The unit test for the diagnostics on multiple levels was not passing on GPUs; the solution is to alter the way masking is used within the functions that find the max velocity.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU (gcc+cuda on Eagle)
  - [x] on CPU (apple-clang on Mac OSX)
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

Issue Number: #1063
