### PR TITLE
Fix ghost cells being used for mac velocity BC functions

### DIFF
--- a/amr-wind/core/FieldBCOps.H
+++ b/amr-wind/core/FieldBCOps.H
@@ -49,7 +49,7 @@ struct FieldBCNoOp
     AMREX_GPU_HOST
     constexpr explicit FieldBCNoOp(const Field& /*unused*/) {}
 
-    FunctorType operator()(const int face_dir = -1) const { return *this; }
+    FunctorType operator()(const int /*face_dir*/ = -1) const { return *this; }
 
     AMREX_GPU_DEVICE
     void operator()(

--- a/amr-wind/core/FieldBCOps.H
+++ b/amr-wind/core/FieldBCOps.H
@@ -49,7 +49,7 @@ struct FieldBCNoOp
     AMREX_GPU_HOST
     constexpr explicit FieldBCNoOp(const Field& /*unused*/) {}
 
-    FunctorType operator()() const { return *this; }
+    FunctorType operator()(const int face_dir = -1) const { return *this; }
 
     AMREX_GPU_DEVICE
     void operator()(
@@ -120,24 +120,28 @@ struct DirichletOp
     amrex::GpuArray<BC, AMREX_SPACEDIM * 2> m_bc_type;
     const InflowOpType m_inflow_op;
     const WallOpType m_wall_op;
+    const int m_face_dir;
 
     AMREX_GPU_HOST
-    constexpr explicit DirichletOp(const Field& fld)
+    constexpr explicit DirichletOp(const Field& fld, const int face_dir)
         : m_ncomp(fld.num_comp())
         , m_bc_type(fld.bc_type())
         , m_inflow_op(fld)
         , m_wall_op(fld)
+        , m_face_dir(face_dir)
     {}
 
     AMREX_GPU_HOST
     DirichletOp(
         const Field& fld,
         const InflowOpType& inflow_op,
-        const WallOpType& wall_op)
+        const WallOpType& wall_op,
+        const int face_dir)
         : m_ncomp(fld.num_comp())
         , m_bc_type(fld.bc_type())
         , m_inflow_op(inflow_op)
         , m_wall_op(wall_op)
+        , m_face_dir{face_dir}
     {}
 
     AMREX_GPU_DEVICE
@@ -169,9 +173,11 @@ struct DirichletOp
                 }
 
                 // Check if the point in question is on the boundary
+                const int big_end =
+                    domain_box.bigEnd(idir) + ((idir == m_face_dir) ? 1 : 0);
                 const bool is_bndry =
                     (ori.isLow() ? (iv[idir] < domain_box.smallEnd(idir))
-                                 : (iv[idir] > domain_box.bigEnd(idir)));
+                                 : (iv[idir] > big_end));
                 if (!is_bndry) {
                     continue;
                 }
@@ -207,7 +213,10 @@ struct FieldBCDirichlet
 
     explicit FieldBCDirichlet(const Field& fld) : m_field(fld) {}
 
-    inline FunctorType operator()() const { return FunctorType(m_field); }
+    inline FunctorType operator()(const int face_dir = -1) const
+    {
+        return FunctorType(m_field, face_dir);
+    }
 
     const Field& m_field;
 };
@@ -228,11 +237,11 @@ struct BCOpCreator
         : m_field(fld), m_inflow_op(inflow_op), m_wall_op(wall_op)
     {}
 
-    inline FunctorType operator()() const
+    inline FunctorType operator()(const int face_dir = -1) const
     {
         return FunctorType{
-            m_field, m_inflow_op.device_instance(),
-            m_wall_op.device_instance()};
+            m_field, m_inflow_op.device_instance(), m_wall_op.device_instance(),
+            face_dir};
     }
 
     const Field& m_field;

