### PR TITLE
Fix non-deterministic MMC bug on GPU

### DIFF
--- a/amr-wind/wind_energy/ABLMesoscaleInput.H
+++ b/amr-wind/wind_energy/ABLMesoscaleInput.H
@@ -64,7 +64,7 @@ private:
 
     int m_nheight;
     int m_ntime;
-    bool m_abl_tendency;
+    bool m_abl_tendency{false};
 };
 
 } // namespace amr_wind


### PR DESCRIPTION

## Summary

Initialize `m_abl_tendency` to false, it is currently just set with a `pp.query`. This leads to a buggy non-deterministic behavior when it is not explicitly set in the input file. This should hopefully fix #1057.

<!--- Please provide a one sentence summary of your changes  -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: #1057 <!-- Note related issues -->
