### PR TITLE
Use one input param for gravity to avoid inconsistencies

### DIFF
--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -55,11 +55,15 @@ void ABLStats::initialize()
         pp.query("normal_direction", m_normal_dir);
         AMREX_ASSERT((0 <= m_normal_dir) && (m_normal_dir < AMREX_SPACEDIM));
         pp.query("kappa", m_kappa);
+        pp.get("reference_temperature", m_ref_theta);
+        pp.query("stats_do_energy_budget", m_do_energy_budget);
+    }
+
+    {
+        amrex::ParmParse pp("incflo");
         amrex::Vector<amrex::Real> gravity{0.0, 0.0, -9.81};
         pp.queryarr("gravity", gravity);
         m_gravity = utils::vec_mag(gravity.data());
-        pp.get("reference_temperature", m_ref_theta);
-        pp.query("stats_do_energy_budget", m_do_energy_budget);
     }
 
     // Get normal direction and associated stuff

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -16,6 +16,11 @@ namespace amr_wind {
 ABLWallFunction::ABLWallFunction(const CFDSim& sim)
     : m_sim(sim), m_mesh(sim.mesh())
 {
+    {
+        amrex::ParmParse pp("incflo");
+        pp.queryarr("gravity", m_gravity);
+    }
+
     amrex::ParmParse pp("ABL");
 
     pp.query("kappa", m_mo.kappa);
@@ -25,7 +30,6 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
     pp.query("mo_beta_h", m_mo.beta_h);
     pp.query("surface_roughness_z0", m_mo.z0);
     pp.query("normal_direction", m_direction);
-    pp.queryarr("gravity", m_gravity);
     AMREX_ASSERT((0 <= m_direction) && (m_direction < AMREX_SPACEDIM));
 
     if (pp.contains("log_law_height")) {


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
We currently have a couple places that read gravity from the input files using `ABL.gravity` instead of `incflo.gravity`. I suspect this was a bug since most other places use the latter.


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

None of the regtests use `ABL.gravity` 

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
