### PR TITLE
Fix netcdf boundary planes read with amrex.the_arena_is_managed=0

### DIFF
--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -127,8 +127,7 @@ void InletData::read_data(
     const auto nelems = bx.numPts() * nc;
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, h_datn.dataPtr(nstart),
-        h_datn.dataPtr(nstart) + nelems,
-        (*m_data_n[ori])[lev].dataPtr(nstart));
+        h_datn.dataPtr(nstart) + nelems, (*m_data_n[ori])[lev].dataPtr(nstart));
     amrex::Gpu::copyAsync(
         amrex::Gpu::hostToDevice, h_datnp1.dataPtr(nstart),
         h_datnp1.dataPtr(nstart) + nelems,


### PR DESCRIPTION
## Summary

Fix netcdf boundary planes read with amrex.the_arena_is_managed=0. Working on greening the non-existent production dashboard ;) 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
