### PR TITLE
Remove ChannelFlow.density and replace with just incflo.density

### DIFF
--- a/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
+++ b/amr-wind/boundary_conditions/wall_models/WallFunction.cpp
@@ -15,6 +15,8 @@ namespace amr_wind {
 WallFunction::WallFunction(CFDSim& sim)
     : m_sim(sim), m_mesh(m_sim.mesh()), m_pa_vel(sim, m_direction)
 {
+    amrex::Real mu;
+    amrex::Real rho{1.0};
     {
         amrex::ParmParse pp("BodyForce");
         amrex::Vector<amrex::Real> body_force{0.0, 0.0, 0.0};
@@ -24,8 +26,13 @@ WallFunction::WallFunction(CFDSim& sim)
     }
     {
         amrex::ParmParse pp("transport");
-        pp.query("viscosity", m_log_law.nu);
+        pp.get("viscosity", mu);
     }
+    {
+        amrex::ParmParse pp("incflo");
+        pp.query("density", rho);
+    }
+    m_log_law.nu = mu / rho;
     {
         amrex::ParmParse pp("WallFunction");
         // Reference height for log-law

--- a/amr-wind/physics/ChannelFlow.cpp
+++ b/amr-wind/physics/ChannelFlow.cpp
@@ -24,17 +24,19 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
         }
     }
     {
+        {
+            amrex::ParmParse pp("incflo");
+            pp.query("density", m_rho);
+        }
         amrex::ParmParse pp("ChannelFlow");
         pp.query("flow_direction", m_mean_vel_dir);
         pp.query("normal_direction", m_norm_dir);
         pp.query("error_log_file", m_output_fname);
 
         if (m_laminar) {
-            pp.query("density", m_rho);
             pp.query("Mean_Velocity", m_mean_vel);
             pp.query("half_channel", m_half);
         } else {
-            pp.query("density", m_rho);
             pp.query("re_tau", m_re_tau);
             pp.query("tke0", m_tke0);
             pp.query("sdr0", m_sdr0);

--- a/test/test_files/channel_godunov_laminar/channel_godunov_laminar.inp
+++ b/test/test_files/channel_godunov_laminar/channel_godunov_laminar.inp
@@ -32,7 +32,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 12.0 0 0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1

--- a/test/test_files/channel_kwsst/channel_kwsst.inp
+++ b/test/test_files/channel_kwsst/channel_kwsst.inp
@@ -28,7 +28,6 @@ TKE.source_terms = KwSSTSrc
 SDR.source_terms = SDRSrc
 incflo.physics = ChannelFlow
 ChannelFlow.re_tau = 1000.0
-ChannelFlow.density = 1.0
 ChannelFlow.tke0 = 0.05
 ChannelFlow.sdr0 = 3528.0
 

--- a/test/test_files/channel_kwsst_hypre/channel_kwsst_hypre.inp
+++ b/test/test_files/channel_kwsst_hypre/channel_kwsst_hypre.inp
@@ -28,7 +28,6 @@ TKE.source_terms = KwSSTSrc
 SDR.source_terms = SDRSrc
 incflo.physics = ChannelFlow
 ChannelFlow.re_tau = 1000.0
-ChannelFlow.density = 1.0
 ChannelFlow.tke0 = 0.05
 ChannelFlow.sdr0 = 3528.0
 

--- a/test/test_files/channel_kwsst_sust/channel_kwsst_sust.inp
+++ b/test/test_files/channel_kwsst_sust/channel_kwsst_sust.inp
@@ -30,7 +30,6 @@ KOmegaSST_coeffs.tke_amb = 0.05
 KOmegaSST_coeffs.sdr_amb = 3528.0
 incflo.physics = ChannelFlow
 ChannelFlow.re_tau = 1000.0
-ChannelFlow.density = 1.0
 ChannelFlow.tke0 = 0.05
 ChannelFlow.sdr0 = 3528.0
 

--- a/test/test_files/channel_kwsstiddes/channel_kwsstiddes.inp
+++ b/test/test_files/channel_kwsstiddes/channel_kwsstiddes.inp
@@ -28,7 +28,6 @@ TKE.source_terms = KwSSTSrc
 SDR.source_terms = SDRSrc
 incflo.physics = ChannelFlow
 ChannelFlow.re_tau = 1000.0
-ChannelFlow.density = 1.0
 ChannelFlow.tke0 = 0.05
 ChannelFlow.sdr0 = 3528.0
 

--- a/test/test_files/channel_mol_mesh_map_x/channel_mol_mesh_map_x.inp
+++ b/test/test_files/channel_mol_mesh_map_x/channel_mol_mesh_map_x.inp
@@ -30,7 +30,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 6e-2 0 0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1

--- a/test/test_files/channel_mol_mesh_map_x_seg_vel_solve/channel_mol_mesh_map_x_seg_vel_solve.inp
+++ b/test/test_files/channel_mol_mesh_map_x_seg_vel_solve/channel_mol_mesh_map_x_seg_vel_solve.inp
@@ -30,7 +30,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 6e-2 0 0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.Mean_Velocity = 1.0
 
 io.output_default_variables = 1

--- a/test/test_files/channel_mol_mesh_map_y/channel_mol_mesh_map_y.inp
+++ b/test/test_files/channel_mol_mesh_map_y/channel_mol_mesh_map_y.inp
@@ -30,7 +30,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 0.0 6e-2 0.0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.flow_direction = 1
 ChannelFlow.normal_direction = 2
 ChannelFlow.Mean_Velocity = 1.0

--- a/test/test_files/channel_mol_mesh_map_z/channel_mol_mesh_map_z.inp
+++ b/test/test_files/channel_mol_mesh_map_z/channel_mol_mesh_map_z.inp
@@ -30,7 +30,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 0.0 0.0 6e-2
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.flow_direction = 2
 ChannelFlow.normal_direction = 0
 ChannelFlow.Mean_Velocity = 1.0

--- a/test/test_files/channel_smagorinsky_analytical/channel_smagorinsky_analytical.inp
+++ b/test/test_files/channel_smagorinsky_analytical/channel_smagorinsky_analytical.inp
@@ -33,7 +33,6 @@ Smagorinsky_coeffs.Cs = 0.1
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 0.003969 0.0 0.0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.re_tau = 180.0
 ChannelFlow.normal_direction = 2
 ChannelFlow.perturb_velocity = true

--- a/test/test_files/halfchannel_symmetricwall/halfchannel_symmetricwall.inp
+++ b/test/test_files/halfchannel_symmetricwall/halfchannel_symmetricwall.inp
@@ -32,7 +32,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 12.0 0 0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.Mean_Velocity = 1.0
 ChannelFlow.half_channel = true
 

--- a/test/test_files/halfchannel_zerogradient/halfchannel_zerogradient.inp
+++ b/test/test_files/halfchannel_zerogradient/halfchannel_zerogradient.inp
@@ -32,7 +32,6 @@ turbulence.model = Laminar
 ICNS.source_terms = BodyForce
 BodyForce.magnitude = 12.0 0 0
 incflo.physics = ChannelFlow
-ChannelFlow.density = 1.0
 ChannelFlow.Mean_Velocity = 1.0
 ChannelFlow.half_channel = true
 


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
`ChannelFlow` seems to define it's own density, and it is unclear why this needs to be a separate parameter from `incflo.density`. This PR consolidates those.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):
Consolidating density into one parameter for `ChannelFlow`
## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
