### PR TITLE
only modify velocity of water during ocean wave initialization

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -73,7 +73,7 @@ struct InitDataOp<LinearWaves>
 
                         phi(i, j, k) = eta - zc;
 
-                        if (phi(i, j, k) >= 0) {
+                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *
                                 std::cosh(
@@ -87,10 +87,6 @@ struct InitDataOp<LinearWaves>
                                     wave_number * (zc - zsl + water_depth)) /
                                 std::sinh(wave_number * water_depth) *
                                 std::sin(phase);
-                        } else {
-                            vel(i, j, k, 0) = 0.;
-                            vel(i, j, k, 1) = 0.;
-                            vel(i, j, k, 2) = 0.;
                         }
                     });
 
@@ -99,9 +95,11 @@ struct InitDataOp<LinearWaves>
                     gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zsl - z;
-                        vel(i, j, k, 0) = 0.0;
-                        vel(i, j, k, 1) = 0.0;
-                        vel(i, j, k, 2) = 0.0;
+                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                            vel(i, j, k, 0) = 0.0;
+                            vel(i, j, k, 1) = 0.0;
+                            vel(i, j, k, 2) = 0.0;
+                        }
                     });
             }
         }

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -113,10 +113,6 @@ struct InitDataOp<StokesWaves>
                             vel(i, j, k, 0) = u_w;
                             vel(i, j, k, 1) = v_w;
                             vel(i, j, k, 2) = w_w;
-                        } else {
-                            vel(i, j, k, 0) = 0.;
-                            vel(i, j, k, 1) = 0.;
-                            vel(i, j, k, 2) = 0.;
                         }
                     });
 
@@ -125,9 +121,11 @@ struct InitDataOp<StokesWaves>
                     gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zero_sea_level - z;
-                        vel(i, j, k, 0) = 0.0;
-                        vel(i, j, k, 1) = 0.0;
-                        vel(i, j, k, 2) = 0.0;
+                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                            vel(i, j, k, 0) = 0.0;
+                            vel(i, j, k, 1) = 0.0;
+                            vel(i, j, k, 2) = 0.0;
+                        }
                     });
             }
         }


### PR DESCRIPTION
## Summary

Necessary for ABL + waves simulations. To go with other physics classes, the ocean waves need not overwrite the velocities in the air.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

Issue Number: maybe #1162 
