### PR TITLE
Clang-tidy readability identifier naming for functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableCase, value: lower_case }
   - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }
   - { key: readability-identifier-naming.ClassIgnoredRegexp, value: "incflo"}
-  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: "^.*"}
+  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: "(Godunov_|setVal|ComputeDt|ComputePrescribeDt|ApplyPredictor|ApplyCorrector|ApplyPrescribeStep|ApplyProjection|UpdateGradP|ReadCheckpointFile|Factory|ReadParameters|InitialProjection|InitialIterations|PrintMax|CheckForNans|InitData|Evolve|buildInfoGetBuildDate|buildInfoGetComp|buildInfoGetGitHash|buildInfoGetCompVersion|FAST_).*"}
   - { key: readability-identifier-naming.GlobalConstantIgnoredRegexp, value: "^.*"}
   - { key: readability-identifier-naming.NamespaceIgnoredRegexp, value: "Hydro"}
   - { key: readability-identifier-naming.StructIgnoredRegexp, value: "(SC_DX|OpFM).*"}

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -71,7 +71,7 @@ CheckOptions:
   - { key: readability-identifier-naming.VariableCase, value: lower_case }
   - { key: readability-identifier-naming.GlobalConstantCase, value: UPPER_CASE }
   - { key: readability-identifier-naming.ClassIgnoredRegexp, value: "incflo"}
-  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: "(Godunov_|setVal|ComputeDt|ComputePrescribeDt|ApplyPredictor|ApplyCorrector|ApplyPrescribeStep|ApplyProjection|UpdateGradP|ReadCheckpointFile|Factory|ReadParameters|InitialProjection|InitialIterations|PrintMax|CheckForNans|InitData|Evolve|buildInfoGetBuildDate|buildInfoGetComp|buildInfoGetGitHash|buildInfoGetCompVersion|FAST_).*"}
+  - { key: readability-identifier-naming.FunctionIgnoredRegexp, value: "(Godunov_|setVal|ComputeDt|ComputePrescribeDt|ApplyPredictor|ApplyCorrector|ApplyPrescribeStep|ApplyProjection|UpdateGradP|ReadCheckpointFile|Factory|ReadParameters|InitialProjection|InitialIterations|PrintMax|CheckForNans|InitData|Evolve|buildInfoGet|FAST_).*"}
   - { key: readability-identifier-naming.GlobalConstantIgnoredRegexp, value: "^.*"}
   - { key: readability-identifier-naming.NamespaceIgnoredRegexp, value: "Hydro"}
   - { key: readability-identifier-naming.StructIgnoredRegexp, value: "(SC_DX|OpFM).*"}

--- a/amr-wind/core/Field.cpp
+++ b/amr-wind/core/Field.cpp
@@ -387,7 +387,7 @@ void Field::to_uniform_space() noexcept
     }
 
     const auto& mesh_fac = m_repo.get_mesh_mapping_field(m_info->m_floc);
-    const auto& mesh_detJ = m_repo.get_mesh_mapping_detJ(m_info->m_floc);
+    const auto& mesh_detJ = m_repo.get_mesh_mapping_det_j(m_info->m_floc);
 
     // scale velocity to accommodate for mesh mapping -> U^bar = U * J/fac
     for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {
@@ -417,7 +417,7 @@ void Field::to_stretched_space() noexcept
     }
 
     const auto& mesh_fac = m_repo.get_mesh_mapping_field(m_info->m_floc);
-    const auto& mesh_detJ = m_repo.get_mesh_mapping_detJ(m_info->m_floc);
+    const auto& mesh_detJ = m_repo.get_mesh_mapping_det_j(m_info->m_floc);
 
     // scale field back to stretched mesh -> U = U^bar * fac/J
     for (int lev = 0; lev < m_repo.num_active_levels(); ++lev) {

--- a/amr-wind/core/FieldRepo.H
+++ b/amr-wind/core/FieldRepo.H
@@ -255,7 +255,7 @@ public:
 
     /** Return a previously created mesh mapping detJ using field location
      */
-    Field& get_mesh_mapping_detJ(FieldLoc floc) const;
+    Field& get_mesh_mapping_det_j(FieldLoc floc) const;
 
     //! Query if field uniquely identified by name and time state exists in
     //! repository

--- a/amr-wind/core/FieldRepo.cpp
+++ b/amr-wind/core/FieldRepo.cpp
@@ -187,7 +187,7 @@ Field& FieldRepo::get_mesh_mapping_field(FieldLoc floc) const
     return *fac;
 }
 
