### PR TITLE
Fix deprecation warning in python scripts

### DIFF
--- a/test/test_files/fextrema_compare.py
+++ b/test/test_files/fextrema_compare.py
@@ -27,10 +27,10 @@ if __name__ == "__main__":
     # Read the files
     cols = ["variables", "minimum_value", "maximum_value"]
     input = pd.read_csv(
-        args.fname, delim_whitespace=True, skiprows=3, header=None, names=cols
+        args.fname, sep="\s+", skiprows=3, header=None, names=cols
     ).sort_values(by=["variables"])
     gold = pd.read_csv(
-        args.gold, delim_whitespace=True, skiprows=3, header=None, names=cols
+        args.gold, sep="\s+", skiprows=3, header=None, names=cols
     ).sort_values(by=["variables"])
 
     # Compare

--- a/test/test_files/mms/plotter.py
+++ b/test/test_files/mms/plotter.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
     lst = []
     for k, fdir in enumerate(args.fdirs):
-        df = pd.read_csv(os.path.join(fdir, "mms.log"), delim_whitespace=True)
+        df = pd.read_csv(os.path.join(fdir, "mms.log"), sep="\s+")
         df["res"] = float(fdir)
         lst.append(df.iloc[-1])
 


### PR DESCRIPTION
## Summary

Pandas is deprecating `delim_whitespace`. This fixes that deprecation warning.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):
