### PR TITLE
remove diffusion_type from reg tests with no diffusion

### DIFF
--- a/test/test_files/inertial_drop/inertial_drop.inp
+++ b/test/test_files/inertial_drop/inertial_drop.inp
@@ -23,7 +23,6 @@ io.outputs = density velocity vof
 #               PHYSICS                 #
 #.......................................#
 incflo.use_godunov = 1
-incflo.diffusion_type = 2
 incflo.godunov_type = "weno"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0

--- a/test/test_files/sloshing_tank/sloshing_tank.inp
+++ b/test/test_files/sloshing_tank/sloshing_tank.inp
@@ -11,7 +11,6 @@ io.derived_outputs = "components(velocity,0,2)" "components(gp,0,2)"
 
 incflo.use_godunov = 1
 incflo.godunov_type="weno"
-incflo.diffusion_type = 2
 transport.model = TwoPhaseTransport
 transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333

--- a/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
+++ b/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
@@ -25,7 +25,6 @@ incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
 incflo.use_godunov = 1
 incflo.godunov_type="weno"
-incflo.diffusion_type = 2
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0
 transport.viscosity_fluid2=0.0

--- a/test/test_files/vortex_patch_scalar_vel/vortex_patch_scalar_vel.inp
+++ b/test/test_files/vortex_patch_scalar_vel/vortex_patch_scalar_vel.inp
@@ -24,7 +24,6 @@ io.outputs = density velocity vof
 incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
 incflo.use_godunov = 1
-incflo.diffusion_type = 2
 incflo.godunov_type="weno"
 incflo.mflux_type="minmod"
 

--- a/test/test_files/zalesak_disk_godunov/zalesak_disk_godunov.inp
+++ b/test/test_files/zalesak_disk_godunov/zalesak_disk_godunov.inp
@@ -24,7 +24,6 @@ io.outputs = density velocity velocity_mueff vof
 incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
 incflo.use_godunov = 1
-incflo.diffusion_type = 2
 incflo.godunov_type = "weno"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0

--- a/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
+++ b/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
@@ -24,7 +24,6 @@ io.outputs = density velocity vof
 incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
 incflo.use_godunov = 1
-incflo.diffusion_type = 2
 incflo.godunov_type = "weno"
 incflo.mflux_type = "minmod"
 


### PR DESCRIPTION
## Summary

Most of these cases are prescribed flow, which does not include a diffusion term in the momentum equation, and the rest are specified as inviscid and the type of diffusion should be irrelevant.

## Pull request type

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): reg test clarification, no diffs expected

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [X] on CPU <!-- note the OS and compiler -->
