### PR TITLE
Move GPU synchronize outside of level loop

### DIFF
--- a/amr-wind/utilities/MultiLevelVector.cpp
+++ b/amr-wind/utilities/MultiLevelVector.cpp
@@ -44,7 +44,7 @@ void MultiLevelVector::copy_to_field(Field& fld)
                 const int idx = (axis == 0) ? i : ((axis == 1) ? j : k);
                 farrs[nbx](i, j, k, 0) = d_ptr[idx];
             });
-        amrex::Gpu::synchronize();
     }
+    amrex::Gpu::synchronize();
 }
 } // namespace amr_wind


### PR DESCRIPTION
## Summary

Super simple change, and this was the only instance of this mistake I found. The synchronize call does not need to be inside the level loop for this function.
