### PR TITLE
Anelastic projection: multiply/divide all components of velocity

### DIFF
--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -334,9 +334,11 @@ void incflo::ApplyProjection(
 
     if (is_anelastic) {
         for (int lev = 0; lev <= finest_level; ++lev) {
-            amrex::Multiply(
-                velocity(lev), (*ref_density)(lev), 0, 0, density[lev]->nComp(),
-                0);
+            for (int idim = 0; idim < velocity.num_comp(); ++idim) {
+                amrex::Multiply(
+                    velocity(lev), (*ref_density)(lev), 0, idim,
+                    density[lev]->nComp(), 0);
+            }
         }
     }
 
@@ -435,9 +437,11 @@ void incflo::ApplyProjection(
 
     if (is_anelastic) {
         for (int lev = 0; lev <= finest_level; ++lev) {
-            amrex::Divide(
-                velocity(lev), (*ref_density)(lev), 0, 0, density[lev]->nComp(),
-                0);
+            for (int idim = 0; idim < velocity.num_comp(); ++idim) {
+                amrex::Divide(
+                    velocity(lev), (*ref_density)(lev), 0, idim,
+                    density[lev]->nComp(), 0);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Found this while working on something else: the anelastic projection is supposed to operate on rho*u, requiring the velocity field to be multiplied by density a priori and divided by density a posteriori. But it looks like only one component of velocity is getting multiplied.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
