### PR TITLE
Speedup geometry refinement tagging

### DIFF
--- a/amr-wind/core/vs/vector.H
+++ b/amr-wind/core/vs/vector.H
@@ -85,6 +85,9 @@ struct VectorT
     //! Normalize the vector to unit vector
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>& normalize();
 
+    //! Sqrt of each component
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> sqrt(const VectorT&);
+
     //! Return the unit vector parallel to this vector
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> unit() const
     {

--- a/amr-wind/core/vs/vectorI.H
+++ b/amr-wind/core/vs/vectorI.H
@@ -134,6 +134,13 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T>& VectorT<T>::normalize()
     }
     return *this;
 }
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE VectorT<T> sqrt(const VectorT<T>& v)
+{
+    return VectorT<T>{std::sqrt(v.x()), std::sqrt(v.y()), std::sqrt(v.z())};
+}
+
 } // namespace amr_wind::vs
 
 #endif /* VS_VECTORI_H */

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -105,7 +105,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
@@ -157,7 +157,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -92,7 +92,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
@@ -144,7 +144,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 

--- a/amr-wind/utilities/CMakeLists.txt
+++ b/amr-wind/utilities/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${amr_wind_lib_name}
       io.cpp
       bc_ops.cpp
       console_io.cpp
+      index_operations.cpp
       IOManager.cpp
       FieldPlaneAveraging.cpp
       FieldPlaneAveragingFine.cpp

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -1,7 +1,12 @@
 #ifndef INDEX_OPERATIONS_H
 #define INDEX_OPERATIONS_H
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include <AMReX_Box.H>
+#include <AMReX_RealBox.H>
+#include <AMReX_Geometry.H>
 
-namespace amr_wind {
+namespace amr_wind::utils {
 
 //! Return closest index (from lower) of value in vector
 AMREX_FORCE_INLINE int
@@ -31,6 +36,16 @@ AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
     return T{-1, -1};
 }
 
-} /* namespace amr_wind */
+/** Convert a bounding box into amrex::Box index space at a given level
+ *
+ *  \param rbx Bounding box as defined in global domain coordinates
+ *  \param geom AMReX geometry information for a given level
+ *  \return The Box instance that defines the index space equivalent to bounding
+ * boxt
+ */
+amrex::Box
+realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom);
+
+} // namespace amr_wind::utils
 
 #endif /* INDEX_OPERATIONS_H */

--- a/amr-wind/utilities/index_operations.cpp
+++ b/amr-wind/utilities/index_operations.cpp
@@ -1,0 +1,26 @@
+#include "amr-wind/utilities/index_operations.H"
+
+namespace amr_wind::utils {
+amrex::Box
+realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom)
+{
+    const auto* problo = geom.ProbLo();
+    const auto* probhi = geom.ProbHi();
+    const auto* dxi = geom.InvCellSize();
+
+    amrex::IntVect lo, hi;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        amrex::Real bbox_min = amrex::max(rbx.lo()[i], problo[i]);
+        amrex::Real bbox_max = amrex::min(rbx.hi()[i], probhi[i]);
+
+        amrex::Real rlo = std::floor((bbox_min - problo[i]) * dxi[i]);
+        amrex::Real rhi = std::ceil((bbox_max - problo[i]) * dxi[i]);
+
+        lo[i] = static_cast<int>(rlo);
+        hi[i] = static_cast<int>(rhi);
+    }
+
+    return amrex::Box{lo, hi};
+}
+
+} // namespace amr_wind::utils

--- a/amr-wind/utilities/tagging/BoxRefiner.H
+++ b/amr-wind/utilities/tagging/BoxRefiner.H
@@ -30,7 +30,7 @@ public:
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
 
-    amrex::RealBox bound_box() const override { return m_bound_box; };
+    const amrex::RealBox& bound_box() const override { return m_bound_box; };
 
 protected:
     amrex::Gpu::DeviceVector<vs::Vector> m_hex_corners;

--- a/amr-wind/utilities/tagging/BoxRefiner.H
+++ b/amr-wind/utilities/tagging/BoxRefiner.H
@@ -30,10 +30,13 @@ public:
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
 
