### PR TITLE
Move channel flow wall model assert on body force to a better place

### DIFF
--- a/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
+++ b/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
@@ -21,9 +21,6 @@ WallFunction::WallFunction(CFDSim& sim)
         pp.getarr("magnitude", body_force);
         m_log_law.utau_mean = std::sqrt(std::sqrt(
             body_force[0] * body_force[0] + body_force[1] * body_force[1]));
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            std::abs(body_force[2]) < 1e-16,
-            "body force in z should be zero for this wall function");
     }
     {
         amrex::ParmParse pp("transport");

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -441,6 +441,13 @@ void ChannelFlow::post_init_actions()
             m_norm_dir == 2,
             "Wall normal direction should be 2 if using a wall model");
         velocity.register_custom_bc<VelWallFunc>(m_wall_func);
+
+        amrex::ParmParse pp("BodyForce");
+        amrex::Vector<amrex::Real> body_force{0.0, 0.0, 0.0};
+        pp.getarr("magnitude", body_force);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            std::abs(body_force[2]) < 1e-16,
+            "body force in z should be zero if using a wall model");
     }
 }
 


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
We require that the normal direction is 2 and that the body force in the 2 direction is 0 when using a wall model. However the constructor for the wall model gets initialized even when a wall model for the channel flow even when not using one. This PR moves the assert to the right place.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background
This fixes the reg test `channel_mol_mesh_map_z` from failing.
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
