### PR TITLE
Make the AMD ABL regtest stable on GPUs

### DIFF
--- a/test/test_files/abl_amd_wenoz/abl_amd_wenoz.inp
+++ b/test/test_files/abl_amd_wenoz/abl_amd_wenoz.inp
@@ -42,6 +42,8 @@ incflo.velocity = 6.128355544951824  5.142300877492314 0.0
 
 ABL.temperature_heights = 650.0 750.0 1000.0
 ABL.temperature_values = 300.0 308.0 308.75
+ABL.perturb_temperature = true
+ABL.perturb_velocity = true
 
 ABL.kappa = .41
 ABL.surface_roughness_z0 = 0.15


### PR DESCRIPTION
## Summary
Perturb temperature/velocity values so that the regtest values aren't too small for SGS terms. Currently the `alpha_eff` is close to machine precision leading to flaky regtest runs on GPUs.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): update regtest parameters

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
