### PR TITLE
Bump the clang format lint action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Clone
       uses: actions/checkout@v4
     - name: Check formatting
-      uses: DoozyX/clang-format-lint-action@v0.18
+      uses: DoozyX/clang-format-lint-action@v0.18.1
       with:
         source: './amr-wind ./unit_tests ./tools/utilities'
         exclude: '.'

--- a/amr-wind/utilities/MultiLevelVector.H
+++ b/amr-wind/utilities/MultiLevelVector.H
@@ -22,7 +22,7 @@ namespace amr_wind {
 class MultiLevelVector
 {
 public:
-    MultiLevelVector(const FieldLoc floc = FieldLoc::CELL) : m_floc(floc){};
+    MultiLevelVector(const FieldLoc floc = FieldLoc::CELL) : m_floc(floc) {};
 
     void resize(const int axis, const amrex::Vector<amrex::Geometry>& geom);
 


### PR DESCRIPTION
## Summary

Bump the clang format lint action version to use a fixed LLVM clang-format version.