### PR TITLE
Fix num thread omp console print

### DIFF
--- a/amr-wind/utilities/console_io.cpp
+++ b/amr-wind/utilities/console_io.cpp
@@ -143,8 +143,7 @@ void print_banner(MPI_Comm comm, std::ostream& out)
         << "  OpenMP           :: "
 #ifdef AMREX_USE_OMP
         << "ON    (max threads = " << amrex::OpenMP::get_max_threads()
-        << ", num threads = " << amrex::OpenMP::get_num_threads() << ")"
-        << std::endl
+        << ")" << std::endl
 #else
         << "OFF" << std::endl
 #endif


### PR DESCRIPTION
## Summary

Turns out that `get_num_threads()` has the wrong value in the console_io. So let's not use it there.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
