### PR TITLE
Conform multiphase CFL to expectations

### DIFF
--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -112,6 +112,11 @@ void incflo::ComputeDt(bool explicit_diffusion)
                         result = std::abs(v_bx(i, j, k, 0)) * dxinv[0] / fac_x +
                                  std::abs(v_bx(i, j, k, 1)) * dxinv[1] / fac_y +
                                  std::abs(v_bx(i, j, k, 2)) * dxinv[2] / fac_z;
+
+                        // Multiply advective CFL by 2 when near interface
+                        result *= 2.0
+                        // CFL requirement to ensure vof conservation is 0.5;
+                        // this is half the typical concept of a CFL (1.0)
                     }
                     return result;
                 });

--- a/amr-wind/incflo_compute_dt.cpp
+++ b/amr-wind/incflo_compute_dt.cpp
@@ -114,7 +114,7 @@ void incflo::ComputeDt(bool explicit_diffusion)
                                  std::abs(v_bx(i, j, k, 2)) * dxinv[2] / fac_z;
 
                         // Multiply advective CFL by 2 when near interface
-                        result *= 2.0
+                        result *= 2.0;
                         // CFL requirement to ensure vof conservation is 0.5;
                         // this is half the typical concept of a CFL (1.0)
                     }

--- a/test/test_files/breaking_waves_kwsst/breaking_waves_kwsst.inp
+++ b/test/test_files/breaking_waves_kwsst/breaking_waves_kwsst.inp
@@ -8,7 +8,7 @@ time.max_step                =   100          # Max number of time steps
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.fixed_dt         =   -0.005        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#

--- a/test/test_files/breaking_waves_laminar/breaking_waves_laminar.inp
+++ b/test/test_files/breaking_waves_laminar/breaking_waves_laminar.inp
@@ -8,7 +8,7 @@ time.max_step                =   10          # Max number of time steps
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.fixed_dt         =   -0.005        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#

--- a/test/test_files/inertial_drop/inertial_drop.inp
+++ b/test/test_files/inertial_drop/inertial_drop.inp
@@ -8,7 +8,7 @@ time.max_step                =   10
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.initial_dt       =   0.05        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #

--- a/test/test_files/ow_linear/ow_linear.inp
+++ b/test/test_files/ow_linear/ow_linear.inp
@@ -9,7 +9,7 @@ time.max_step                =   20          # Max number of time steps
 #.......................................#
 time.initial_dt = 0.01
 time.fixed_dt         =   0.005        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 time.use_force_cfl= false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #

--- a/test/test_files/ow_stokes/ow_stokes.inp
+++ b/test/test_files/ow_stokes/ow_stokes.inp
@@ -9,7 +9,7 @@ time.max_step                =   20          # Max number of time steps
 #.......................................#
 time.initial_dt = 0.01
 time.fixed_dt         =   0.005        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 time.use_force_cfl= false
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #

--- a/test/test_files/ow_w2a/ow_w2a.inp
+++ b/test/test_files/ow_w2a/ow_w2a.inp
@@ -8,7 +8,7 @@ time.max_step                =   10
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.fixed_dt         =   1.0        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#

--- a/test/test_files/rain_drop/rain_drop.inp
+++ b/test/test_files/rain_drop/rain_drop.inp
@@ -8,7 +8,7 @@ time.max_step                =   20
 #         TIME STEP COMPUTATION         #
 #.......................................#
 time.fixed_dt         =   0.004        # Use this constant dt if > 0
-time.cfl              =   0.45         # CFL factor
+time.cfl              =   0.95         # CFL factor
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #

--- a/test/test_files/sloshing_tank/sloshing_tank.inp
+++ b/test/test_files/sloshing_tank/sloshing_tank.inp
@@ -2,7 +2,7 @@ time.stop_time               =   10     # Max (simulated) time to evolve
 time.max_step                =   10    # Max number of time steps
 
 time.initial_dt       =   0.05        # Use this constant dt if > 0
-time.cfl              =   0.5         # CFL factor
+time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
 
 io.output_default_variables = 0


### PR DESCRIPTION
## Summary

Multiplies advective CFL by 2 near interface so that different constraints, in different parts of the domain, can apply together.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

The volume-of-fluid scheme implemented in AMR-Wind requires a CFL of < 0.5 to ensure conservation of each phase. Therefore, it has been the recommendation to run multiphase simulations at CFL < 0.5. However, for simulations where there are dynamics both near and far from the interface, such as an ABL simulation with waves, this may be unnecessarily restrictive, e.g., when the flow in the air is at a higher CFL compared to the flow near the waves. The changes in this PR multiply the advective CFL calculated near the interface by 2, so it can be compared with 1 instead of with 0.5. This will prevent dt from being overly restricted by the CFL in a multiphase ABL case.
