### PR TITLE
Make time output precision/format consistent with header in checkpoint files

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/ABLForcing.H
@@ -69,7 +69,7 @@ public:
             std::ofstream outfile;
             // Forces are recorded at n+1/2
             outfile.open(m_force_timetable, std::ios::out | std::ios::app);
-            outfile << std::fixed << std::setprecision(15) << nph_time << "\t"
+            outfile << std::setprecision(17) << nph_time << "\t"
                     << m_abl_forcing[0] << "\t" << m_abl_forcing[1] << "\t"
                     << 0.0 << std::endl;
         }

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -527,7 +527,7 @@ void ABLBoundaryPlane::write_file()
     if (m_out_fmt == "native") {
         if (amrex::ParallelDescriptor::IOProcessor()) {
             std::ofstream oftime(m_time_file, std::ios::out | std::ios::app);
-            oftime << t_step << ' ' << std::fixed << std::setprecision(15)
+            oftime << t_step << ' ' << std::setprecision(17)
                    << time << '\n';
             oftime.close();
         }

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -527,8 +527,7 @@ void ABLBoundaryPlane::write_file()
     if (m_out_fmt == "native") {
         if (amrex::ParallelDescriptor::IOProcessor()) {
             std::ofstream oftime(m_time_file, std::ios::out | std::ios::app);
-            oftime << t_step << ' ' << std::setprecision(17)
-                   << time << '\n';
+            oftime << t_step << ' ' << std::setprecision(17) << time << '\n';
             oftime.close();
         }
 


### PR DESCRIPTION
This may fix #768 . Changing the output precision in `ABLBoundaryPlane` and force time table to be consistent with https://github.com/Exawind/amr-wind/blob/741cb77111da01fe7026512f0a0cfdb3b9072398/amr-wind/utilities/IOManager.cpp#L322

## Summary

<!--- Please provide a one sentence summary of your changes  -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
