### PR TITLE
Skip boxes that don't have actuators

### DIFF
--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -91,6 +91,13 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
     BL_PROFILE("amr-wind::ActSrcOp<" + fname + ">");
 
     const auto& bx = mfi.tilebox();
+
+    const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+    const auto& bxi = bx & bxa;
+    if (bxi.isEmpty()) {
+      return;
+    }
+    
     const auto& sarr = m_act_src(lev).array(mfi);
     const auto& problo = geom.ProbLoArray();
     const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -95,9 +95,9 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
     const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
     const auto& bxi = bx & bxa;
     if (bxi.isEmpty()) {
-      return;
+        return;
     }
-    
+
     const auto& sarr = m_act_src(lev).array(mfi);
     const auto& problo = geom.ProbLoArray();
     const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -92,7 +92,7 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
 
     const auto& bx = mfi.tilebox();
 
-    const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+    const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
     const auto& bxi = bx & bxa;
     if (bxi.isEmpty()) {
       return;

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -56,28 +56,19 @@ void Actuator::post_init_actions()
     BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions");
 
     amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
-    {
-        BL_PROFILE(
-            "amr-wind::actuator::Actuator::post_init_actions::determine_root_"
-            "proc");
-        for (auto& act : m_actuators) {
-            act->determine_root_proc(act_proc_count);
-        }
+    for (auto& act : m_actuators) {
+        act->determine_root_proc(act_proc_count);
     }
 
     {
-        BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::sanity");
         // Sanity check that we have processed the turbines correctly
         int nact =
             std::accumulate(act_proc_count.begin(), act_proc_count.end(), 0);
         AMREX_ALWAYS_ASSERT(num_actuators() == nact);
     }
 
-    {
-        BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::init_src");
-        for (auto& act : m_actuators) {
-            act->init_actuator_source();
-        }
+    for (auto& act : m_actuators) {
+        act->init_actuator_source();
     }
 
     // Ensure velocity fills ghost cells prior to sampling

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -55,20 +55,27 @@ void Actuator::post_init_actions()
 {
     BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions");
 
-    amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
+      amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
+    {
+      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::determine_root_proc");
     for (auto& act : m_actuators) {
         act->determine_root_proc(act_proc_count);
     }
+    }
 
     {
+      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::sanity");
         // Sanity check that we have processed the turbines correctly
         int nact =
             std::accumulate(act_proc_count.begin(), act_proc_count.end(), 0);
         AMREX_ALWAYS_ASSERT(num_actuators() == nact);
     }
 
+    {
+      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::init_src");
     for (auto& act : m_actuators) {
         act->init_actuator_source();
+    }
     }
 
     // Ensure velocity fills ghost cells prior to sampling

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -55,16 +55,18 @@ void Actuator::post_init_actions()
 {
     BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions");
 
-      amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
+    amrex::Vector<int> act_proc_count(amrex::ParallelDescriptor::NProcs(), 0);
     {
-      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::determine_root_proc");
-    for (auto& act : m_actuators) {
-        act->determine_root_proc(act_proc_count);
-    }
+        BL_PROFILE(
+            "amr-wind::actuator::Actuator::post_init_actions::determine_root_"
+            "proc");
+        for (auto& act : m_actuators) {
+            act->determine_root_proc(act_proc_count);
+        }
     }
 
     {
-      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::sanity");
+        BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::sanity");
         // Sanity check that we have processed the turbines correctly
         int nact =
             std::accumulate(act_proc_count.begin(), act_proc_count.end(), 0);
@@ -72,10 +74,10 @@ void Actuator::post_init_actions()
     }
 
     {
-      BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::init_src");
-    for (auto& act : m_actuators) {
-        act->init_actuator_source();
-    }
+        BL_PROFILE("amr-wind::actuator::Actuator::post_init_actions::init_src");
+        for (auto& act : m_actuators) {
+            act->init_actuator_source();
+        }
     }
 
     // Ensure velocity fills ghost cells prior to sampling

--- a/amr-wind/wind_energy/actuator/actuator_utils.H
+++ b/amr-wind/wind_energy/actuator/actuator_utils.H
@@ -13,6 +13,16 @@ struct ActInfo;
 
 namespace utils {
 
+  /** Convert a bounding box into amrex::Box index space at a given level
+ *
+ *  \param rbx Bounding box as defined in global domain coordinates
+ *  \param geom AMReX geometry information for a given level
+ *  \return The Box instance that defines the index space equivalent to bounding
+ * boxt
+ */
+amrex::Box
+realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom);
+
 /** Return a set of process IDs (MPI ranks) that contain AMR boxes that interact
  *  with a given actuator body.
  *

--- a/amr-wind/wind_energy/actuator/actuator_utils.H
+++ b/amr-wind/wind_energy/actuator/actuator_utils.H
@@ -13,7 +13,7 @@ struct ActInfo;
 
 namespace utils {
 
-  /** Convert a bounding box into amrex::Box index space at a given level
+/** Convert a bounding box into amrex::Box index space at a given level
  *
  *  \param rbx Bounding box as defined in global domain coordinates
  *  \param geom AMReX geometry information for a given level

--- a/amr-wind/wind_energy/actuator/actuator_utils.cpp
+++ b/amr-wind/wind_energy/actuator/actuator_utils.cpp
@@ -3,15 +3,6 @@
 
 namespace amr_wind::actuator::utils {
 
-namespace {
-
-/** Convert a bounding box into amrex::Box index space at a given level
- *
- *  \param rbx Bounding box as defined in global domain coordinates
- *  \param geom AMReX geometry information for a given level
- *  \return The Box instance that defines the index space equivalent to bounding
- * boxt
- */
 amrex::Box
 realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom)
 {
@@ -33,8 +24,6 @@ realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom)
 
     return amrex::Box{lo, hi};
 }
-
-} // namespace
 
 std::set<int> determine_influenced_procs(
     const amrex::AmrCore& mesh, const amrex::RealBox& rbx)

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -101,6 +101,13 @@ public:
         const amrex::Geometry& geom)
     {
         const auto& bx = mfi.tilebox();
+
+        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto& bxi = bx & bxa;
+        if (bxi.isEmpty()) {
+          return;
+        }
+        
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
         const auto& problo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -47,10 +47,11 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa =
+            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
-          return;
+            return;
         }
 
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
@@ -109,12 +110,13 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa =
+            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
-          return;
+            return;
         }