--- a/amr-wind/core/FieldFillPatchOps.H
+++ b/amr-wind/core/FieldFillPatchOps.H
@@ -278,21 +278,31 @@ public:
                     m_mesh.Geom(lev), physbc, i);
             }
         } else {
-            amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> cphysbc(
-                m_mesh.Geom(lev - 1), bcrec, bc_functor());
+            AMREX_D_TERM(
+                amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> cphysbcx(
+                    m_mesh.Geom(lev - 1), bcrec, bc_functor_face(0));
+                , amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> cphysbcy(
+                      m_mesh.Geom(lev - 1), bcrec, bc_functor_face(1));
+                , amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> cphysbcz(
+                      m_mesh.Geom(lev - 1), bcrec, bc_functor_face(2)););
 
-            amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> fphysbc(
-                m_mesh.Geom(lev), bcrec, bc_functor());
+            AMREX_D_TERM(
+                amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> fphysbcx(
+                    m_mesh.Geom(lev), bcrec, bc_functor_face(0));
+                , amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> fphysbcy(
+                      m_mesh.Geom(lev), bcrec, bc_functor_face(1));
+                , amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> fphysbcz(
+                      m_mesh.Geom(lev), bcrec, bc_functor_face(2)););
 
             amrex::Array<
                 amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>>,
                 AMREX_SPACEDIM>
-                cphysbc_arr = {AMREX_D_DECL(cphysbc, cphysbc, cphysbc)};
+                cphysbc_arr = {AMREX_D_DECL(cphysbcx, cphysbcy, cphysbcz)};
 
             amrex::Array<
                 amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>>,
                 AMREX_SPACEDIM>
-                fphysbc_arr = {AMREX_D_DECL(fphysbc, fphysbc, fphysbc)};
+                fphysbc_arr = {AMREX_D_DECL(fphysbcx, fphysbcy, fphysbcz)};
 
             amrex::Array<int, AMREX_SPACEDIM> idx = {AMREX_D_DECL(0, 1, 2)};
             const amrex::Array<amrex::Vector<amrex::BCRec>, AMREX_SPACEDIM>

--- a/amr-wind/core/FieldFillPatchOps.H
+++ b/amr-wind/core/FieldFillPatchOps.H
@@ -270,9 +270,9 @@ public:
     {
 
         if (lev == 0) {
-            amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> physbc(
-                m_mesh.Geom(lev), bcrec, bc_functor());
             for (int i = 0; i < static_cast<int>(mfabs.size()); i++) {
+                amrex::PhysBCFunct<amrex::GpuBndryFuncFab<Functor>> physbc(
+                    m_mesh.Geom(lev), bcrec, bc_functor_face(i));
                 amrex::FillPatchSingleLevel(
                     *mfabs[i], nghost, time, {ffabs[i]}, {time}, 0, 0, 1,
                     m_mesh.Geom(lev), physbc, i);
@@ -386,6 +386,8 @@ public:
 
 protected:
     Functor bc_functor() { return m_op(); }
+
+    Functor bc_functor_face(const int face_dir) { return m_op(face_dir); }
 
     void check_face_mapper()
     {

--- a/amr-wind/physics/udfs/Rankine.H
+++ b/amr-wind/physics/udfs/Rankine.H
@@ -45,6 +45,27 @@ struct Rankine
                     vel_ref[2] + 0.0)};
 
             field(iv[0], iv[1], iv[2], dcomp + comp) = vel[orig_comp + comp];
+
+            amrex::IntVect ivhh(AMREX_D_DECL(41, 12, 1));
+            amrex::IntVect ivhi(AMREX_D_DECL(40, 12, 1));
+            amrex::IntVect ivlo(AMREX_D_DECL(0, 12, 1));
+            amrex::IntVect ivlm(AMREX_D_DECL(-1, 12, 1));
+            if (iv == ivlo)
+                amrex::Print()
+                    << "Rankine.H op: filling " << vel[orig_comp + comp]
+                    << " at i=0" << std::endl;
+            if (iv == ivlm)
+                amrex::Print()
+                    << "Rankine.H op: filling " << vel[orig_comp + comp]
+                    << " at i=-1" << std::endl;
+            if (iv == ivhi)
+                amrex::Print()
+                    << "Rankine.H op: filling " << vel[orig_comp + comp]
+                    << " at i=40" << std::endl;
+            if (iv == ivhh)
+                amrex::Print()
+                    << "Rankine.H op: filling " << vel[orig_comp + comp]
+                    << " at i=41" << std::endl;
         }
     };
     using DeviceType = DeviceOp;

--- a/amr-wind/physics/udfs/Rankine.H
+++ b/amr-wind/physics/udfs/Rankine.H
@@ -45,27 +45,6 @@ struct Rankine
                     vel_ref[2] + 0.0)};
 
             field(iv[0], iv[1], iv[2], dcomp + comp) = vel[orig_comp + comp];
-
-            amrex::IntVect ivhh(AMREX_D_DECL(41, 12, 1));
-            amrex::IntVect ivhi(AMREX_D_DECL(40, 12, 1));
-            amrex::IntVect ivlo(AMREX_D_DECL(0, 12, 1));
-            amrex::IntVect ivlm(AMREX_D_DECL(-1, 12, 1));
-            if (iv == ivlo)
-                amrex::Print()
-                    << "Rankine.H op: filling " << vel[orig_comp + comp]
-                    << " at i=0" << std::endl;
-            if (iv == ivlm)
-                amrex::Print()
-                    << "Rankine.H op: filling " << vel[orig_comp + comp]
-                    << " at i=-1" << std::endl;
-            if (iv == ivhi)
-                amrex::Print()
-                    << "Rankine.H op: filling " << vel[orig_comp + comp]
-                    << " at i=40" << std::endl;
-            if (iv == ivhh)
-                amrex::Print()
-                    << "Rankine.H op: filling " << vel[orig_comp + comp]
-                    << " at i=41" << std::endl;
         }
     };
     using DeviceType = DeviceOp;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -241,6 +241,7 @@ add_test_re(vortex_dipole_wall_collision)
 add_test_re(burggraf_flow)
 add_test_re(abl_godunov_rayleigh_damping)
 add_test_re(rankine)
