### PR TITLE
Pass correct half-time values for MAC vel bndry fills

### DIFF
--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -137,7 +137,7 @@ public:
     {
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::pre_advection_actions");
-        m_adv_op->preadvect(fstate, m_time.deltaT(), m_time.new_time());
+        m_adv_op->preadvect(fstate, m_time.deltaT(), m_time.current_time());
     }
 
     void compute_predictor_rhs(const DiffusionType difftype) override

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -305,7 +305,8 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         if (fvm::Godunov::nghost_state > 0) {
             amrex::Array<Field*, AMREX_SPACEDIM> mac_vel = {
                 AMREX_D_DECL(&u_mac, &v_mac, &w_mac)};
-            dof_field.fillpatch_sibling_fields(time + 0.5*dt, u_mac.num_grow(), mac_vel);
+            dof_field.fillpatch_sibling_fields(
+                time + 0.5*dt, u_mac.num_grow(), mac_vel);
         }
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -305,7 +305,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         if (fvm::Godunov::nghost_state > 0) {
             amrex::Array<Field*, AMREX_SPACEDIM> mac_vel = {
                 AMREX_D_DECL(&u_mac, &v_mac, &w_mac)};
-            dof_field.fillpatch_sibling_fields(time, u_mac.num_grow(), mac_vel);
+            dof_field.fillpatch_sibling_fields(time + 0.5*dt, u_mac.num_grow(), mac_vel);
         }
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -306,7 +306,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
             amrex::Array<Field*, AMREX_SPACEDIM> mac_vel = {
                 AMREX_D_DECL(&u_mac, &v_mac, &w_mac)};
             dof_field.fillpatch_sibling_fields(
-                time + 0.5*dt, u_mac.num_grow(), mac_vel);
+                time + 0.5 * dt, u_mac.num_grow(), mac_vel);
         }
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {

--- a/amr-wind/wind_energy/ABLFillInflow.cpp
+++ b/amr-wind/wind_energy/ABLFillInflow.cpp
@@ -94,7 +94,8 @@ void ABLFillInflow::fillpatch_sibling_fields(
     for (int i = 0; i < static_cast<int>(mfabs.size()); i++) {
         // use new_time to populate boundary data instead of half-time
         // to avoid interpolating from precursor data
-        m_bndry_plane.populate_data(lev, m_time.new_time(), m_field, *mfabs[i], 0, i);
+        m_bndry_plane.populate_data(
+            lev, m_time.new_time(), m_field, *mfabs[i], 0, i);
     }
 }
 

--- a/amr-wind/wind_energy/ABLFillInflow.cpp
+++ b/amr-wind/wind_energy/ABLFillInflow.cpp
@@ -92,7 +92,9 @@ void ABLFillInflow::fillpatch_sibling_fields(
         lev, time, mfabs, ffabs, cfabs, nghost, lbcrec, fstate);
 
     for (int i = 0; i < static_cast<int>(mfabs.size()); i++) {
-        m_bndry_plane.populate_data(lev, time, m_field, *mfabs[i], 0, i);
+        // use new_time to populate boundary data instead of half-time
+        // to avoid interpolating from precursor data
+        m_bndry_plane.populate_data(lev, m_time.new_time(), m_field, *mfabs[i], 0, i);
     }
 }
 


### PR DESCRIPTION
## Summary

Passes half-time values to the UDFs for filling the MAC velocity boundaries, which is the correct behavior. Before this change, the initial iterations passed zero and the advancing iterations passed the "new time" values instead of the half-time values.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