+    amrex::RealBox bound_box() const override { return m_bound_box; };
+
 protected:
     amrex::Gpu::DeviceVector<vs::Vector> m_hex_corners;
     amrex::Gpu::DeviceVector<vs::Vector> m_face_normals;
     amrex::Gpu::DeviceVector<int> m_face_origin;
+    amrex::RealBox m_bound_box;
 };
 
 } // namespace amr_wind::tagging

--- a/amr-wind/utilities/tagging/CylinderRefiner.H
+++ b/amr-wind/utilities/tagging/CylinderRefiner.H
@@ -27,7 +27,7 @@ public:
         const amrex::Box& /*bx*/,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
-    amrex::RealBox bound_box() const override { return m_bound_box; };
+    const amrex::RealBox& bound_box() const override { return m_bound_box; };
 
 private:
     vs::Vector m_start;

--- a/amr-wind/utilities/tagging/CylinderRefiner.H
+++ b/amr-wind/utilities/tagging/CylinderRefiner.H
@@ -27,6 +27,7 @@ public:
         const amrex::Box& /*bx*/,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const override;
+    amrex::RealBox bound_box() const override { return m_bound_box; };
 
 private:
     vs::Vector m_start;
@@ -34,6 +35,8 @@ private:
 
     amrex::Real m_outer_radius;
     amrex::Real m_inner_radius{0.0};
+
+    amrex::RealBox m_bound_box;
 };
 
 } // namespace amr_wind::tagging

--- a/amr-wind/utilities/tagging/CylinderRefiner.cpp
+++ b/amr-wind/utilities/tagging/CylinderRefiner.cpp
@@ -30,6 +30,19 @@ CylinderRefiner::CylinderRefiner(
     pp.get("outer_radius", m_outer_radius);
     // Optional inner radius to restrict tagging to an annulus of the cylinder
     pp.query("inner_radius", m_inner_radius);
+
+    // Define the bounding box around the cylinder
+    const auto axis = m_end - m_start;
+    const auto proj =
+        m_outer_radius * sqrt(vs::Vector::one() - axis * axis / mag_sqr(axis));
+    const auto sm = m_start - proj;
+    const auto em = m_end - proj;
+    const auto sp = m_start + proj;
+    const auto ep = m_end + proj;
+    m_bound_box = amrex::RealBox(
+        amrex::min(sm[0], em[0]), amrex::min(sm[1], em[1]),
+        amrex::min(sm[2], em[2]), amrex::max(sp[0], ep[0]),
+        amrex::max(sp[1], ep[1]), amrex::max(sp[2], ep[2]));
 }
 
 void CylinderRefiner::operator()(

--- a/amr-wind/utilities/tagging/CylinderRefiner.cpp
+++ b/amr-wind/utilities/tagging/CylinderRefiner.cpp
@@ -35,10 +35,12 @@ CylinderRefiner::CylinderRefiner(
     const auto axis = m_end - m_start;
     const auto proj =
         m_outer_radius * sqrt(vs::Vector::one() - axis * axis / mag_sqr(axis));
-    const auto sm = m_start - proj;
-    const auto em = m_end - proj;
-    const auto sp = m_start + proj;
-    const auto ep = m_end + proj;
+    const amrex::Real search_fraction = 0.05;
+    const auto search_radius = (1.0 + search_fraction) * proj;
+    const auto sm = m_start - search_radius;
+    const auto em = m_end - search_radius;
+    const auto sp = m_start + search_radius;
+    const auto ep = m_end + search_radius;
     m_bound_box = amrex::RealBox(
         amrex::min(sm[0], em[0]), amrex::min(sm[1], em[1]),
         amrex::min(sm[2], em[2]), amrex::max(sp[0], ep[0]),

--- a/amr-wind/utilities/tagging/GeometryRefinement.H
+++ b/amr-wind/utilities/tagging/GeometryRefinement.H
@@ -1,6 +1,7 @@
 #ifndef GEOMETRYREFINEMENT_H
 #define GEOMETRYREFINEMENT_H
 
+#include "amr-wind/utilities/index_operations.H"
 #include "amr-wind/utilities/tagging/RefinementCriteria.H"
 
 namespace amr_wind {
@@ -23,6 +24,8 @@ public:
         const amrex::Box&,
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const = 0;
+
+    virtual amrex::RealBox bound_box() const = 0;
 };
 
 } // namespace tagging

--- a/amr-wind/utilities/tagging/GeometryRefinement.H
+++ b/amr-wind/utilities/tagging/GeometryRefinement.H
@@ -25,7 +25,7 @@ public:
         const amrex::Geometry& geom,
         const amrex::Array4<amrex::TagBox::TagType>& tags) const = 0;
 
-    virtual amrex::RealBox bound_box() const = 0;
+    virtual const amrex::RealBox& bound_box() const = 0;
 };
 
 } // namespace tagging

