### PR TITLE
Remove duplicated instances of closest_index

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -2,6 +2,7 @@
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/wind_energy/ABL.H"
 #include "amr-wind/core/FieldUtils.H"
+#include "amr-wind/utilities/index_operations.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Gpu.H"
 #include "AMReX_Print.H"
@@ -10,20 +11,6 @@
 #include <iomanip>
 
 namespace amr_wind::pde::icns {
-
-namespace {
-
-//! Return closest index (from lower) of value in vector
-AMREX_FORCE_INLINE int
-closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
-{
-    auto const it = std::upper_bound(vec.begin(), vec.end(), value);
-    AMREX_ALWAYS_ASSERT(it != vec.end());
-
-    const int idx = static_cast<int>(std::distance(vec.begin(), it));
-    return std::max(idx - 1, 0);
-}
-} // namespace
 
 ABLMesoForcingMom::ABLMesoForcingMom(const CFDSim& sim)
     : ABLMesoscaleForcing(sim, identifier())

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -3,6 +3,7 @@
 #include "amr-wind/wind_energy/ABL.H"
 #include "amr-wind/core/FieldUtils.H"
 #include "amr-wind/utilities/ncutils/nc_interface.H"
+#include "amr-wind/utilities/index_operations.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Gpu.H"
 #include "AMReX_Print.H"
@@ -10,20 +11,6 @@
 #include <memory>
 
 namespace amr_wind::pde::temperature {
-
-namespace {
-
-//! Return closest index (from lower) of value in vector
-AMREX_FORCE_INLINE int
-closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
-{
-    auto const it = std::upper_bound(vec.begin(), vec.end(), value);
-    AMREX_ALWAYS_ASSERT(it != vec.end());
-
-    const int idx = static_cast<int>(std::distance(vec.begin(), it));
-    return std::max(idx - 1, 0);
-}
-} // namespace
 
 ABLMesoForcingTemp::ABLMesoForcingTemp(const CFDSim& sim)
     : ABLMesoscaleForcing(sim, identifier())

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -34,4 +34,3 @@ AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
 } /* namespace amr_wind */
 
 #endif /* INDEX_OPERATIONS_H */
-

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -1,0 +1,37 @@
+#ifndef INDEX_OPERATIONS_H
+#define INDEX_OPERATIONS_H
+
+namespace amr_wind {
+
+//! Return closest index (from lower) of value in vector
+AMREX_FORCE_INLINE int
+closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
+{
+    auto const it = std::upper_bound(vec.begin(), vec.end(), value);
+    AMREX_ALWAYS_ASSERT(it != vec.end());
+
+    const int idx = static_cast<int>(std::distance(vec.begin(), it));
+    return std::max(idx - 1, 0);
+}
+
+//! Return indices perpendicular to normal
+template <typename T = amrex::GpuArray<int, 2>>
+AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
+{
+    switch (normal) {
+    case 0:
+        return T{1, 2};
+    case 1:
+        return T{0, 2};
+    case 2:
+        return T{0, 1};
+    default:
+        amrex::Abort("Invalid normal value to determine perpendicular indices");
+    }
+    return T{-1, -1};
+}
+
+} /* namespace amr_wind */
+
+#endif /* INDEX_OPERATIONS_H */
+

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -4,39 +4,12 @@
 #include "AMReX_Gpu.H"
 #include "AMReX_ParmParse.H"
 #include "amr-wind/utilities/ncutils/nc_interface.H"
+#include "amr-wind/utilities/index_operations.H"
 #include <AMReX_PlotFileUtil.H>
 
 namespace amr_wind {
 
 namespace {
-
-//! Return closest index (from lower) of value in vector
-AMREX_FORCE_INLINE int
-closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
-{
-    auto const it = std::upper_bound(vec.begin(), vec.end(), value);
-    AMREX_ALWAYS_ASSERT(it != vec.end());
-
-    const int idx = static_cast<int>(std::distance(vec.begin(), it));
-    return std::max(idx - 1, 0);
-}
-
-//! Return indices perpendicular to normal
-template <typename T = amrex::GpuArray<int, 2>>
-AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
-{
-    switch (normal) {
-    case 0:
-        return T{1, 2};
-    case 1:
-        return T{0, 2};
-    case 2:
-        return T{0, 1};
-    default:
-        amrex::Abort("Invalid normal value to determine perpendicular indices");
-    }
-    return T{-1, -1};
-}
 
 //! Return offset vector
 AMREX_FORCE_INLINE amrex::IntVect offset(const int face_dir, const int normal)


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
The `closest_index` function seems to have been copy pasted into three different places, consolidating them under one common header file. Moving another unnamed namespace function into the new common header file as well. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
