### PR TITLE
Make Waves2AMR routines deterministic by default

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -215,6 +215,10 @@ struct ReadInputsOp<W2AWaves>
             pp.query("HOS_init_time", wdata.t_winit);
         }
 
+        // Default fftw_plan is deterministic
+        std::string fftw_planner_flag{"estimate"};
+        pp.query("fftw_planner_flag", fftw_planner_flag);
+
         amrex::Vector<amrex::Real> prob_lo_input(AMREX_SPACEDIM);
         amrex::ParmParse pp_geom("geometry");
         pp_geom.getarr("prob_lo", prob_lo_input);
@@ -300,9 +304,22 @@ struct ReadInputsOp<W2AWaves>
         wdata.v_mptr = modes_hosgrid::allocate_complex(wdata.n0, wdata.n1);
         wdata.w_mptr = modes_hosgrid::allocate_complex(wdata.n0, wdata.n1);
 
+        // Set up planner flag based on input
+        auto plan_f = modes_hosgrid::planner_flags::estimate;
+        if (fftw_planner_flag == "patient") {
+            plan_f = modes_hosgrid::planner_flags::patient;
+        } else if (fftw_planner_flag == "exhaustive") {
+            plan_f = modes_hosgrid::planner_flags::exhaustive;
+        } else if (fftw_planner_flag == "measure") {
+            plan_f = modes_hosgrid::planner_flags::measure;
+        } else if (!(fftw_planner_flag == "estimate")) {
+            amrex::Print()
+                << "WARNING (waves2amr_ops): invalid fftw_planner_flag "
+                   "specified; defaulting to estimate (FFTW_ESTIMATE).\n";
+        }
         // Set up plan for FFTW
-        wdata.plan =
-            modes_hosgrid::plan_ifftw(wdata.n0, wdata.n1, wdata.eta_mptr);
+        wdata.plan = modes_hosgrid::plan_ifftw(
+            wdata.n0, wdata.n1, wdata.eta_mptr, plan_f);
 
         // Create height vector for velocity mode conversion before
         // interpolation, with prob_lo as bottom
@@ -389,8 +406,7 @@ struct InitDataOp<W2AWaves>
 {
     void
     // cppcheck-suppress constParameterReference
-    operator()(
-        W2AWaves::DataType & data, int level, const amrex::Geometry & geom)
+    operator()(W2AWaves::DataType& data, int level, const amrex::Geometry& geom)
     {
 
 #ifdef AMR_WIND_USE_W2A

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -406,7 +406,8 @@ struct InitDataOp<W2AWaves>
 {
     void
     // cppcheck-suppress constParameterReference
-    operator()(W2AWaves::DataType& data, int level, const amrex::Geometry& geom)
+    operator()(
+        W2AWaves::DataType & data, int level, const amrex::Geometry & geom)
     {
 
 #ifdef AMR_WIND_USE_W2A

--- a/docs/sphinx/user/inputs_ocean_waves.rst
+++ b/docs/sphinx/user/inputs_ocean_waves.rst
@@ -118,6 +118,17 @@ The following input arguments are only valid for the W2AWaves wave type:
    This argument is only active if HOS_init_timestep is omitted. AMR-Wind will pick the
    time step in the modes closest to the specified time.
 
+.. input_param:: OceanWaves.label.fftw_planner_flag
+
+   **type:** String, optional, default = estimate
+
+   When setting up a plan for the inverse Fourier transform within the Waves2AMR library,
+   the FFTW algorithm can use different techniques to choose among available methods. Some of these
+   are faster than others, and the optimal choice can also depend on the architecture. The
+   default, "estimate", which corresponds to FFTW_ESTIMATE, is deterministic. The other
+   options are "exhaustive", "patient", and "measure". Variations from nondeterministic
+   approaches are tiny, on the order of machine precision.
+
 .. input_param:: OceanWaves.label.number_interp_points_in_z
 
    **type:** Integer, mandatory


### PR DESCRIPTION
## Summary

Regression test "ow_w2a" had been nondeterministic; this was due to the use of certain FFTW approaches that are nondeterministic. This PR allows the user to choose which approach to use and sets the default to a deterministic one.

## Pull request type

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

Issue Number: closes #1090