-        
+
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
         const auto& problo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();
@@ -173,12 +175,13 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa =
+            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
-          return;
+            return;
         }
-        
+
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
         const auto& problo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -46,6 +46,13 @@ public:
         const amrex::Geometry& geom)
     {
         const auto& bx = mfi.tilebox();
+
+        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto& bxi = bx & bxa;
+        if (bxi.isEmpty()) {
+          return;
+        }
+
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
         const auto& problo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();
@@ -165,6 +172,13 @@ public:
         const amrex::Geometry& geom)
     {
         const auto& bx = mfi.tilebox();
+
+        const auto bxa = utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto& bxi = bx & bxa;
+        if (bxi.isEmpty()) {
+          return;
+        }
+        
         const auto& sarr = actObj.m_act_src(lev).array(mfi);
         const auto& problo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();

--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
@@ -88,7 +88,7 @@ operator()(const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom)
     const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
     const auto& bxi = bx & bxa;
     if (bxi.isEmpty()) {
-      return;
+        return;
     }
 
     const auto& sarr = m_act_src(lev).array(mfi);

--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
@@ -84,6 +84,13 @@ operator()(const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom)
     BL_PROFILE("amr-wind::ActSrcOp<" + fname + ">");
 
     const auto& bx = mfi.tilebox();
+
+    const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
+    const auto& bxi = bx & bxa;
+    if (bxi.isEmpty()) {
+      return;
+    }
+
     const auto& sarr = m_act_src(lev).array(mfi);
     const auto& problo = geom.ProbLoArray();
     const auto& dx = geom.CellSizeArray();


### PR DESCRIPTION
## Summary

Skip boxes where the actuator won't have an influence by using the actuator's `bound_box`.

For a large case (thanks @hgopalan!) with O(3k) actuator disks: 

Original profile:
```
Time spent in InitData():    5595.328444
Time spent in Evolve():      4523.809873


TinyProfiler total time across processes [min...avg...max]: 1.012e+04 ... 1.012e+04 ... 1.012e+04

------------------------------------------------------------------------------------------------------------------
Name                                                               NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
------------------------------------------------------------------------------------------------------------------
amr-wind::ActSrcOp<UniformCtDisk>                                  328603      200.2      596.4       4695  46.39%
FillBoundary_finish()                                               49052      23.43       3851       4479  44.27%
amr-wind::actuator::Actuator::post_init_actions                         2       2678       3185       3902  38.56%
amr-wind::RefineCriteriaManager::initialize                             1      635.8        943       1372  13.56%
amr-wind::incflo::ReadCheckpointFile()                                  1    0.02672      345.9       1128  11.15%
FabArray::ParallelCopy_finish()                                      8814      12.83      192.3      708.8   7.00%
DistributionMapping::LeastUsedCPUs()                                   16    0.02703      557.4      643.2   6.36%
MLLinOp::makeSubCommunicator()                                         13     0.1679      84.76        108   1.07%
amr-wind::incflo::ErrorEst()                                            3      86.24      97.05      105.3   1.04%
FPinfo::FPinfo()                                                        9    0.04631      18.73      74.71   0.74%
MLNodeLaplacian::Fsmooth()                                           5160      41.84      45.45      46.89   0.46%
FillBoundary_nowait()                                               49052      16.56      19.55      25.42   0.25%
```

With this PR:
```
Time spent in InitData():    5369.242606
Time spent in Evolve():      165.6200254


TinyProfiler total time across processes [min...avg...max]: 5535 ... 5535 ... 5535

---------------------------------------------------------------------------------------------------------------------
Name                                                                  NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------------------------------
amr-wind::actuator::Actuator::pre_init_actions                             1       2664       3034       3979  71.88%
amr-wind::incflo::ReadCheckpointFile()                                     1    0.02621      313.5       1834  33.14%
DistributionMapping::LeastUsedCPUs()                                      16    0.01368       1084       1392  25.14%
amr-wind::RefineCriteriaManager::initialize                                1      663.1      873.9       1378  24.91%
FillBoundary_finish()                                                  52854       16.6      83.13      89.02   1.61%
amr-wind::ActSrcOp<UniformCtDisk>                                      54477     0.2865      2.766      65.97   1.19%
amr-wind::incflo::ErrorEst()                                               3      30.58      36.08       40.2   0.73%
MLNodeLaplacian::Fsmooth()                                              5128      14.54      16.97      17.85   0.32%
```

This is a *27X speedup* of the time evolution step. The source calculation `amr-wind::ActSrcOp<UniformCtDisk>` went from 46% of the runtime to 1% of the runtime, or a *220X speedup*. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): speedup code

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