-Field& FieldRepo::get_mesh_mapping_detJ(FieldLoc floc) const
+Field& FieldRepo::get_mesh_mapping_det_j(FieldLoc floc) const
 {
     Field* detJ = nullptr;
     switch (floc) {

--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -81,22 +81,22 @@ public:
     void set_restart_time(int tidx, amrex::Real time);
 
     AMREX_FORCE_INLINE
-    amrex::Real deltaT() const { return m_dt[0]; }
+    amrex::Real delta_t() const { return m_dt[0]; }
 
     AMREX_FORCE_INLINE
-    amrex::Real& deltaT() { return m_dt[0]; }
+    amrex::Real& delta_t() { return m_dt[0]; }
 
     AMREX_FORCE_INLINE
-    amrex::Real deltaTNm1() const { return m_dt[1]; }
+    amrex::Real delta_t_nm1() const { return m_dt[1]; }
 
     AMREX_FORCE_INLINE
-    amrex::Real deltaTNm2() const { return m_dt[2]; }
+    amrex::Real delta_t_nm2() const { return m_dt[2]; }
 
     AMREX_FORCE_INLINE
-    amrex::Real& deltaTNm1() { return m_dt[1]; }
+    amrex::Real& delta_t_nm1() { return m_dt[1]; }
 
     AMREX_FORCE_INLINE
-    amrex::Real& deltaTNm2() { return m_dt[2]; }
+    amrex::Real& delta_t_nm2() { return m_dt[2]; }
 
     AMREX_FORCE_INLINE
     amrex::Real current_time() const { return m_cur_time; }
@@ -163,10 +163,10 @@ private:
     //! Maximum CFL constraint
     amrex::Real m_max_cfl{0.5};
 
-    //! Fixed deltaT indicated by user
+    //! Fixed delta_t indicated by user
     amrex::Real m_fixed_dt{-1.0};
 
-    //! Initial deltaT indicated by user
+    //! Initial delta_t indicated by user
     amrex::Real m_initial_dt{-1.0};
 
     //! Current CFL

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -7,7 +7,7 @@ namespace amr_wind {
 
 void SimTime::parse_parameters()
 {
-    // Initialize deltaT to negative values
+    // Initialize delta_t to negative values
     for (amrex::Real& i : m_dt) {
         i = -1.0;
     }
@@ -213,7 +213,7 @@ void SimTime::set_current_cfl(
 
     } else {
         // If user has specified fixed DT then issue a warning if the timestep
-        // is larger than the deltaT determined from max. CFL considerations.
+        // is larger than the delta_t determined from max. CFL considerations.
         // Only issue warnings when the error is greater than 1% of the timestep
         // specified
         if ((1.0 - (dt_new / m_fixed_dt)) > 0.01) {

--- a/amr-wind/core/vs/tensor.H
+++ b/amr-wind/core/vs/tensor.H
@@ -62,7 +62,7 @@ struct TensorT
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static constexpr TensorT<T>
-    I() noexcept
+    identity() noexcept
     {
         return TensorT{Traits::one(),  Traits::zero(), Traits::zero(),
                        Traits::zero(), Traits::one(),  Traits::zero(),

--- a/amr-wind/diffusion/incflo_diffusion.cpp
+++ b/amr-wind/diffusion/incflo_diffusion.cpp
@@ -214,11 +214,11 @@ void viscosity_to_uniform_space(
     const auto& mesh_fac_zf =
         repo.get_mesh_mapping_field(amr_wind::FieldLoc::ZFACE);
     const auto& mesh_detJ_xf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::XFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::XFACE);
     const auto& mesh_detJ_yf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::YFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::YFACE);
     const auto& mesh_detJ_zf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::ZFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::ZFACE);
 
     // beta accounted for mesh mapping (x-face) = J/fac^2 * mu
     for (amrex::MFIter mfi(b[0]); mfi.isValid(); ++mfi) {

--- a/amr-wind/equation_systems/CompRHSOps.H
+++ b/amr-wind/equation_systems/CompRHSOps.H
@@ -71,7 +71,7 @@ struct ComputeRHSOp
         auto& conv_term = fields.conv_term.state(fstate);
         auto& mask_cell = fields.repo.get_int_field("mask_cell");
         Field const* mesh_detJ =
-            mesh_mapping ? &(fields.repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            mesh_mapping ? &(fields.repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                          : nullptr;
 
         for (int lev = 0; lev < nlevels; ++lev) {
@@ -190,7 +190,7 @@ struct ComputeRHSOp
         auto& conv_term_old = fields.conv_term.state(FieldState::Old);
         auto& mask_cell = fields.repo.get_int_field("mask_cell");
         Field const* mesh_detJ =
-            mesh_mapping ? &(fields.repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            mesh_mapping ? &(fields.repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                          : nullptr;
 
         for (int lev = 0; lev < nlevels; ++lev) {

--- a/amr-wind/equation_systems/DiffusionOps.cpp
+++ b/amr-wind/equation_systems/DiffusionOps.cpp
@@ -76,9 +76,9 @@ void DiffSolverIface<LinOp>::set_acoeffs(LinOp& linop, const FieldState fstate)
     auto& repo = m_pdefields.repo;
     const int nlevels = repo.num_active_levels();
     const auto& density = m_density.state(fstate);
-    Field const* mesh_detJ = m_mesh_mapping
-                                 ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
-                                 : nullptr;
+    Field const* mesh_detJ =
+        m_mesh_mapping ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
+                       : nullptr;
     std::unique_ptr<ScratchField> rho_times_detJ =
         m_mesh_mapping ? repo.create_scratch_field(
                              1, m_density.num_grow()[0], FieldLoc::CELL)

--- a/amr-wind/equation_systems/DiffusionOps.cpp
+++ b/amr-wind/equation_systems/DiffusionOps.cpp
@@ -77,7 +77,7 @@ void DiffSolverIface<LinOp>::set_acoeffs(LinOp& linop, const FieldState fstate)
     const int nlevels = repo.num_active_levels();
     const auto& density = m_density.state(fstate);
     Field const* mesh_detJ = m_mesh_mapping
-                                 ? &(repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+                                 ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                                  : nullptr;
     std::unique_ptr<ScratchField> rho_times_detJ =
         m_mesh_mapping ? repo.create_scratch_field(

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -130,14 +130,14 @@ public:
     {
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::compute_advection_term");
-        (*m_adv_op)(fstate, m_time.deltaT());
+        (*m_adv_op)(fstate, m_time.delta_t());
     }
 
     void pre_advection_actions(const FieldState fstate) override
     {
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::pre_advection_actions");
-        m_adv_op->preadvect(fstate, m_time.deltaT(), m_time.current_time());
+        m_adv_op->preadvect(fstate, m_time.delta_t(), m_time.current_time());
     }
 
     void compute_predictor_rhs(const DiffusionType difftype) override
@@ -145,7 +145,7 @@ public:
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::compute_predictor_rhs");
         m_rhs_op.predictor_rhs(
-            difftype, m_time.deltaT(), m_sim.has_mesh_mapping());
+            difftype, m_time.delta_t(), m_sim.has_mesh_mapping());
     }
 
     void compute_corrector_rhs(const DiffusionType difftype) override
@@ -153,7 +153,7 @@ public:
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::compute_corrector_rhs");
         m_rhs_op.corrector_rhs(
-            difftype, m_time.deltaT(), m_sim.has_mesh_mapping());
+            difftype, m_time.delta_t(), m_sim.has_mesh_mapping());
     }
 
     void solve(const amrex::Real dt) override

--- a/amr-wind/equation_systems/icns/icns_advection.cpp
+++ b/amr-wind/equation_systems/icns/icns_advection.cpp
@@ -282,11 +282,11 @@ void MacProjOp::mac_proj_to_uniform_space(
     const auto& mesh_fac_zf =
         repo.get_mesh_mapping_field(amr_wind::FieldLoc::ZFACE);
     const auto& mesh_detJ_xf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::XFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::XFACE);
     const auto& mesh_detJ_yf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::YFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::YFACE);
     const auto& mesh_detJ_zf =
-        repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::ZFACE);
+        repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::ZFACE);
 
     // scale U^mac to accommodate for mesh mapping -> U^bar = J/fac *
     // U^mac beta accounted for mesh mapping = J/fac^2 * 1/rho construct

--- a/amr-wind/equation_systems/icns/icns_diffusion.H
+++ b/amr-wind/equation_systems/icns/icns_diffusion.H
@@ -127,7 +127,7 @@ public:
         const auto& density = m_density.state(fstate);
         const auto& viscosity = m_pdefields.mueff;
         Field const* mesh_detJ =
-            m_mesh_mapping ? &(repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            m_mesh_mapping ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                            : nullptr;
         std::unique_ptr<ScratchField> rho_times_detJ =
             m_mesh_mapping ? repo.create_scratch_field(
@@ -199,7 +199,7 @@ public:
         auto rhs_ptr = repo.create_scratch_field("rhs", field.num_comp(), 0);
         const auto& viscosity = m_pdefields.mueff;
         Field const* mesh_detJ =
-            m_mesh_mapping ? &(repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            m_mesh_mapping ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                            : nullptr;
         std::unique_ptr<ScratchField> rho_times_detJ =
             m_mesh_mapping ? repo.create_scratch_field(
@@ -344,7 +344,7 @@ public:
         const auto& density = m_density.state(fstate);
         const auto& viscosity = m_pdefields.mueff;
         Field const* mesh_detJ =
-            m_mesh_mapping ? &(repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            m_mesh_mapping ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                            : nullptr;
         std::unique_ptr<ScratchField> rho_times_detJ =
             m_mesh_mapping ? repo.create_scratch_field(
@@ -432,7 +432,7 @@ public:
         const auto& geom = repo.mesh().Geom();
 
         Field const* mesh_detJ =
-            m_mesh_mapping ? &(repo.get_mesh_mapping_detJ(FieldLoc::CELL))
+            m_mesh_mapping ? &(repo.get_mesh_mapping_det_j(FieldLoc::CELL))
                            : nullptr;
         std::unique_ptr<ScratchField> rho_times_detJ =
             m_mesh_mapping ? repo.create_scratch_field(

--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -43,7 +43,7 @@ public:
         const auto& current_time = m_time.current_time();
         const auto& new_time = m_time.new_time();
         const auto& nph_time = 0.5 * (current_time + new_time);
-        const auto& dt = m_time.deltaT();
+        const auto& dt = m_time.delta_t();
         const auto& t_step = m_time.time_index();
 
         if (!m_vel_timetable.empty()) {

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -28,7 +28,7 @@ ABLMesoForcingMom::ABLMesoForcingMom(const CFDSim& sim)
 
     if ((amrex::toLower(m_forcing_scheme) == "indirect") &&
         !m_update_transition_height) {
-        indirectForcingInit(); // do this once
+        indirect_forcing_init(); // do this once
     }
 }
 
@@ -228,8 +228,8 @@ void ABLMesoForcingMom::mean_velocity_heights(
             amrex::Print() << "current transition height = "
                            << m_transition_height << std::endl;
 
-            setTransitionWeighting();
-            indirectForcingInit();
+            set_transition_weighting();
+            indirect_forcing_init();
         }
 
         amrex::Array<amrex::Real, 4> ezP_U;
@@ -287,8 +287,8 @@ void ABLMesoForcingMom::mean_velocity_heights(
         }
 
         if (amrex::toLower(m_forcing_transition) == "indirecttodirect") {
-            blendForcings(error_U, error_U_direct, error_U);
-            blendForcings(error_V, error_V_direct, error_V);
+            blend_forcings(error_U, error_U_direct, error_U);
+            blend_forcings(error_V, error_V_direct, error_V);
 
             if (m_debug) {
                 for (size_t ih = 0; ih < n_levels; ih++) {
@@ -299,9 +299,9 @@ void ABLMesoForcingMom::mean_velocity_heights(
         }
     }
 
-    if (forcingToConstant()) {
-        constantForcingTransition(error_U);
-        constantForcingTransition(error_V);
+    if (forcing_to_constant()) {
+        constant_forcing_transition(error_U);
+        constant_forcing_transition(error_V);
 
         if (m_debug) {
             for (size_t ih = 0; ih < n_levels; ih++) {
@@ -336,7 +336,7 @@ void ABLMesoForcingMom::operator()(
         return;
     }
 
-    const auto& dt = m_time.deltaT();
+    const auto& dt = m_time.delta_t();
     const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -28,7 +28,7 @@ ABLMesoForcingTemp::ABLMesoForcingTemp(const CFDSim& sim)
 
     if ((amrex::toLower(m_forcing_scheme) == "indirect") &&
         !m_update_transition_height) {
-        indirectForcingInit(); // do this once
+        indirect_forcing_init(); // do this once
     }
 }
 
@@ -202,8 +202,8 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
             amrex::Print() << "current transition height = "
                            << m_transition_height << std::endl;
 
-            setTransitionWeighting();
-            indirectForcingInit();
+            set_transition_weighting();
+            indirect_forcing_init();
         }
 
         amrex::Array<amrex::Real, 4> ezP_T;
@@ -247,7 +247,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
         }
 
         if (amrex::toLower(m_forcing_transition) == "indirecttodirect") {
-            blendForcings(error_T, error_T_direct, error_T);
+            blend_forcings(error_T, error_T_direct, error_T);
 
             if (m_debug) {
                 for (size_t ih = 0; ih < n_levels; ih++) {
@@ -258,8 +258,8 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
         }
     }
 
-    if (forcingToConstant()) {
-        constantForcingTransition(error_T);
+    if (forcing_to_constant()) {
+        constant_forcing_transition(error_T);
 
         if (m_debug) {
             for (size_t ih = 0; ih < n_levels; ih++) {
@@ -290,7 +290,7 @@ void ABLMesoForcingTemp::operator()(
         return;
     }
 
-    const auto& dt = m_time.deltaT();
+    const auto& dt = m_time.delta_t();
     const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
 

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -305,8 +305,8 @@ void incflo::ApplyPredictor(bool incremental_projection)
         auto& field = eqn->fields().field;
         if (m_diff_type != DiffusionType::Explicit) {
             amrex::Real dt_diff = (m_diff_type == DiffusionType::Implicit)
-                                      ? m_time.deltaT()
-                                      : 0.5 * m_time.deltaT();
+                                      ? m_time.delta_t()
+                                      : 0.5 * m_time.delta_t();
 
             // Solve diffusion eqn. and update of the scalar field
             eqn->solve(dt_diff);
@@ -320,7 +320,7 @@ void incflo::ApplyPredictor(bool incremental_projection)
                 eqn->fields().diff_term.state(amr_wind::FieldState::New);
             amr_wind::field_ops::copy(*diff_old, diff_new, 0, 0, 1, 0);
             eqn->compute_diffusion_term(amr_wind::FieldState::New);
-            amrex::Real dto2 = 0.5 * m_time.deltaT();
+            amrex::Real dto2 = 0.5 * m_time.delta_t();
             amr_wind::field_ops::saxpy(
                 eqn->fields().field, -dto2, *diff_old, 0, 0, 1, 0);
             amr_wind::field_ops::saxpy(
@@ -360,8 +360,8 @@ void incflo::ApplyPredictor(bool incremental_projection)
     if (m_diff_type == DiffusionType::Crank_Nicolson ||
         m_diff_type == DiffusionType::Implicit) {
         Real dt_diff = (m_diff_type == DiffusionType::Implicit)
-                           ? m_time.deltaT()
-                           : 0.5 * m_time.deltaT();
+                           ? m_time.delta_t()
+                           : 0.5 * m_time.delta_t();
         icns().solve(dt_diff);
     } else if (m_diff_type == DiffusionType::Explicit && m_use_godunov) {
         // explicit RK2
@@ -373,7 +373,7 @@ void incflo::ApplyPredictor(bool incremental_projection)
             icns().fields().diff_term.state(amr_wind::FieldState::New);
         amr_wind::field_ops::copy(*diff_old, diff_new, 0, 0, AMREX_SPACEDIM, 0);
         icns().compute_diffusion_term(amr_wind::FieldState::New);
-        amrex::Real dto2 = 0.5 * m_time.deltaT();
+        amrex::Real dto2 = 0.5 * m_time.delta_t();
         amr_wind::field_ops::saxpy(
             icns().fields().field, -dto2, *diff_old, 0, 0, AMREX_SPACEDIM, 0);
         amr_wind::field_ops::saxpy(
@@ -391,7 +391,7 @@ void incflo::ApplyPredictor(bool incremental_projection)
     //
     // ************************************************************************************
     ApplyProjection(
-        (density_new).vec_const_ptrs(), new_time, m_time.deltaT(),
+        (density_new).vec_const_ptrs(), new_time, m_time.delta_t(),
         incremental_projection);
 
     if (m_verbose > 2) {
@@ -563,8 +563,8 @@ void incflo::ApplyCorrector()
         auto& field = eqn->fields().field;
         if (m_diff_type != DiffusionType::Explicit) {
             amrex::Real dt_diff = (m_diff_type == DiffusionType::Implicit)
-                                      ? m_time.deltaT()
-                                      : 0.5 * m_time.deltaT();
+                                      ? m_time.delta_t()
+                                      : 0.5 * m_time.delta_t();
 
             // Solve diffusion eqn. and update of the scalar field
             eqn->solve(dt_diff);
@@ -599,8 +599,8 @@ void incflo::ApplyCorrector()
     if (m_diff_type == DiffusionType::Crank_Nicolson ||
         m_diff_type == DiffusionType::Implicit) {
         Real dt_diff = (m_diff_type == DiffusionType::Implicit)
-                           ? m_time.deltaT()
-                           : 0.5 * m_time.deltaT();
+                           ? m_time.delta_t()
+                           : 0.5 * m_time.delta_t();
         icns().solve(dt_diff);
     }
     icns().post_solve_actions();
@@ -610,7 +610,7 @@ void incflo::ApplyCorrector()
     // *************************************************************************************
     bool incremental = false;
     ApplyProjection(
-        (density_new).vec_const_ptrs(), new_time, m_time.deltaT(), incremental);
+        (density_new).vec_const_ptrs(), new_time, m_time.delta_t(), incremental);
 }
 
 void incflo::prescribe_advance()
@@ -706,8 +706,8 @@ void incflo::ApplyPrescribeStep()
         auto& field = eqn->fields().field;
         if (m_diff_type != DiffusionType::Explicit) {
             amrex::Real dt_diff = (m_diff_type == DiffusionType::Implicit)
-                                      ? m_time.deltaT()
-                                      : 0.5 * m_time.deltaT();
+                                      ? m_time.delta_t()
+                                      : 0.5 * m_time.delta_t();
 
             // Solve diffusion eqn. and update of the scalar field
             eqn->solve(dt_diff);

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -610,7 +610,8 @@ void incflo::ApplyCorrector()
     // *************************************************************************************
     bool incremental = false;
     ApplyProjection(
-        (density_new).vec_const_ptrs(), new_time, m_time.delta_t(), incremental);
+        (density_new).vec_const_ptrs(), new_time, m_time.delta_t(),
+        incremental);
 }
 
 void incflo::prescribe_advance()

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -116,7 +116,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                     // Generation region
                     if (x <= problo[0] + gen_length) {
                         const amrex::Real Gamma =
-                            utils::Gamma_generate(x - problo[0], gen_length);
+                            utils::gamma_generate(x - problo[0], gen_length);
                         const amrex::Real vf =
                             (1. - Gamma) * target_volfrac(i, j, k) * rampf +
                             Gamma * volfrac(i, j, k);
@@ -148,7 +148,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                     }
                     // Numerical beach (sponge layer)
                     if (x + beach_length >= probhi[0]) {
-                        const amrex::Real Gamma = utils::Gamma_absorb(
+                        const amrex::Real Gamma = utils::gamma_absorb(
                             x - (probhi[0] - beach_length), beach_length, 1.0);
                         if (has_beach) {
                             volfrac(i, j, k) =

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -26,7 +26,7 @@ free_surface_to_vof(amrex::Real eta, amrex::Real z, amrex::Real dz)
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-Gamma_generate(amrex::Real x, amrex::Real gen_length)
+gamma_generate(amrex::Real x, amrex::Real gen_length)
 {
     amrex::Real Gamma = 0.0;
     amrex::Real xtilde = std::max(std::min(1. - x / gen_length, 1.0), 0.0);
@@ -34,7 +34,7 @@ Gamma_generate(amrex::Real x, amrex::Real gen_length)
     return Gamma;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real Gamma_absorb(
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real gamma_absorb(
     amrex::Real x, amrex::Real absorb_length, amrex::Real absorb_length_factor)
 {
     amrex::Real Gamma = 0.0;

--- a/amr-wind/overset/OversetOps.cpp
+++ b/amr-wind/overset/OversetOps.cpp
@@ -372,7 +372,7 @@ void OversetOps::replace_masked_gradp()
     const auto nlevels = repo.num_active_levels();
 
     // Get timestep
-    const amrex::Real dt = (*m_sim_ptr).time().deltaT();
+    const amrex::Real dt = (*m_sim_ptr).time().delta_t();
 
     // Get blanking for cells
     const auto& iblank_cell = repo.get_int_field("iblank_cell");

--- a/amr-wind/physics/SyntheticTurbulence.cpp
+++ b/amr-wind/physics/SyntheticTurbulence.cpp
@@ -330,7 +330,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void interp_perturb_vel(
         i += nynz;
     }
 
-    // Right quad (t = t+deltaT)
+    // Right quad (t = t+delta_t)
     vel_r[0] = wt.yl * wt.zl * t_grid.uvel[qidx[0]] +
                wt.yr * wt.zl * t_grid.uvel[qidx[1]] +
                wt.yr * wt.zr * t_grid.uvel[qidx[2]] +

--- a/amr-wind/physics/multiphase/VortexPatch.cpp
+++ b/amr-wind/physics/multiphase/VortexPatch.cpp
@@ -107,7 +107,7 @@ void VortexPatch::initialize_fields(int level, const amrex::Geometry& geom)
 void VortexPatch::pre_advance_work()
 {
     const auto& time =
-        m_sim.time().current_time() + 0.5 * m_sim.time().deltaT();
+        m_sim.time().current_time() + 0.5 * m_sim.time().delta_t();
 
     const int nlevels = m_sim.repo().num_active_levels();
     const auto& geom = m_sim.mesh().Geom();

--- a/amr-wind/physics/multiphase/VortexPatchScalarVel.cpp
+++ b/amr-wind/physics/multiphase/VortexPatchScalarVel.cpp
@@ -118,7 +118,7 @@ void VortexPatchScalarVel::initialize_fields(
 void VortexPatchScalarVel::pre_advance_work()
 {
     const auto& time =
-        m_sim.time().current_time() + 0.5 * m_sim.time().deltaT();
+        m_sim.time().current_time() + 0.5 * m_sim.time().delta_t();
 
     const int nlevels = m_sim.repo().num_active_levels();
     const auto& geom = m_sim.mesh().Geom();

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -148,8 +148,9 @@ void incflo::ApplyProjection(
             ? &(m_repo.get_mesh_mapping_field(amr_wind::FieldLoc::CELL))
             : nullptr;
     amr_wind::Field const* mesh_detJ =
-        mesh_mapping ? &(m_repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::CELL))
-                     : nullptr;
+        mesh_mapping
+            ? &(m_repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::CELL))
+            : nullptr;
     const auto* ref_density =
         is_anelastic ? &(m_repo.get_field("reference_density")) : nullptr;
 

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -122,7 +122,7 @@ void incflo::ApplyProjection(
     // projects (U^*-U^n + dt Gp) rather than (U^* + dt Gp)
 
     bool proj_for_small_dt =
-        (time > 0.0 and m_time.deltaT() < 0.1 * m_time.deltaTNm1());
+        (time > 0.0 and m_time.delta_t() < 0.1 * m_time.delta_t_nm1());
 
     if (m_verbose > 2) {
         if (proj_for_small_dt) {
@@ -148,7 +148,7 @@ void incflo::ApplyProjection(
             ? &(m_repo.get_mesh_mapping_field(amr_wind::FieldLoc::CELL))
             : nullptr;
     amr_wind::Field const* mesh_detJ =
-        mesh_mapping ? &(m_repo.get_mesh_mapping_detJ(amr_wind::FieldLoc::CELL))
+        mesh_mapping ? &(m_repo.get_mesh_mapping_det_j(amr_wind::FieldLoc::CELL))
                      : nullptr;
     const auto* ref_density =
         is_anelastic ? &(m_repo.get_field("reference_density")) : nullptr;

--- a/amr-wind/turbulence/RANS/KOmegaSST.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSST.cpp
@@ -105,7 +105,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
     // Compute strain rate into shear production term
     fvm::strainrate(this->m_shear_prod, vel);
 
-    const amrex::Real deltaT = (this->m_sim).time().deltaT();
+    const amrex::Real delta_t = (this->m_sim).time().delta_t();
     const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> gravity{
         m_gravity[0], m_gravity[1], m_gravity[2]};
     const amrex::Real Bfac = this->m_buoyancy_factor;
@@ -202,7 +202,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                                         diss_amb;
 
                     tke_lhs_arr(i, j, k) = beta_star * rho_arr(i, j, k) *
-                                           sdr_arr(i, j, k) * deltaT;
+                                           sdr_arr(i, j, k) * delta_t;
 
                     // For SDR equation:
                     amrex::Real production_omega =
@@ -230,7 +230,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                             (rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
                              0.5 * std::abs(cross_diffusion) /
                                  (sdr_arr(i, j, k) + 1e-15)) *
-                            deltaT;
+                            delta_t;
                     } else if (diff_type == DiffusionType::Implicit) {
                         /* Source term linearization is based on Florian
                            Menter's (1993) AIAA paper */
@@ -244,7 +244,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                             (2.0 * rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
                              std::abs(cross_diffusion) /
                                  (sdr_arr(i, j, k) + 1e-15)) *
-                            deltaT;
+                            delta_t;
 
                     } else {
                         sdr_src_arr(i, j, k) =
@@ -256,7 +256,7 @@ void KOmegaSST<Transport>::update_turbulent_viscosity(
                                                 sdr_diss_amb;
 
                         sdr_lhs_arr(i, j, k) = 0.5 * rho_arr(i, j, k) * beta *
-                                               sdr_arr(i, j, k) * deltaT;
+                                               sdr_arr(i, j, k) * delta_t;
                     }
                 });
         }

--- a/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
+++ b/amr-wind/turbulence/RANS/KOmegaSSTIDDES.cpp
@@ -119,7 +119,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
     auto vortmag = (this->m_sim.repo()).create_scratch_field(1, 0);
     fvm::vorticity_mag(*vortmag, vel);
 
-    const amrex::Real deltaT = (this->m_sim).time().deltaT();
+    const amrex::Real delta_t = (this->m_sim).time().delta_t();
 
     const int nlevels = repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
@@ -255,7 +255,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
 
                     tke_lhs_arr(i, j, k) = rho_arr(i, j, k) *
                                            std::sqrt(tke_arr(i, j, k)) /
-                                           l_iddes * deltaT;
+                                           l_iddes * delta_t;
 
                     // For SDR equation:
                     amrex::Real production_omega =
@@ -285,7 +285,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                             (rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
                              0.5 * std::abs(cross_diffusion) /
                                  (sdr_arr(i, j, k) + 1e-15)) *
-                            deltaT;
+                            delta_t;
 
                     } else if (diff_type == DiffusionType::Implicit) {
                         /* Source term linearization is based on Florian
@@ -300,7 +300,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                             (2.0 * rho_arr(i, j, k) * beta * sdr_arr(i, j, k) +
                              std::abs(cross_diffusion) /
                                  (sdr_arr(i, j, k) + 1e-15)) *
-                            deltaT;
+                            delta_t;
                     } else {
                         sdr_src_arr(i, j, k) =
                             production_omega + cross_diffusion;
@@ -311,7 +311,7 @@ void KOmegaSSTIDDES<Transport>::update_turbulent_viscosity(
                                                 sdr_diss_amb;
 
                         sdr_lhs_arr(i, j, k) = 0.5 * rho_arr(i, j, k) * beta *
-                                               sdr_arr(i, j, k) * deltaT;
+                                               sdr_arr(i, j, k) * delta_t;
                     }
                 });
         }

--- a/amr-wind/utilities/DirectionSelector.H
+++ b/amr-wind/utilities/DirectionSelector.H
@@ -62,7 +62,7 @@ using ZDir = DirectionSelector<2>;
 // The IntVect is used to set the constant index in the parallel direction.
 template <typename IndexSelector>
 AMREX_GPU_HOST_DEVICE amrex::Box
-PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
+perpendicular_box(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect plane_lo, plane_hi;
 
@@ -88,7 +88,7 @@ PerpendicularBox(const amrex::Box& bx, const amrex::IntVect& iv)
 // direction.
 template <typename IndexSelector>
 AMREX_GPU_HOST_DEVICE amrex::Box
-ParallelBox(const amrex::Box& bx, const amrex::IntVect& iv)
+parallel_box(const amrex::Box& bx, const amrex::IntVect& iv)
 {
     amrex::IntVect line_lo, line_hi;
 

--- a/amr-wind/utilities/FieldPlaneAveraging.cpp
+++ b/amr-wind/utilities/FieldPlaneAveraging.cpp
@@ -277,7 +277,7 @@ void FPlaneAveraging<FType>::compute_averages(
         auto fab_arr = mfab.const_array(mfi);
 
         amrex::Box pbx =
-            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
         amrex::ParallelFor(
             amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -287,7 +287,7 @@ void FPlaneAveraging<FType>::compute_averages(
                 // Loop over the direction perpendicular to the plane.
                 // This reduces the atomic pressure on the destination arrays.
 
-                amrex::Box lbx = ParallelBox<IndexSelector>(
+                amrex::Box lbx = parallel_box<IndexSelector>(
                     bx, amrex::IntVect{p_i, p_j, p_k});
 
                 for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
@@ -384,7 +384,7 @@ void VelPlaneAveraging::compute_hvelmag_averages(
         auto fab_arr = mfab.const_array(mfi);
 
         amrex::Box pbx =
-            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
         amrex::ParallelFor(
             amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -394,7 +394,7 @@ void VelPlaneAveraging::compute_hvelmag_averages(
                 // Loop over the direction perpendicular to the plane.
                 // This reduces the atomic pressure on the destination arrays.
 
-                amrex::Box lbx = ParallelBox<IndexSelector>(
+                amrex::Box lbx = parallel_box<IndexSelector>(
                     bx, amrex::IntVect{p_i, p_j, p_k});
 
                 for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {

--- a/amr-wind/utilities/FieldPlaneAveragingFine.H
+++ b/amr-wind/utilities/FieldPlaneAveragingFine.H
@@ -142,10 +142,10 @@ public: // public for GPU
     amrex::Real line_hvelmag_average_interpolated(amrex::Real x) const;
     /** evaluate line haverage at specific location for horizontal velocity
      * magnitude times x-velocity */
-    amrex::Real line_Su_average_interpolated(amrex::Real x) const;
+    amrex::Real line_su_average_interpolated(amrex::Real x) const;
     /** evaluate line haverage at specific location for horizontal velocity
      * magnitude times y-velocity */
-    amrex::Real line_Sv_average_interpolated(amrex::Real x) const;
+    amrex::Real line_sv_average_interpolated(amrex::Real x) const;
 };
 
 } // namespace amr_wind

--- a/amr-wind/utilities/FieldPlaneAveragingFine.cpp
+++ b/amr-wind/utilities/FieldPlaneAveragingFine.cpp
@@ -240,7 +240,7 @@ void FPlaneAveragingFine<FType>::compute_averages(const IndexSelector& idxOp)
             auto mask_arr = level_mask.const_array(mfi);
 
             amrex::Box pbx =
-                PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+                perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
             amrex::ParallelFor(
                 amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -251,7 +251,7 @@ void FPlaneAveragingFine<FType>::compute_averages(const IndexSelector& idxOp)
                     // This reduces the atomic pressure on the destination
                     // arrays.
 
-                    amrex::Box lbx = ParallelBox<IndexSelector>(
+                    amrex::Box lbx = parallel_box<IndexSelector>(
                         bx, amrex::IntVect{p_i, p_j, p_k});
 
                     for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
@@ -428,7 +428,7 @@ void VelPlaneAveragingFine::compute_hvelmag_averages(const IndexSelector& idxOp)
             auto mask_arr = level_mask.const_array(mfi);
 
             amrex::Box pbx =
-                PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+                perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
             amrex::ParallelFor(
                 amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -439,7 +439,7 @@ void VelPlaneAveragingFine::compute_hvelmag_averages(const IndexSelector& idxOp)
                     // This reduces the atomic pressure on the destination
                     // arrays.
 
-                    amrex::Box lbx = ParallelBox<IndexSelector>(
+                    amrex::Box lbx = parallel_box<IndexSelector>(
                         bx, amrex::IntVect{p_i, p_j, p_k});
 
                     for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
@@ -546,7 +546,7 @@ VelPlaneAveragingFine::line_hvelmag_average_interpolated(amrex::Real x) const
 }
 
 amrex::Real
-VelPlaneAveragingFine::line_Su_average_interpolated(amrex::Real x) const
+VelPlaneAveragingFine::line_su_average_interpolated(amrex::Real x) const
 {
     int ind;
     amrex::Real c;
@@ -556,7 +556,7 @@ VelPlaneAveragingFine::line_Su_average_interpolated(amrex::Real x) const
 }
 
 amrex::Real
-VelPlaneAveragingFine::line_Sv_average_interpolated(amrex::Real x) const
+VelPlaneAveragingFine::line_sv_average_interpolated(amrex::Real x) const
 {
     int ind;
     amrex::Real c;

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -327,9 +327,9 @@ void IOManager::write_header(
         << end_level - start_level << "\n"
         << time.time_index() << "\n"
         << time.new_time() << "\n"
-        << time.deltaT() << "\n"
-        << time.deltaTNm1() << "\n"
-        << time.deltaTNm2() << "\n";
+        << time.delta_t() << "\n"
+        << time.delta_t_nm1() << "\n"
+        << time.delta_t_nm2() << "\n";
 
     const auto geom = mesh.Geom(0);
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {

--- a/amr-wind/utilities/SecondMomentAveraging.cpp
+++ b/amr-wind/utilities/SecondMomentAveraging.cpp
@@ -157,7 +157,7 @@ void SecondMomentAveraging::compute_average(
         auto mfab_arr2 = mfab2.const_array(mfi);
 
         amrex::Box pbx =
-            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
         amrex::ParallelFor(
             amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -167,7 +167,7 @@ void SecondMomentAveraging::compute_average(
                 // Loop over the direction perpendicular to the plane.
                 // This reduces the atomic pressure on the destination arrays.
 
-                amrex::Box lbx = ParallelBox<IndexSelector>(
+                amrex::Box lbx = parallel_box<IndexSelector>(
                     bx, amrex::IntVect{p_i, p_j, p_k});
 
                 for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {

--- a/amr-wind/utilities/ThirdMomentAveraging.cpp
+++ b/amr-wind/utilities/ThirdMomentAveraging.cpp
@@ -181,7 +181,7 @@ void ThirdMomentAveraging::compute_average(
         auto mfab_arr3 = mfab3.const_array(mfi);
 
         amrex::Box pbx =
-            PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
+            perpendicular_box<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
 
         amrex::ParallelFor(
             amrex::Gpu::KernelInfo().setReduction(true), pbx,
@@ -191,7 +191,7 @@ void ThirdMomentAveraging::compute_average(
                 // Loop over the direction perpendicular to the plane.
                 // This reduces the atomic pressure on the destination arrays.
 
-                amrex::Box lbx = ParallelBox<IndexSelector>(
+                amrex::Box lbx = parallel_box<IndexSelector>(
                     bx, amrex::IntVect{p_i, p_j, p_k});
 
                 for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {

--- a/amr-wind/utilities/averaging/ReAveraging.cpp
+++ b/amr-wind/utilities/averaging/ReAveraging.cpp
@@ -47,7 +47,7 @@ void ReAveraging::operator()(
     const amrex::Real filter_width,
     const amrex::Real elapsed_time)
 {
-    const amrex::Real dt = time.deltaT();
+    const amrex::Real dt = time.delta_t();
     const amrex::Real filter =
         amrex::max(amrex::min(filter_width, elapsed_time), dt);
     const amrex::Real factor = amrex::max<amrex::Real>(filter - dt, 0.0);

--- a/amr-wind/utilities/averaging/ReynoldsStress.cpp
+++ b/amr-wind/utilities/averaging/ReynoldsStress.cpp
@@ -61,7 +61,7 @@ void ReynoldsStress::operator()(
     const amrex::Real filter_width,
     const amrex::Real elapsed_time)
 {
-    const amrex::Real dt = time.deltaT();
+    const amrex::Real dt = time.delta_t();
     const amrex::Real filter =
         amrex::max(amrex::min(filter_width, elapsed_time), dt);
     const amrex::Real factor = amrex::max<amrex::Real>(filter - dt, 0.0);

--- a/amr-wind/utilities/io.cpp
+++ b/amr-wind/utilities/io.cpp
@@ -11,7 +11,7 @@ namespace {
 const std::string level_prefix{"Level_"};
 }
 
-void GotoNextLine(std::istream& is)
+void goto_next_line(std::istream& is)
 {
     constexpr std::streamsize bl_ignore_max{100000};
     is.ignore(bl_ignore_max, '\n');
@@ -52,29 +52,29 @@ void incflo::ReadCheckpointFile()
 
     // Finest level
     is >> finest_level;
-    GotoNextLine(is);
+    goto_next_line(is);
 
     int nstep;
     amrex::Real cur_time, dt_restart;
     // Step count
     is >> nstep;
-    GotoNextLine(is);
+    goto_next_line(is);
 
     // Current time
     is >> cur_time;
-    GotoNextLine(is);
+    goto_next_line(is);
 
     m_time.set_restart_time(nstep, cur_time);
 
     // Time step size
     is >> dt_restart;
-    GotoNextLine(is);
+    goto_next_line(is);
 
-    is >> m_time.deltaTNm1();
-    GotoNextLine(is);
+    is >> m_time.delta_t_nm1();
+    goto_next_line(is);
 
-    is >> m_time.deltaTNm2();
-    GotoNextLine(is);
+    is >> m_time.delta_t_nm2();
+    goto_next_line(is);
 
     // Low coordinates of domain bounding box
     std::getline(is, line);
@@ -153,7 +153,7 @@ void incflo::ReadCheckpointFile()
     for (int lev = 0; lev <= finest_level; ++lev) {
         // read in level 'lev' BoxArray from Header
         ba_inp[lev].readFrom(is);
-        GotoNextLine(is);
+        goto_next_line(is);
     }
 
     // always use level 0 to check domain size

--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.cpp
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.cpp
@@ -296,7 +296,7 @@ void DTUSpinnerSampler::update_sampling_locations()
     // Not current_time()
     amrex::Real time = m_sim.time().new_time();
     amrex::Real start_time = m_sim.time().start_time();
-    amrex::Real dt_sim = m_sim.time().deltaT();
+    amrex::Real dt_sim = m_sim.time().delta_t();
     const amrex::Real dt_s = m_scan_time / m_num_samples;
     amrex::Real start_diff = std::abs(time - start_time);
 

--- a/amr-wind/utilities/sampling/FieldNorms.H
+++ b/amr-wind/utilities/sampling/FieldNorms.H
@@ -35,7 +35,7 @@ public:
 
     //! calculate the L2 norm of a given field and component
     static amrex::Real
-    L2_norm(amr_wind::Field& field, const int comp, const bool use_mask);
+    l2_norm(amr_wind::Field& field, const int comp, const bool use_mask);
 
     const amrex::Vector<std::string>& var_names() const { return m_var_names; }
 

--- a/amr-wind/utilities/sampling/FieldNorms.cpp
+++ b/amr-wind/utilities/sampling/FieldNorms.cpp
@@ -35,7 +35,7 @@ void FieldNorms::initialize()
 }
 
 amrex::Real
-FieldNorms::L2_norm(amr_wind::Field& field, const int comp, const bool use_mask)
+FieldNorms::l2_norm(amr_wind::Field& field, const int comp, const bool use_mask)
 {
     amrex::Real nrm = 0.0;
 
@@ -101,7 +101,7 @@ void FieldNorms::process_field_norms()
     int ind = 0;
     for (const auto& fld : m_sim.io_manager().plot_fields()) {
         for (int comp = 0; comp < fld->num_comp(); ++comp) {
-            m_fnorms[ind++] = L2_norm(*fld, comp, m_use_mask);
+            m_fnorms[ind++] = l2_norm(*fld, comp, m_use_mask);
         }
     }
 }

--- a/amr-wind/utilities/sampling/RadarSampler.cpp
+++ b/amr-wind/utilities/sampling/RadarSampler.cpp
@@ -83,7 +83,7 @@ void RadarSampler::initialize(const std::string& key)
 
     // Calculate total number of necessary beams per timstep
     // Due to subsampling freq
-    amrex::Real dt_sim = m_sim.time().deltaT();
+    amrex::Real dt_sim = m_sim.time().delta_t();
     amrex::Real dt_sample = 1.0 / m_sample_freq;
     double timestep_sample_ratio = dt_sim / dt_sample;
     m_ntotal = int(std::ceil(timestep_sample_ratio));
@@ -192,7 +192,7 @@ void RadarSampler::update_sampling_locations()
 {
     amrex::Real time = m_sim.time().current_time();
     amrex::Real start_time = m_sim.time().start_time();
-    amrex::Real dt_sim = m_sim.time().deltaT();
+    amrex::Real dt_sim = m_sim.time().delta_t();
     amrex::Real dt_sample = 1.0 / m_sample_freq;
     amrex::Real st_diff = time - start_time;
 

--- a/amr-wind/utilities/sampling/SamplingUtils.cpp
+++ b/amr-wind/utilities/sampling/SamplingUtils.cpp
@@ -59,9 +59,9 @@ vs::Tensor rotation_matrix(vs::Vector dst, vs::Vector src)
 
     const double small = 1e-14 * vs::mag(dst);
     if (std::abs(1 + ang) < small) {
-        return scale(vs::Tensor::I(), -1);
+        return scale(vs::Tensor::identity(), -1);
     }
-    return vs::Tensor::I() + vmat + scale((vmat & vmat), 1. / (1 + ang));
+    return vs::Tensor::identity() + vmat + scale((vmat & vmat), 1. / (1 + ang));
 }
 
 vs::Tensor skew_cross(vs::Vector a, vs::Vector b)

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -96,7 +96,7 @@ private:
     amrex::Real m_ref_height{50.0};
 
     //! Amplitude of temperature perturbations
-    amrex::Real m_deltaT{0.8};
+    amrex::Real m_delta_t{0.8};
 
     //! Mean for Gaussian number generator
     amrex::Real m_theta_gauss_mean{0.0};

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -42,7 +42,7 @@ void ABLFieldInit::initialize_from_inputfile()
     pp_abl.query("random_gauss_mean", m_theta_gauss_mean);
     pp_abl.query("random_gauss_var", m_theta_gauss_var);
     pp_abl.query("cutoff_height", m_theta_cutoff_height);
-    pp_abl.query("theta_amplitude", m_deltaT);
+    pp_abl.query("theta_amplitude", m_delta_t);
 
     pp_abl.query("init_tke", m_tke_init);
     pp_abl.query("init_tke_beare_profile", m_tke_init_profile);
@@ -294,7 +294,7 @@ void ABLFieldInit::perturb_temperature(
     const auto theta_cutoff_height = m_theta_cutoff_height;
     const auto theta_gauss_mean = m_theta_gauss_mean;
     const auto theta_gauss_var = m_theta_gauss_var;
-    const auto deltaT = m_deltaT;
+    const auto delta_t = m_delta_t;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -311,7 +311,7 @@ void ABLFieldInit::perturb_temperature(
                 const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                 if (z < theta_cutoff_height) {
                     theta(i, j, k) =
-                        deltaT * amrex::RandomNormal(
+                        delta_t * amrex::RandomNormal(
                                      theta_gauss_mean, theta_gauss_var, engine);
                 }
             });

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -310,9 +310,9 @@ void ABLFieldInit::perturb_temperature(
                     const amrex::RandomEngine& engine) noexcept {
                 const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                 if (z < theta_cutoff_height) {
-                    theta(i, j, k) =
-                        delta_t * amrex::RandomNormal(
-                                     theta_gauss_mean, theta_gauss_var, engine);
+                    theta(i, j, k) = delta_t * amrex::RandomNormal(
+                                                   theta_gauss_mean,
+                                                   theta_gauss_var, engine);
                 }
             });
     }

--- a/amr-wind/wind_energy/ABLMesoscaleForcing.H
+++ b/amr-wind/wind_energy/ABLMesoscaleForcing.H
@@ -15,9 +15,9 @@ class ABLMesoscaleForcing
 public:
     ABLMesoscaleForcing(const CFDSim& sim, const std::string& identifier);
 
-    void indirectForcingInit();
+    void indirect_forcing_init();
 
-    static void invertMat(
+    static void invert_mat(
         const amrex::Array2D<amrex::Real, 0, 3, 0, 3>& m,
         amrex::Array2D<amrex::Real, 0, 3, 0, 3>& im);
 
@@ -73,19 +73,19 @@ protected:
     //
     // weighting profile manipulation
     //
-    void setTransitionWeighting(); // will override weighting profile
+    void set_transition_weighting(); // will override weighting profile
     void
-    updateWeights(); // interpolate current profile to planar averaging heights
+    update_weights(); // interpolate current profile to planar averaging heights
 
     //
     // forcing profile manipulation
     //
-    bool haveForcingTransition()
+    bool have_forcing_transition()
     {
         return (amrex::toLower(m_forcing_transition) != "none");
     }
 
-    bool forcingToConstant()
+    bool forcing_to_constant()
     {
         // - check if m_forcing_transition ends with "Constant"
         if (m_forcing_transition.length() < 8) {
@@ -99,13 +99,13 @@ protected:
     // - slope varies linearly from the actual gradient of the forcing profile
     // at m_transition_height
     //   to 0 at (m_transition_height + m_transition_thicnkess)
-    void constantForcingTransition(amrex::Vector<amrex::Real>& error);
+    void constant_forcing_transition(amrex::Vector<amrex::Real>& error);
 
     // - blend between a lower and upper forcing profile; the blending fraction
     // is assumed to be
     //   equal to W(z), but this is not a requirement; W=1 and W=0 correspond to
     //   the lower and upper profiles, respectively
-    void blendForcings(
+    void blend_forcings(
         const amrex::Vector<amrex::Real>& lower,
         const amrex::Vector<amrex::Real>& upper,
         amrex::Vector<amrex::Real>& error);

--- a/amr-wind/wind_energy/ABLMesoscaleForcing.cpp
+++ b/amr-wind/wind_energy/ABLMesoscaleForcing.cpp
@@ -42,7 +42,7 @@ ABLMesoscaleForcing::ABLMesoscaleForcing(
             m_user_specified_weighting = true;
         }
 
-        if (!haveForcingTransition()) {
+        if (!have_forcing_transition()) {
             if (!m_user_specified_weighting) {
                 // default is to have uniform weighting throughout
                 amrex::Print()
@@ -64,7 +64,7 @@ ABLMesoscaleForcing::ABLMesoscaleForcing(
                                << m_transition_height + m_transition_thickness
                                << std::endl;
                 // set weighting profile
-                setTransitionWeighting();
+                set_transition_weighting();
             } else {
                 // expect to read transition_height history in netCDF input file
                 // and the weighting profile will need to be updated every step
@@ -83,7 +83,7 @@ ABLMesoscaleForcing::ABLMesoscaleForcing(
     } // if forcing scheme is "indirect"
 }
 
-void ABLMesoscaleForcing::setTransitionWeighting()
+void ABLMesoscaleForcing::set_transition_weighting()
 {
     amrex::Real zmin = m_mesh.Geom(0).ProbLo(m_axis);
     amrex::Real zmax = m_mesh.Geom(0).ProbHi(m_axis);
@@ -105,7 +105,7 @@ void ABLMesoscaleForcing::setTransitionWeighting()
     }
 }
 
-void ABLMesoscaleForcing::updateWeights()
+void ABLMesoscaleForcing::update_weights()
 {
     amrex::Print() << "Updating weights" << std::endl;
 
@@ -114,7 +114,7 @@ void ABLMesoscaleForcing::updateWeights()
             interp::linear(m_weighting_heights, m_weighting_values, m_zht[i]);
     }
 
-    if (haveForcingTransition()) {
+    if (have_forcing_transition()) {
         // note the blending weights will differ from the regression weights if
         // a user-specified weighting profile is specified
         for (int i = 0; i < m_nht; ++i) {
@@ -124,7 +124,7 @@ void ABLMesoscaleForcing::updateWeights()
     }
 }
 
-void ABLMesoscaleForcing::indirectForcingInit()
+void ABLMesoscaleForcing::indirect_forcing_init()
 {
     if (m_W.empty()) {
         // Will be here for:
@@ -134,12 +134,12 @@ void ABLMesoscaleForcing::indirectForcingInit()
         amrex::Print() << "Initializing indirect forcing" << std::endl;
         m_W.resize(m_nht);
         m_blend.resize(m_nht);
-        updateWeights();
-    } else if (haveForcingTransition()) {
+        update_weights();
+    } else if (have_forcing_transition()) {
         // Will be here for:
         // - partial profile assim w/ variable transition height
         amrex::Print() << "Reinitializing indirect forcing" << std::endl;
-        updateWeights();
+        update_weights();
     } else {
         amrex::Print() << "Should not be reinitializing indirect forcing!"
                        << std::endl;
@@ -165,10 +165,10 @@ void ABLMesoscaleForcing::indirectForcingInit()
         }
     }
     // Invert the matrix Z^T W Z
-    invertMat(zTz, m_im_zTz);
+    invert_mat(zTz, m_im_zTz);
 }
 
-void ABLMesoscaleForcing::invertMat(
+void ABLMesoscaleForcing::invert_mat(
     const amrex::Array2D<amrex::Real, 0, 3, 0, 3>& m,
     // cppcheck-suppress constParameterReference
     amrex::Array2D<amrex::Real, 0, 3, 0, 3>& im)
@@ -217,7 +217,7 @@ void ABLMesoscaleForcing::invertMat(
     im(3, 3) = det * (m(0, 0) * A1212 - m(0, 1) * A0212 + m(0, 2) * A0112);
 }
 
-void ABLMesoscaleForcing::constantForcingTransition(
+void ABLMesoscaleForcing::constant_forcing_transition(
     amrex::Vector<amrex::Real>& error)
 {
     // based on SOWFA6/src/ABLForcing/drivingForce/drivingForce.C
@@ -274,7 +274,7 @@ void ABLMesoscaleForcing::constantForcingTransition(
     }
 }
 
-void ABLMesoscaleForcing::blendForcings(
+void ABLMesoscaleForcing::blend_forcings(
     const amrex::Vector<amrex::Real>& lower, // W=1
     const amrex::Vector<amrex::Real>& upper, // W=0
     amrex::Vector<amrex::Real>& error)

--- a/amr-wind/wind_energy/ABLModulatedPowerLaw.H
+++ b/amr-wind/wind_energy/ABLModulatedPowerLaw.H
@@ -76,7 +76,7 @@ private:
     amrex::Gpu::DeviceVector<amrex::Real> m_thht_d;
     amrex::Gpu::DeviceVector<amrex::Real> m_thvv_d;
 
-    amrex::Real m_deltaT{0.8};
+    amrex::Real m_delta_t{0.8};
     amrex::Real m_theta_cutoff_height{250.0};
     amrex::Real m_theta_gauss_mean{0.0};
     amrex::Real m_theta_gauss_var{1.0};

--- a/amr-wind/wind_energy/ABLModulatedPowerLaw.cpp
+++ b/amr-wind/wind_energy/ABLModulatedPowerLaw.cpp
@@ -279,8 +279,8 @@ void ABLModulatedPowerLaw::set_temperature(
 
                     if (z < theta_cutoff_height) {
                         arr(i, j, k) += delta_t * amrex::RandomNormal(
-                                                     theta_gauss_mean,
-                                                     theta_gauss_var, engine);
+                                                      theta_gauss_mean,
+                                                      theta_gauss_var, engine);
                     }
                 });
         }

--- a/amr-wind/wind_energy/ABLModulatedPowerLaw.cpp
+++ b/amr-wind/wind_energy/ABLModulatedPowerLaw.cpp
@@ -45,7 +45,7 @@ ABLModulatedPowerLaw::ABLModulatedPowerLaw(CFDSim& sim)
     pp.query("stop_time", m_stop_time);
     pp.query("degrees_per_second", m_degrees_per_sec);
 
-    pp.query("deltaT", m_deltaT);
+    pp.query("delta_t", m_delta_t);
     pp.query("theta_cutoff_height", m_theta_cutoff_height);
     pp.query("theta_gauss_mean", m_theta_gauss_mean);
     pp.query("theta_gauss_var", m_theta_gauss_var);
@@ -96,7 +96,7 @@ void ABLModulatedPowerLaw::pre_advance_work()
 
     if (m_time.current_time() > m_start_time &&
         m_time.current_time() < m_stop_time) {
-        m_wind_direction -= m_degrees_per_sec * m_time.deltaT();
+        m_wind_direction -= m_degrees_per_sec * m_time.delta_t();
     }
     const amrex::Real wind_direction = -m_wind_direction + 270.0;
     const amrex::Real wind_direction_radian = utils::radians(wind_direction);
@@ -222,7 +222,7 @@ void ABLModulatedPowerLaw::set_temperature(
 
     BL_PROFILE("amr-wind::ABLModulatedPowerLaw::set_temperature");
 
-    const amrex::Real deltaT = m_deltaT;
+    const amrex::Real delta_t = m_delta_t;
     const amrex::Real theta_cutoff_height = m_theta_cutoff_height;
     const amrex::Real theta_gauss_mean = m_theta_gauss_mean;
     const amrex::Real theta_gauss_var = m_theta_gauss_var;
@@ -278,7 +278,7 @@ void ABLModulatedPowerLaw::set_temperature(
                     arr(i, j, k) = theta;
 
                     if (z < theta_cutoff_height) {
-                        arr(i, j, k) += deltaT * amrex::RandomNormal(
+                        arr(i, j, k) += delta_t * amrex::RandomNormal(
                                                      theta_gauss_mean,
                                                      theta_gauss_var, engine);
                     }

--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -664,7 +664,7 @@ void ABLStats::write_netcdf()
             // Solve for diffusion term using other terms
             calc_tke_diffusion(
                 *tke_diffusion, tke_buoy_prod, tke_shear_prod, tke_dissip,
-                m_sim.time().deltaT());
+                m_sim.time().delta_t());
             {
                 FieldPlaneAveraging pa_tke_buoy_prod(
                     tke_dissip, m_sim.time(), m_normal_dir);

--- a/amr-wind/wind_energy/ABLWallFunction.cpp
+++ b/amr-wind/wind_energy/ABLWallFunction.cpp
@@ -127,8 +127,8 @@ void ABLWallFunction::update_umean(
         m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
         m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
         m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
-        m_mo.Su_mean = vpa.line_Su_average_interpolated(m_mo.zref);
-        m_mo.Sv_mean = vpa.line_Sv_average_interpolated(m_mo.zref);
+        m_mo.Su_mean = vpa.line_su_average_interpolated(m_mo.zref);
+        m_mo.Sv_mean = vpa.line_sv_average_interpolated(m_mo.zref);
         m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
     }
 

--- a/amr-wind/wind_energy/actuator/FLLC.H
+++ b/amr-wind/wind_energy/actuator/FLLC.H
@@ -53,7 +53,7 @@ struct FLLCData
  * @param pp Parser
  * @param data Data to be populated from parser
  */
-void FLLCParse(const utils::ActParser& pp, FLLCData& data);
+void fllc_parse(const utils::ActParser& pp, FLLCData& data);
 
 /**
  * @brief Initialize FLLC data structure. This should be called at the end of
@@ -63,7 +63,7 @@ void FLLCParse(const utils::ActParser& pp, FLLCData& data);
  * @param view Component view that has references to the grid data
  * @param eps_chord epsilon chord
  */
-void FLLCInit(
+void fllc_init(
     FLLCData& data, const ComponentView& view, const amrex::Real eps_chord);
 
 } // namespace amr_wind::actuator

--- a/amr-wind/wind_energy/actuator/FLLC.cpp
+++ b/amr-wind/wind_energy/actuator/FLLC.cpp
@@ -3,7 +3,7 @@
 
 namespace amr_wind::actuator {
 
-void FLLCInit(
+void fllc_init(
     FLLCData& data, const ComponentView& view, const amrex::Real eps_chord)
 {
 
@@ -105,7 +105,7 @@ void FLLCInit(
     data.initialized = true;
 }
 
-void FLLCParse(const utils::ActParser& pp, FLLCData& data)
+void fllc_parse(const utils::ActParser& pp, FLLCData& data)
 {
     pp.query("epsilon", data.epsilon);
     pp.query("fllc_relaxation_factor", data.relaxation_factor);

--- a/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/disk_ops.cpp
@@ -207,8 +207,8 @@ void optional_parameters(DiskBaseData& meta, const utils::ActParser& pp)
     // yawing
     const auto east = get_east_orientation();
 
-    auto normalRotOp = vs::Tensor::I();
-    auto sampleRotOp = vs::Tensor::I();
+    auto normalRotOp = vs::Tensor::identity();
+    auto sampleRotOp = vs::Tensor::identity();
 
     if (pp.contains("tilt")) {
         amrex::Real tilt;

--- a/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/fast/FastIface.cpp
@@ -66,7 +66,7 @@ void FastIface::parse_inputs(
         !time.adaptive_timestep(),
         "Adaptive time-stepping not supported when OpenFAST is enabled");
 
-    m_dt_cfd = time.deltaT();
+    m_dt_cfd = time.delta_t();
 
     // Set OpenFAST end time to be at least as long as the CFD time. User
     // can choose a longer duration in input file.
@@ -74,7 +74,7 @@ void FastIface::parse_inputs(
                                   ? time.stop_time()
                                   : std::numeric_limits<amrex::Real>::max();
     const amrex::Real stop2 = time.stop_time_index() > 0
-                                  ? time.stop_time_index() * time.deltaT()
+                                  ? time.stop_time_index() * time.delta_t()
                                   : std::numeric_limits<amrex::Real>::max();
     const amrex::Real cfd_stop = amrex::min(stop1, stop2);
     m_stop_time = cfd_stop;

--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -41,7 +41,7 @@ struct ReadInputsOp<TurbineFast, SrcTrait>
         tf.num_blades = tdata.num_blades;
         tf.num_pts_blade = tdata.num_pts_blade;
         tf.num_pts_tower = tdata.num_pts_tower;
-        tf.dt_cfd = data.sim().time().deltaT();
+        tf.dt_cfd = data.sim().time().delta_t();
 
         pp.get("openfast_start_time", tf.start_time);
         pp.get("openfast_stop_time", tf.stop_time);
@@ -410,7 +410,7 @@ struct InitDataOp<TurbineFast, SrcTrait>
                                       ? time.stop_time()
                                       : std::numeric_limits<amrex::Real>::max();
         const amrex::Real stop2 = time.stop_time_index() > -1
-                                      ? time.stop_time_index() * time.deltaT()
+                                      ? time.stop_time_index() * time.delta_t()
                                       : std::numeric_limits<amrex::Real>::max();
         const amrex::Real cfd_stop = amrex::min(stop1, stop2);
         const amrex::Real cfd_start = time.current_time();
@@ -520,7 +520,7 @@ struct ComputeForceOp<TurbineFast, SrcTrait>
             for (int i = 0; i < tdata.num_blades; ++i) {
                 if (!(tdata.fllc[i].initialized) &&
                     (time.current_time() > tdata.fllc[i].fllc_start_time)) {
-                    FLLCInit(
+                    fllc_init(
                         tdata.fllc[i], tdata.blades[i], tdata.eps_chord[0]);
                 }
             }

--- a/amr-wind/wind_energy/actuator/turbine/turbine_utils.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/turbine_utils.cpp
@@ -34,7 +34,7 @@ void read_inputs(
     if (use_fllc) {
         for (int i = 0; i < tdata.num_blades; ++i) {
             tdata.fllc.emplace_back();
-            FLLCParse(pp, tdata.fllc.back());
+            fllc_parse(pp, tdata.fllc.back());
         }
     }
 

--- a/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/fixed_wing_ops.H
@@ -86,7 +86,7 @@ struct ReadInputsOp<FixedWing, ActSrcLine>
         }
         if (use_fllc) {
             wdata.fllc = std::make_unique<FLLCData>();
-            FLLCParse(pp, *(wdata.fllc));
+            fllc_parse(pp, *(wdata.fllc));
         }
 
         if (!pp.contains("epsilon") && !pp.contains("epsilon_chord")) {

--- a/amr-wind/wind_energy/actuator/wing/wing_ops.H
+++ b/amr-wind/wind_energy/actuator/wing/wing_ops.H
@@ -244,7 +244,7 @@ struct ComputeForceOp<
                 wdata.component_view =
                     amr_wind::actuator::wing::make_component_view<ActTrait>(
                         data);
-                FLLCInit(
+                fllc_init(
                     *(wdata.fllc.get()), wdata.component_view,
                     wdata.epsilon_chord[0]);
             }

--- a/tools/utilities/coarsen-chkpt/CoarsenCheckpt.cpp
+++ b/tools/utilities/coarsen-chkpt/CoarsenCheckpt.cpp
@@ -104,10 +104,10 @@ void CoarsenCheckpt::read_chkpt_add_baselevel()
     is >> dt_restart;
     GotoNextLine(is);
 
-    is >> sim().time().deltaTNm1();
+    is >> sim().time().delta_t_nm1();
     GotoNextLine(is);
 
-    is >> sim().time().deltaTNm2();
+    is >> sim().time().delta_t_nm2();
     GotoNextLine(is);
 
     // Low coordinates of domain bounding box

--- a/unit_tests/core/test_simtime.cpp
+++ b/unit_tests/core/test_simtime.cpp
@@ -49,15 +49,15 @@ TEST_F(SimTimeTest, init)
     // Check that the timestep size during initialization respects the shrink
     // value
     time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
-    EXPECT_NEAR(time.deltaT(), 0.1 * dt_new, tol);
-    const double first_dt = time.deltaT();
+    EXPECT_NEAR(time.delta_t(), 0.1 * dt_new, tol);
+    const double first_dt = time.delta_t();
 
     bool stop_sim = time.new_timestep();
     EXPECT_TRUE(stop_sim);
     // Check that the timestep growth is not greater than 10% of the last
     // timestep
     time.set_current_cfl(cur_cfl * 0.5, 0.0, 0.0);
-    EXPECT_NEAR(time.deltaT(), 1.1 * first_dt, tol);
+    EXPECT_NEAR(time.delta_t(), 1.1 * first_dt, tol);
 }
 
 TEST_F(SimTimeTest, time_loop)

--- a/unit_tests/equation_systems/test_icns_gravityforcing.cpp
+++ b/unit_tests/equation_systems/test_icns_gravityforcing.cpp
@@ -22,7 +22,7 @@ void init_density(amr_wind::Field& density, const int k_thresh = -3)
     }
 }
 
-amrex::Real get_Fgz_sum(amr_wind::Field& src_term)
+amrex::Real get_fgz_sum(amr_wind::Field& src_term)
 {
     amrex::Real Fgz_sum = 0.0;
 
@@ -46,7 +46,7 @@ amrex::Real get_Fgz_sum(amr_wind::Field& src_term)
     return Fgz_sum;
 }
 
-void Fgtest_kernel(
+void fgtest_kernel(
     const amrex::Real Fz_ref,
     const int ncells,
     const int nz,
@@ -80,7 +80,7 @@ void Fgtest_kernel(
     my_incflo.icns().compute_source_term(fstate);
 
     // Check forcing average value
-    const amrex::Real Fz_avg = get_Fgz_sum(Fg_field) / ncells;
+    const amrex::Real Fz_avg = get_fgz_sum(Fg_field) / ncells;
     EXPECT_NEAR(Fz_ref, Fz_avg, 1e-8);
 }
 
@@ -144,7 +144,7 @@ TEST_F(GravityForcingTest, full_term_u)
     // Expected average gravity term
     amrex::Real Fg = -5.0;
     // Test with ordinary gravity term (rho not included)
-    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
+    fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
 }
 
 TEST_F(GravityForcingTest, full_term_rhou)
@@ -169,7 +169,7 @@ TEST_F(GravityForcingTest, full_term_rhou)
     }
     Fg *= fac / m_nz;
     // Test with ordinary gravity term (rho included)
-    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::New);
+    fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::New);
 }
 
 TEST_F(GravityForcingTest, perturb_const)
@@ -190,7 +190,7 @@ TEST_F(GravityForcingTest, perturb_const)
     // Expected average gravity term
     amrex::Real Fg = (1.0 - rho_ref) * gz / 1.0;
     // Test with ordinary gravity term (rho not multiplied)
-    Fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
+    fgtest_kernel(Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::Old);
 }
 
 TEST_F(GravityForcingTest, perturb_field)
@@ -210,7 +210,7 @@ TEST_F(GravityForcingTest, perturb_field)
     }
     Fg *= fac / m_nz;
     // Test with ordinary gravity term (rho included)
-    Fgtest_kernel(
+    fgtest_kernel(
         Fg, m_nx * m_ny * m_nz, m_nz, amr_wind::FieldState::New, true);
 }
 

--- a/unit_tests/multiphase/test_vof_BCs.cpp
+++ b/unit_tests/multiphase/test_vof_BCs.cpp
@@ -165,7 +165,7 @@ protected:
     }
 
     void
-    testing_BC_coorddir(const int option, const int dir, const amrex::Real tol)
+    testing_bc_coorddir(const int option, const int dir, const amrex::Real tol)
     {
 
         // Get string version of direction
@@ -332,9 +332,9 @@ protected:
 constexpr double tol1 = 1.0e-15;
 constexpr double tol2 = 6.0e-2;
 
-TEST_F(VOFBCTest, dirichletX) { testing_BC_coorddir(1, 0, tol1); }
-TEST_F(VOFBCTest, slipwallY) { testing_BC_coorddir(2, 1, tol2); }
-TEST_F(VOFBCTest, noslipwallZ) { testing_BC_coorddir(3, 2, tol1); }
-TEST_F(VOFBCTest, pressureX) { testing_BC_coorddir(4, 0, tol1); }
+TEST_F(VOFBCTest, dirichletX) { testing_bc_coorddir(1, 0, tol1); }
+TEST_F(VOFBCTest, slipwallY) { testing_bc_coorddir(2, 1, tol2); }
+TEST_F(VOFBCTest, noslipwallZ) { testing_bc_coorddir(3, 2, tol1); }
+TEST_F(VOFBCTest, pressureX) { testing_bc_coorddir(4, 0, tol1); }
 
 } // namespace amr_wind_tests

--- a/unit_tests/ocean_waves/test_relaxation_zones.cpp
+++ b/unit_tests/ocean_waves/test_relaxation_zones.cpp
@@ -111,7 +111,7 @@ void apply_relaxation_zone_field(
                         probhi[0]);
                     if (x <= problo[0] + gen_length) {
                         const amrex::Real Gamma =
-                            amr_wind::ocean_waves::utils::Gamma_generate(
+                            amr_wind::ocean_waves::utils::gamma_generate(
                                 x - problo[0], gen_length);
                         comp_arr(i, j, k) = targ_arr(i, j, k) * (1. - Gamma) +
                                             comp_arr(i, j, k) * Gamma;

--- a/unit_tests/offshore_wind/test_abloffshore_src.cpp
+++ b/unit_tests/offshore_wind/test_abloffshore_src.cpp
@@ -122,7 +122,7 @@ TEST_F(ABLOffshoreMeshTest, abl_forcing)
         auto& time = sim().time();
         time.new_timestep();
         time.set_current_cfl(2.0, 0.0, 0.0);
-        EXPECT_NEAR(time.deltaT(), 0.1, tol);
+        EXPECT_NEAR(time.delta_t(), 0.1, tol);
 
         src_term.setVal(0.0);
         abl_forcing.set_mean_velocities(10.0, 5.0);
@@ -141,7 +141,7 @@ TEST_F(ABLOffshoreMeshTest, abl_forcing)
 
         // Targets are U = (20.0, 10.0, 0.0) set in initial conditions
         // Means (set above) V = (10.0, 5.0, 0.0)
-        // deltaT (set above) dt = 0.1
+        // delta_t (set above) dt = 0.1
         const amrex::Array<amrex::Real, AMREX_SPACEDIM> golds{
             {100.0, 50.0, 0.0}};
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {

--- a/unit_tests/turbulence/test_turbulence_LES_bc.cpp
+++ b/unit_tests/turbulence/test_turbulence_LES_bc.cpp
@@ -122,7 +122,7 @@ protected:
             // zlo is defined in each case
         }
     }
-    void OneEqKsgs_setup_params() const
+    void one_eq_ksgs_setup_params() const
     {
         {
             amrex::ParmParse pp("turbulence");
@@ -235,7 +235,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_noslip)
         amrex::ParmParse pp("zlo");
         pp.add("type", (std::string) "no_slip_wall");
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     test_calls_body();
     auto& muturb = sim().repo().get_field("mu_turb");
 
@@ -278,7 +278,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_slip)
         amrex::ParmParse pp("zlo");
         pp.add("type", (std::string) "slip_wall");
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     test_calls_body();
     auto& muturb = sim().repo().get_field("mu_turb");
 
@@ -322,7 +322,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_wallmodel)
         amrex::ParmParse pp("incflo");
         pp.add("diffusion_type", 0);
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     const bool do_postsolve = true;
     test_calls_body(do_postsolve);
     auto& muturb = sim().repo().get_field("mu_turb");
@@ -367,7 +367,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_wallmodel_failnofillpatch)
         amrex::ParmParse pp("incflo");
         pp.add("diffusion_type", 0);
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     const bool do_postsolve = false;
     test_calls_body(do_postsolve);
     auto& muturb = sim().repo().get_field("mu_turb");
@@ -423,7 +423,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_zerogradient)
         amrex::ParmParse pp("zlo");
         pp.add("type", (std::string) "zero_gradient");
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     test_calls_body();
     auto& muturb = sim().repo().get_field("mu_turb");
 
@@ -464,7 +464,7 @@ TEST_F(TurbLESTestBC, test_1eqKsgs_symmetricwall)
         amrex::ParmParse pp("zlo");
         pp.add("type", (std::string) "symmetric_wall");
     }
-    OneEqKsgs_setup_params();
+    one_eq_ksgs_setup_params();
     test_calls_body();
     auto& muturb = sim().repo().get_field("mu_turb");
 

--- a/unit_tests/utilities/test_free_surface.cpp
+++ b/unit_tests/utilities/test_free_surface.cpp
@@ -319,7 +319,7 @@ protected:
             pp.addarr("is_periodic", amrex::Vector<int>{{1, 1, 0}});
         }
     }
-    void setup_grid0D(int ninst, const std::string& fsname)
+    void setup_grid_0d(int ninst, const std::string& fsname)
     {
         amrex::ParmParse pp(fsname);
         pp.add("output_frequency", 1);
@@ -328,8 +328,8 @@ protected:
         pp.addarr("start", m_pt_coord);
         pp.addarr("end", m_pt_coord);
     }
-    void setup_grid0D(int ninst) { setup_grid0D(ninst, "freesurface"); }
-    void setup_grid2D(int ninst)
+    void setup_grid_0d(int ninst) { setup_grid_0d(ninst, "freesurface"); }
+    void setup_grid_2d(int ninst)
     {
         amrex::ParmParse pp("freesurface");
         pp.add("output_frequency", 1);
@@ -338,7 +338,7 @@ protected:
         pp.addarr("start", m_pl_start);
         pp.addarr("end", m_pl_end);
     }
-    void setup_grid2D_narrow()
+    void setup_grid_2d_narrow()
     {
         amrex::ParmParse pp("freesurface");
         pp.add("output_frequency", 1);
@@ -378,7 +378,7 @@ TEST_F(FreeSurfaceTest, point)
     initialize_mesh();
     auto& repo = sim().repo();
     auto& vof = repo.declare_field("vof", 1, 2);
-    setup_grid0D(1);
+    setup_grid_0d(1);
 
     init_vof(vof, m_water_level0);
     auto& m_sim = sim();
@@ -404,7 +404,7 @@ TEST_F(FreeSurfaceTest, plane)
     initialize_mesh();
     auto& repo = sim().repo();
     auto& vof = repo.declare_field("vof", 1, 2);
-    setup_grid2D(1);
+    setup_grid_2d(1);
 
     init_vof(vof, m_water_level1);
     auto& m_sim = sim();
@@ -425,7 +425,7 @@ TEST_F(FreeSurfaceTest, multivalued)
     initialize_mesh();
     auto& repo = sim().repo();
     auto& vof = repo.declare_field("vof", 1, 2);
-    setup_grid2D(3);
+    setup_grid_2d(3);
 
     // Parameters of water level
     amrex::Real wl0 = m_probhi[2] * 2 / 3;
@@ -456,7 +456,7 @@ TEST_F(FreeSurfaceTest, sloped)
     initialize_mesh();
     auto& repo = sim().repo();
     auto& vof = repo.declare_field("vof", 1, 2);
-    setup_grid2D_narrow();
+    setup_grid_2d_narrow();
 
     amrex::Real slope = 0.125;
     amrex::Real domain_l = m_probhi[0];
@@ -490,10 +490,10 @@ TEST_F(FreeSurfaceTest, multisampler)
     auto& vof = repo.declare_field("vof", 1, 2);
 
     // Set up parameters for one sampler
-    setup_grid0D(1, "freesurface0");
+    setup_grid_0d(1, "freesurface0");
 
     // Set up parameters for another sampler
-    setup_grid2D_narrow();
+    setup_grid_2d_narrow();
 
     // Initialize VOF distribution and access sim
     init_vof(vof, m_water_level1);
@@ -517,7 +517,7 @@ TEST_F(FreeSurfaceTest, regrid)
     // Set up parameters for refinement
     setup_fieldrefinement();
     // Set up parameters for sampler
-    setup_grid2D(1);
+    setup_grid_2d(1);
     // Create mesh and initialize
     reset_prob_domain();
     auto rmesh = FSRefineMesh();

--- a/unit_tests/wind_energy/actuator/test_FLLC.cpp
+++ b/unit_tests/wind_energy/actuator/test_FLLC.cpp
@@ -24,7 +24,7 @@ TEST(TestFLLCData, data_initializes_with_cviews)
 
     data.nonuniform = false;
 
-    FLLCInit(data, view, 1.0);
+    fllc_init(data, view, 1.0);
 
     ASSERT_EQ(num_points, data.les_velocity.size());
     ASSERT_EQ(num_points, data.optimal_velocity.size());
@@ -58,7 +58,7 @@ TEST(TestFLLCData, data_initializes_with_cviews_nonuniform)
         view.chord[ip] = 1.;
     }
 
-    FLLCInit(data, view, 1.0);
+    fllc_init(data, view, 1.0);
 
     const int npts_r = static_cast<int>(data.nonuniform_r.size());
     const int npts_dr = static_cast<int>(data.nonuniform_dr.size());

--- a/unit_tests/wind_energy/actuator/test_actuator_fixed_wing.cpp
+++ b/unit_tests/wind_energy/actuator/test_actuator_fixed_wing.cpp
@@ -76,7 +76,7 @@ protected:
         pp_f.addarr("end", amrex::Vector<amrex::Real>{0.0, 4.0, 0.0});
     }
 
-    void pitching_wing_2D_setup()
+    void pitching_wing_2d_setup()
     {
         amrex::ParmParse pp_a("Actuator");
         pp_a.add("labels", (std::string) "F1");
@@ -286,7 +286,7 @@ TEST_F(ActFixedWingTest, pitch_table_2D)
     write_airfoil_file(m_afname);
     write_pitch_file(m_ptname);
     initialize_domain();
-    pitching_wing_2D_setup();
+    pitching_wing_2d_setup();
     ActPhysicsTest act(sim());
     act.pre_init_actions();
     act.post_init_actions();

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -93,7 +93,7 @@ TEST_F(ABLMeshTest, abl_forcing)
         auto& time = sim().time();
         time.new_timestep();
         time.set_current_cfl(2.0, 0.0, 0.0);
-        EXPECT_NEAR(time.deltaT(), 0.1, tol);
+        EXPECT_NEAR(time.delta_t(), 0.1, tol);
 
         src_term.setVal(0.0);
         abl_forcing.set_mean_velocities(10.0, 5.0);
@@ -106,7 +106,7 @@ TEST_F(ABLMeshTest, abl_forcing)
 
         // Targets are U = (20.0, 10.0, 0.0) set in initial conditions
         // Means (set above) V = (10.0, 5.0, 0.0)
-        // deltaT (set above) dt = 0.1
+        // delta_t (set above) dt = 0.1
         const amrex::Array<amrex::Real, AMREX_SPACEDIM> golds{
             {100.0, 50.0, 0.0}};
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {


### PR DESCRIPTION
## Summary

Enforcing clang-tidy readability identifier naming for functions. You will notice that a bunch of function names are allowed/excluded from the check. These correspond to amrex conventions and I thought best to leave them be.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
