### PR TITLE
Add warning to user to consolidate turbine input.

### DIFF
--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -31,18 +31,29 @@ void Actuator::pre_init_actions()
 
     const int nturbines = static_cast<int>(labels.size());
 
-    if(nturbines > 50){
-      amrex::Print() << "WARNING: There are many turbines in this case. Please ensure you have consolidated common turbine options under a common prefix. For example, the following: " << std::endl;
-      amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk" << std::endl;
-      amrex::Print() << "  Actuator.Turb1.epsilon         = 5.0 5.0 5.0" << std::endl;
-      amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk" << std::endl;
-      amrex::Print() << "  Actuator.Turb2.epsilon         = 5.0 5.0 5.0" << std::endl;
-      amrex::Print() << "becomes: " << std::endl;
-      amrex::Print() << "  Actuator.UniformCtDisk.epsilon = 5.0 5.0 5.0" << std::endl;
-      amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk" << std::endl;
-      amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk" << std::endl;
+    if (nturbines > 50) {
+        amrex::Print()
+            << "WARNING: There are many turbines in this case. Please ensure "
+               "you have consolidated common turbine options under a common "
+               "prefix. For example, the following: "
+            << std::endl;
+        amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk"
+                       << std::endl;
+        amrex::Print() << "  Actuator.Turb1.epsilon         = 5.0 5.0 5.0"
+                       << std::endl;
+        amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk"
+                       << std::endl;
+        amrex::Print() << "  Actuator.Turb2.epsilon         = 5.0 5.0 5.0"
+                       << std::endl;
+        amrex::Print() << "becomes: " << std::endl;
+        amrex::Print() << "  Actuator.UniformCtDisk.epsilon = 5.0 5.0 5.0"
+                       << std::endl;
+        amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk"
+                       << std::endl;
+        amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk"
+                       << std::endl;
     }
-    
+
     for (int i = 0; i < nturbines; ++i) {
         const std::string& tname = labels[i];
         const std::string& prefix = identifier() + "." + tname;

--- a/amr-wind/wind_energy/actuator/Actuator.cpp
+++ b/amr-wind/wind_energy/actuator/Actuator.cpp
@@ -31,6 +31,18 @@ void Actuator::pre_init_actions()
 
     const int nturbines = static_cast<int>(labels.size());
 
+    if(nturbines > 50){
+      amrex::Print() << "WARNING: There are many turbines in this case. Please ensure you have consolidated common turbine options under a common prefix. For example, the following: " << std::endl;
+      amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk" << std::endl;
+      amrex::Print() << "  Actuator.Turb1.epsilon         = 5.0 5.0 5.0" << std::endl;
+      amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk" << std::endl;
+      amrex::Print() << "  Actuator.Turb2.epsilon         = 5.0 5.0 5.0" << std::endl;
+      amrex::Print() << "becomes: " << std::endl;
+      amrex::Print() << "  Actuator.UniformCtDisk.epsilon = 5.0 5.0 5.0" << std::endl;
+      amrex::Print() << "  Actuator.Turb1.type            = UniformCtDisk" << std::endl;
+      amrex::Print() << "  Actuator.Turb2.type            = UniformCtDisk" << std::endl;
+    }
+    
     for (int i = 0; i < nturbines; ++i) {
         const std::string& tname = labels[i];
         const std::string& prefix = identifier() + "." + tname;

--- a/docs/sphinx/user/inputs_Actuator.rst
+++ b/docs/sphinx/user/inputs_Actuator.rst
@@ -29,6 +29,20 @@ turbines as actuator disks and actuator line models.
    supported are: ``TurbineFastLine``, ``TurbineFastDisk``, and 
    ``FixedWingLine``.
 
+It is recommended to group common parameters across actuators using the ``Actuator.[type].[param]``. For example::
+
+   Actuator.Turb1.type            = UniformCtDisk"
+   Actuator.Turb1.epsilon         = 5.0 5.0 5.0"
+   Actuator.Turb2.type            = UniformCtDisk"
+   Actuator.Turb2.epsilon         = 5.0 5.0 5.0"
+
+becomes::
+
+   Actuator.UniformCtDisk.epsilon = 5.0 5.0 5.0"
+   Actuator.Turb1.type            = UniformCtDisk"
+   Actuator.Turb2.type            = UniformCtDisk"
+
+
 FixedWingLine
 """""""""""""
 


### PR DESCRIPTION
## Summary

`amrex::parmparse::contains` can be slow if the input file is large. If we have many turbines in the input file, each with common inputs, the input file balloons to several MB. This PR adds a warning to the user to make sure they have consolidated the common options for the turbines. This is the warning:

```
WARNING: Make sure common turbine options are consolidated under a common prefix.
For example, the following:
  Actuator.Turb1.type            = UniformCtDisk
  Actuator.Turb1.epsilon         = 5.0 5.0 5.0
  Actuator.Turb2.type            = UniformCtDisk
  Actuator.Turb2.epsilon         = 5.0 5.0 5.0
becomes:
  Actuator.UniformCtDisk.epsilon = 5.0 5.0 5.0
  Actuator.Turb1.type            = UniformCtDisk
  Actuator.Turb2.type            = UniformCtDisk
```

As an example, I was given an input file with O(3k) actuator disks. This input file was O(10) MB. By consolidating the input file, I reduced it to O(400) KB. The profiling went from:
```
Time spent in InitData():    520.3938055
Time spent in Evolve():      8.677764836


TinyProfiler total time across processes [min...avg...max]: 529.1 ... 529.1 ... 529.1

-----------------------------------------------------------------------------------------------------------------
Name                                                              NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-----------------------------------------------------------------------------------------------------------------
amrex::ParmParse::contains                                         52962      287.4      291.4      324.3  61.29%
amr_wind::utils::MultiParser::query_val                             4995      41.64      43.28      44.79   8.46%
DistributionMapping::LeastUsedCPUs()                                   1   0.002837       31.4      39.59   7.48%
amr_wind::utils::MultiParser::query_arr_val                         3996      29.69      30.82      31.67   5.99%
amrex::ParmParse::get_double                                        4006      22.39         23      23.64   4.47%
amr_wind::utils::MultiParser::getarr_val                            3996      22.32      22.95      23.52   4.45%
FillBoundary_finish()                                              10784       6.97      8.949      10.78   2.04%
```

to this:
```
Time spent in InitData():    90.01327278
Time spent in Evolve():      8.92871262


TinyProfiler total time across processes [min...avg...max]: 98.99 ... 99.07 ... 99.08

-----------------------------------------------------------------------------------------------------------------
Name                                                              NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-----------------------------------------------------------------------------------------------------------------
amrex::ParmParse::contains                                         55959      24.17      25.09      25.95  26.19%
FillBoundary_finish()                                              10784      6.368      9.304      10.91  11.01%
amr-wind::godunov::compute_fluxes                                    649      6.274      7.575      8.172   8.25%
MLNodeLaplacian::Fsmooth()                                           600       6.64      7.005      7.603   7.67%
FillBoundary_nowait()                                              10784      4.931      5.634       6.28   6.34%
amrex::Copy()                                                       6278      5.439      5.605      6.014   6.07%
MLPoisson::Fsmooth()                                                1824      3.324      3.952      4.901   4.95%
MLABecLaplacian::Fsmooth()                                           216      3.174      3.559      4.345   4.39%
FabArray::setVal()                                                  1110      3.748      3.853       3.95   3.99%
```

which is a 6x speedup in the inits. Hopefully this warning will guide users away from this anti-pattern. I hope this actually works. I don't want to implement a "search" for common options since this can get quite expensive I think.

@WeiqunZhang is aware of this and is thinking about implementing a speedier version of `contains`. But this is core to AMReX and the implementation needs to be carefully vetted/tested so it will take some time.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): warning to user