+add_test_re(rankine-sym)
 
 if(NOT AMR_WIND_ENABLE_CUDA)
   add_test_re(ctv_godunov_plm)

--- a/test/test_files/rankine-sym/rankine-sym.inp
+++ b/test/test_files/rankine-sym/rankine-sym.inp
@@ -1,0 +1,80 @@
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            SIMULATION STOP            #
+#.......................................#
+time.stop_time               =   450.0  # vort init at -1250; domain length = 2000; to travel 4500 at 10 m/s, need 450 s
+time.max_step                =   100000
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#         TIME STEP COMPUTATION         #
+#.......................................#
+time.fixed_dt         =   1.0        # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            INPUT AND OUTPUT           #
+#.......................................#
+time.plot_interval            =  1       # Steps between plot files
+time.checkpoint_interval      =  -1       # Steps between checkpoint files
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#               PHYSICS                 #
+#.......................................#
+incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
+incflo.density          = 1.0          # Reference density
+incflo.use_godunov = 1
+incflo.diffusion_type = 2
+incflo.do_initial_proj = false
+incflo.initial_iterations = 0
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+incflo.physics = ABL
+#ICNS.source_terms = CoriolisForcing
+#CoriolisForcing.east_vector = 1.0 0.0 0.0
+#CoriolisForcing.north_vector = 0.0 1.0 0.0
+#CoriolisForcing.latitude = 90.0
+#CoriolisForcing.rotational_time_period = 125663.706143592
+incflo.velocity = 10.0 0.0 0.0
+ABL.reference_temperature = 300.0
+ABL.temperature_heights = 0.0 2000.0
+ABL.temperature_values = 300.0 300.0
+ABL.perturb_temperature = false
+ABL.perturb_velocity = false
+#ABL.cutoff_height = 50.0
+#ABL.perturb_ref_height = 50.0
+#ABL.Uperiods = 4.0
+#ABL.Vperiods = 4.0
+#ABL.deltaU = 1.0
+#ABL.deltaV = 1.0
+#ABL.kappa = .41
+#ABL.surface_roughness_z0 = 0.01
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#        ADAPTIVE MESH REFINEMENT       #
+#.......................................#
+amr.n_cell              = 40 60 4    # Grid cells at coarsest AMRlevel
+amr.max_level           = 0           # Max AMR level in hierarchy
+amr.blocking_factor = 4
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              GEOMETRY                 #
+#.......................................#
+geometry.prob_lo        =   0.    -1500.    0.  # Lo corner coordinates
+geometry.prob_hi        =   2000.  1500.  200.  # Hi corner coordinates
+geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
+
+# Boundary conditions
+xlo.type = "mass_inflow"
+xlo.density = 1.0
+xlo.velocity.inflow_type = Rankine
+xlo.temperature = 300.0
+xhi.type = "mass_inflow"
+xhi.density = 1.0
+xhi.velocity.inflow_type = Rankine
+xhi.temperature = 300.0
+ylo.type = "slip_wall"
+yhi.type =   "slip_wall"
+zlo.type =   "slip_wall"
+zhi.type =   "slip_wall"
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              VERBOSITY                #
+#.......................................#
+incflo.verbose          =   0          # incflo_level


### PR DESCRIPTION
## Summary

Fixing the fact that the UDFs are called on cell-centered and face centered velocities and, therefore, the indices of the cells should be set appropriately.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

Left to do:
- [x] I need to do the same for `lev != 0`

The following is included:

- [ ] new unit-test(s)
- [x] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

With these changes, the fillpatch of the mac velocities now touches the following indices depending on the face-centered mac velocity component. For umac, we need to be touching -1 and 41 (with n_cell = 40). For the others it is -1 and 40.

```
  MAC_projection                 9         0.01766980429       1.787159811e-14
this face_idir: 0
Rankine.H op: filling 10.73181747 at i=-1
Rankine.H op: filling 10.13957005 at i=41
this face_idir: 1
Rankine.H op: filling 1.016180833 at i=-1
Rankine.H op: filling 0.5357916479 at i=40
this face_idir: 2
Rankine.H op: filling 0 at i=-1
Rankine.H op: filling 0 at i=40
```

Issue Number: #1076