--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -59,10 +59,10 @@ void GeometryRefinement::operator()(
         const auto& tag = tags.array(mfi);
 
         for (const auto& gg : m_geom_refiners) {
-            const auto bxa = utils::realbox_to_box(gg->bound_box(), geom);
+            const auto& bxa = utils::realbox_to_box(gg->bound_box(), geom);
             const auto& bxi = bx & bxa;
             if (bxi.isEmpty()) {
-                return;
+                continue;
             }
 
             (*gg)(bx, geom, tag);

--- a/amr-wind/utilities/tagging/GeometryRefinement.cpp
+++ b/amr-wind/utilities/tagging/GeometryRefinement.cpp
@@ -59,6 +59,12 @@ void GeometryRefinement::operator()(
         const auto& tag = tags.array(mfi);
 
         for (const auto& gg : m_geom_refiners) {
+            const auto bxa = utils::realbox_to_box(gg->bound_box(), geom);
+            const auto& bxi = bx & bxa;
+            if (bxi.isEmpty()) {
+                return;
+            }
+
             (*gg)(bx, geom, tag);
         }
     }

--- a/amr-wind/utilities/tagging/RefinementCriteria.cpp
+++ b/amr-wind/utilities/tagging/RefinementCriteria.cpp
@@ -32,6 +32,7 @@ void RefineCriteriaManager::initialize()
 void RefineCriteriaManager::tag_cells(
     int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
 {
+    BL_PROFILE("amr-wind::RefineCriteriaManager::tag_cells");
     for (const auto& rc : m_refiners) {
         (*rc)(lev, tags, time, ngrow);
     }

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -77,14 +77,14 @@ void InletData::read_data(
     const size_t nc = fld->num_comp();
     const int nstart = m_components[static_cast<int>(fld->id())];
 
-    const int idx = closest_index(times, time);
+    const int idx = utils::closest_index(times, time);
     const int idxp1 = idx + 1;
     m_tn = times[idx];
     m_tnp1 = times[idxp1];
     AMREX_ALWAYS_ASSERT(((m_tn <= time) && (time <= m_tnp1)));
 
     const int normal = ori.coordDir();
-    const amrex::GpuArray<int, 2> perp = perpendicular_idx(normal);
+    const amrex::GpuArray<int, 2> perp = utils::perpendicular_idx(normal);
 
     const auto& bx = (*m_data_n[ori])[lev].box();
     const auto& lo = bx.loVect();
@@ -150,7 +150,7 @@ void InletData::read_data_native(
     const int nstart =
         static_cast<int>(m_components[static_cast<int>(fld->id())]);
 
-    const int idx = closest_index(times, time);
+    const int idx = utils::closest_index(times, time);
     const int idxp1 = idx + 1;
 
     m_tn = times[idx];
@@ -381,7 +381,8 @@ void ABLBoundaryPlane::write_header()
             auto v_face = plane_grp.def_scalar("side", NC_INT);
             v_face.put(&face_dir);
 
-            const auto perp = perpendicular_idx<amrex::Vector<int>>(normal);
+            const auto perp =
+                utils::perpendicular_idx<amrex::Vector<int>>(normal);
             auto v_perp = plane_grp.def_var("perpendicular", NC_INT, {"pdim"});
             v_perp.put(perp.data());
 
@@ -427,7 +428,8 @@ void ABLBoundaryPlane::write_header()
         for (auto& plane_grp : ncf.all_groups()) {
             int normal;
             plane_grp.var("normal").get(&normal);
-            const amrex::GpuArray<int, 2> perp = perpendicular_idx(normal);
+            const amrex::GpuArray<int, 2> perp =
+                utils::perpendicular_idx(normal);
 
             const int nlevels = plane_grp.num_groups();
             for (int lev = 0; lev < nlevels; ++lev) {
@@ -615,7 +617,8 @@ void ABLBoundaryPlane::read_header()
             int normal, face_dir;
             plane_grp.var("normal").get(&normal);
             plane_grp.var("side").get(&face_dir);
-            const amrex::GpuArray<int, 2> perp = perpendicular_idx(normal);
+            const amrex::GpuArray<int, 2> perp =
+                utils::perpendicular_idx(normal);
             const amrex::Orientation ori(
                 normal, amrex::Orientation::Side(face_dir));
 
@@ -794,7 +797,7 @@ void ABLBoundaryPlane::read_file()
 
     if (m_out_fmt == "native") {
 
-        const int index = closest_index(m_in_times, time);
+        const int index = utils::closest_index(m_in_times, time);
         const int t_step1 = m_in_timesteps[index];
         const int t_step2 = m_in_timesteps[index + 1];
 
@@ -950,7 +953,7 @@ void ABLBoundaryPlane::write_data(
     BL_PROFILE("amr-wind::ABLBoundaryPlane::write_data");
     // Plane info
     const int normal = ori.coordDir();
-    const amrex::GpuArray<int, 2> perp = perpendicular_idx(normal);
+    const amrex::GpuArray<int, 2> perp = utils::perpendicular_idx(normal);
     const amrex::IntVect v_offset = offset(ori.faceDir(), normal);
 
     // Field info

--- a/amr-wind/wind_energy/actuator/ActSrcLineOp.H
+++ b/amr-wind/wind_energy/actuator/ActSrcLineOp.H
@@ -92,7 +92,8 @@ void ActSrcOp<ActTrait, ActSrcLine>::operator()(
 
     const auto& bx = mfi.tilebox();
 
-    const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
+    const auto bxa =
+        amr_wind::utils::realbox_to_box(m_data.info().bound_box, geom);
     const auto& bxi = bx & bxa;
     if (bxi.isEmpty()) {
         return;

--- a/amr-wind/wind_energy/actuator/actuator_utils.H
+++ b/amr-wind/wind_energy/actuator/actuator_utils.H
@@ -3,6 +3,7 @@
 
 #include "amr-wind/core/vs/vector_space.H"
 #include "AMReX_AmrCore.H"
+#include "amr-wind/utilities/index_operations.H"
 #include <cmath>
 
 #include <set>
@@ -12,16 +13,6 @@ namespace amr_wind::actuator {
 struct ActInfo;
 
 namespace utils {
-
-/** Convert a bounding box into amrex::Box index space at a given level
- *
- *  \param rbx Bounding box as defined in global domain coordinates
- *  \param geom AMReX geometry information for a given level
- *  \return The Box instance that defines the index space equivalent to bounding
- * boxt
- */
-amrex::Box
-realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom);
 
 /** Return a set of process IDs (MPI ranks) that contain AMR boxes that interact
  *  with a given actuator body.

--- a/amr-wind/wind_energy/actuator/actuator_utils.cpp
+++ b/amr-wind/wind_energy/actuator/actuator_utils.cpp
@@ -3,35 +3,13 @@
 
 namespace amr_wind::actuator::utils {
 
-amrex::Box
-realbox_to_box(const amrex::RealBox& rbx, const amrex::Geometry& geom)
-{
-    const auto* problo = geom.ProbLo();
-    const auto* probhi = geom.ProbHi();
-    const auto* dxi = geom.InvCellSize();
-
-    amrex::IntVect lo, hi;
-    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-        amrex::Real bbox_min = amrex::max(rbx.lo()[i], problo[i]);
-        amrex::Real bbox_max = amrex::min(rbx.hi()[i], probhi[i]);
-
-        amrex::Real rlo = std::floor((bbox_min - problo[i]) * dxi[i]);
-        amrex::Real rhi = std::ceil((bbox_max - problo[i]) * dxi[i]);
-
-        lo[i] = static_cast<int>(rlo);
-        hi[i] = static_cast<int>(rhi);
-    }
-
-    return amrex::Box{lo, hi};
-}
-
 std::set<int> determine_influenced_procs(
     const amrex::AmrCore& mesh, const amrex::RealBox& rbx)
 {
     std::set<int> procs;
     const int finest_level = mesh.finestLevel();
     const int nlevels = mesh.finestLevel() + 1;
-    auto bx = realbox_to_box(rbx, mesh.Geom(0));
+    auto bx = amr_wind::utils::realbox_to_box(rbx, mesh.Geom(0));
 
     for (int lev = 0; lev < nlevels; ++lev) {
         const auto& ba = mesh.boxArray(lev);

--- a/amr-wind/wind_energy/actuator/disk/disk_spreading.H
+++ b/amr-wind/wind_energy/actuator/disk/disk_spreading.H
@@ -47,8 +47,8 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa =
-            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa = amr_wind::utils::realbox_to_box(
+            actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
             return;
@@ -110,8 +110,8 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa =
-            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa = amr_wind::utils::realbox_to_box(
+            actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
             return;
@@ -175,8 +175,8 @@ public:
     {
         const auto& bx = mfi.tilebox();
 
-        const auto bxa =
-            utils::realbox_to_box(actObj.m_data.info().bound_box, geom);
+        const auto bxa = amr_wind::utils::realbox_to_box(
+            actObj.m_data.info().bound_box, geom);
         const auto& bxi = bx & bxa;
         if (bxi.isEmpty()) {
             return;

--- a/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
+++ b/amr-wind/wind_energy/actuator/turbine/ActSrcDiskOp_Turbine.H
@@ -85,7 +85,8 @@ operator()(const int lev, const amrex::MFIter& mfi, const amrex::Geometry& geom)
 
     const auto& bx = mfi.tilebox();
 
-    const auto bxa = utils::realbox_to_box(m_data.info().bound_box, geom);
+    const auto bxa =
+        amr_wind::utils::realbox_to_box(m_data.info().bound_box, geom);
     const auto& bxi = bx & bxa;
     if (bxi.isEmpty()) {
         return;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -245,6 +245,8 @@ add_test_re(burggraf_flow)
 add_test_re(abl_godunov_rayleigh_damping)
 add_test_re(rankine)
 add_test_re(rankine-sym)
+add_test_re(box_refinement)
+add_test_re(cylinder_refinement)
 
 if(NOT AMR_WIND_ENABLE_CUDA)
   add_test_re(ctv_godunov_plm)

--- a/test/test_files/box_refinement/box_refinement.inp
+++ b/test/test_files/box_refinement/box_refinement.inp
@@ -1,0 +1,102 @@
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            SIMULATION STOP            #
+#.......................................#
+time.stop_time               =   22000.0     # Max (simulated) time to evolve
+time.max_step                =   10          # Max number of time steps
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#         TIME STEP COMPUTATION         #
+#.......................................#
+time.fixed_dt         =   0.5        # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#            INPUT AND OUTPUT           #
+#.......................................#
+time.plot_interval            =  10       # Steps between plot files
+time.checkpoint_interval      =  5       # Steps between checkpoint files
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#               PHYSICS                 #
+#.......................................#
+incflo.gravity          =   0.  0. -9.81  # Gravitational force (3D)
+incflo.density             = 1.0          # Reference density 
+
+incflo.use_godunov = 1
+incflo.diffusion_type = 2
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model = Smagorinsky
+Smagorinsky_coeffs.Cs = 0.135
+
+
+incflo.physics = ABL
+ICNS.source_terms = BoussinesqBuoyancy CoriolisForcing ABLForcing
+BoussinesqBuoyancy.reference_temperature = 300.0
+ABL.reference_temperature = 300.0
+CoriolisForcing.latitude = 41.3
+ABLForcing.abl_forcing_height = 90
+
+incflo.velocity = 6.128355544951824  5.142300877492314 0.0
+
+ABL.temperature_heights = 650.0 750.0 1000.0
+ABL.temperature_values = 300.0 308.0 308.75
+
+ABL.kappa = .41
+ABL.surface_roughness_z0 = 0.15
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#        ADAPTIVE MESH REFINEMENT       #
+#.......................................#
+amr.n_cell              = 24 24 24    # Grid cells at coarsest AMRlevel
+amr.max_level           = 1           # Max AMR level in hierarchy 
+amr.max_grid_size = 16
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              TAGGING                  #
+#.......................................#
+tagging.labels = g0 g1
+tagging.g0.type                          = GeometryRefinement
+tagging.g0.shapes                        = b0 b1
+tagging.g0.level                         = 0
+tagging.g0.b0.type                       = box
+tagging.g0.b0.origin = 200 200 200
+tagging.g0.b0.xaxis =  100 0 0
+tagging.g0.b0.yaxis =  0 100 0
+tagging.g0.b0.zaxis = 0 0 100
+
+tagging.g0.b1.type                       = box
+tagging.g0.b1.origin = 800 200 200
+tagging.g0.b1.xaxis =  50 0 0
+tagging.g0.b1.yaxis =  0 50 0
+tagging.g0.b1.zaxis = 0 0 50
+
+tagging.g1.type                         = GeometryRefinement
+tagging.g1.shapes                       = b2
+tagging.g1.min_level                    = 0
+tagging.g1.max_level                    = 1
+tagging.g1.b2.type                     = box
+tagging.g1.b2.origin = 600 600 600
+tagging.g1.b2.xaxis =  50 0 0
+tagging.g1.b2.yaxis =  0 50 0
+tagging.g1.b2.zaxis = 0 0 50
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              GEOMETRY                 #
+#.......................................#
+geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
+geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
+geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
+
+# Boundary conditions
+zlo.type =   "wall_model"
+
+zhi.type =   "slip_wall"
+zhi.temperature_type = "fixed_gradient"
+zhi.temperature = 0.003 # tracer is used to specify potential temperature gradient
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#              VERBOSITY                #
+#.......................................#
+incflo.verbose          =   0          # incflo_level

--- a/test/test_files/cylinder_refinement/cylinder_refinement.inp
+++ b/test/test_files/cylinder_refinement/cylinder_refinement.inp
@@ -45,6 +45,7 @@ ICNS.source_terms = ActuatorForcing
 
 amr.n_cell              = 64 64 64   # Grid cells at coarsest AMRlevel
 amr.max_level           = 1           # Max AMR level in hierarchy
+amr.max_grid_size = 8
 geometry.prob_lo        =   -315.0 -315.0 -315.0
 geometry.prob_hi        =   315.0  315.0  315.0
 

--- a/test/test_files/cylinder_refinement/cylinder_refinement.inp
+++ b/test/test_files/cylinder_refinement/cylinder_refinement.inp
@@ -1,0 +1,91 @@
+time.stop_time               =   -100.0     # Max (simulated) time to evolve
+time.max_step                =   10         # Max number of time steps
+
+time.fixed_dt         =   0.1      # Use this constant dt if > 0
+time.cfl              =   0.95         # CFL factor
+
+io.KE_int = 0
+io.outputs = actuator_src_term
+time.plot_interval            =  10       # Steps between plot files
+time.checkpoint_interval      =  -1       # Steps between checkpoint files
+
+ConstValue.density.value = 1.0
+ConstValue.velocity.value = 8.0 0.0 0.0
+
+incflo.use_godunov = 1
+incflo.godunov_type = "ppm_nolim"
+incflo.diffusion_type = 2
+incflo.do_initial_proj = 1
+incflo.initial_iterations = 3
+transport.viscosity = 1.0e-5
+transport.laminar_prandtl = 0.7
+transport.turbulent_prandtl = 0.3333
+turbulence.model               = Smagorinsky
+Smagorinsky_coeffs.Cs          = 0.16
+
+incflo.physics = FreeStream Actuator
+Actuator.labels = WTG01
+Actuator.type = UniformCtDisk
+Actuator.UniformCtDisk.spreading = UniformGaussian
+
+Actuator.UniformCtDisk.rotor_diameter = 126.0
+Actuator.UniformCtDisk.base_position = 0.0 0.0 0.0
+Actuator.UniformCtDisk.hub_height = 0.0
+Actuator.UniformCtDisk.yaw = 315.0 # degrees (yaw is relative to north which defaults to {0,1,0})
+Actuator.UniformCtDisk.sample_yaw = 270.0 # set velocity sampling to be in the normal flow direction
+Actuator.UniformCtDisk.thrust_coeff = 0.0 0.7 1.2
+Actuator.UniformCtDisk.wind_speed = 0.0 10.0 12.0
+Actuator.UniformCtDisk.epsilon = 10.0
+Actuator.UniformCtDisk.density = 1.225
+Actuator.UniformCtDisk.diameters_to_sample = 1.0
+Actuator.UniformCtDisk.num_points_r = 5
+Actuator.UniformCtDisk.num_points_t = 20
+
+ICNS.source_terms = ActuatorForcing
+
+amr.n_cell              = 64 64 64   # Grid cells at coarsest AMRlevel
+amr.max_level           = 1           # Max AMR level in hierarchy
+geometry.prob_lo        =   -315.0 -315.0 -315.0
+geometry.prob_hi        =   315.0  315.0  315.0
+
+geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
+
+#¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
+#        Mesh refinement                #
+#.......................................#
+tagging.labels = refine0
+tagging.refine0.type = GeometryRefinement
+tagging.refine0.shapes = c0 c1 c2
+
+tagging.refine0.c0.type = cylinder
+tagging.refine0.c0.start = -200.0 0 0
+tagging.refine0.c0.end = -150.0 0 0
+tagging.refine0.c0.outer_radius = 50.0 
+
+tagging.refine0.c1.type = cylinder
+tagging.refine0.c1.start = 200.0 0 0
+tagging.refine0.c1.end = 250.0 0 0
+tagging.refine0.c1.outer_radius = 10.0
+
+tagging.refine0.c2.type = cylinder
+tagging.refine0.c2.start = -50.0 -200 -50
+tagging.refine0.c2.end = 50.0 200 50
+tagging.refine0.c2.outer_radius = 10.0
+
+# Boundary conditions
+xlo.type = "mass_inflow"
+xlo.density = 1.0
+xlo.velocity = 8.0 0.0 0.0
+xhi.type = "pressure_outflow"
+ylo.type =   "slip_wall"
+yhi.type =   "slip_wall"
+zlo.type =   "slip_wall"
+zhi.type =   "slip_wall"
+
+incflo.verbose          =   0          # incflo_level
+nodal_proj.verbose = 0
+
+nodal_proj.mg_rtol = 1.0e-6
+nodal_proj.mg_atol = 1.0e-12
+mac_proj.mg_rtol = 1.0e-6
+mac_proj.mg_atol = 1.0e-12


### PR DESCRIPTION
## Summary

This PR speeds up the geometry refinement tagging by computing bounding boxes for the refinements and only computing the tagging within those bounding boxes.

Ran a case with 1643 `GeometryRefinement` boxes. Before this PR:
```
amr-wind::RefineCriteriaManager::tag_cells                             2      32.94      33.53      33.95  16.95%
```

With this PR:
```
amr-wind::RefineCriteriaManager::tag_cells                             2   0.004658    0.03249      1.011   0.60%
```

For those counting, that's a 1000X speedup in the tagging functionality for geometry refinement.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): performance improvement

## Checklist

The following is included:

- [ ] new unit-test(s)
- [x] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
