### PR TITLE
fixes bug in WENO calculations at the xhi domain boundary

### DIFF
--- a/amr-wind/convection/incflo_godunov_weno.H
+++ b/amr-wind/convection/incflo_godunov_weno.H
@@ -94,10 +94,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void Godunov_weno_xbc(
 
         } else if (i == domhi - 1) {
 
-            sm = -0.2 * s(domhi + 1, j, k, n) + 0.75 * s(domhi, j, k, n) +
+            sp = -0.2 * s(domhi + 1, j, k, n) + 0.75 * s(domhi, j, k, n) +
                  0.5 * s(domhi - 1, j, k, n) - 0.05 * s(domhi - 2, j, k, n);
 
-            sp = sedge1;
+            sm = sedge1;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1126 where unexpected asymmetries were observed.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional information

All regression tests are passing, not including the two that require netcdf. One unit test fails but it seems like a machine precision difference if I'm reading the logs correctly. 

Perhaps this bug was not noticed earlier because it may be uncommon to have `ext_dir` BC type at the xhi boundary?
