### PR TITLE
use Hydro routines for edge BCs

### DIFF
--- a/amr-wind/convection/incflo_godunov_ppm.H
+++ b/amr-wind/convection/incflo_godunov_ppm.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_Gpu.H>
 #include <AMReX_BCRec.H>
+#include <hydro_bcs_K.H>
 
 /* This header file contains the inlined __host__ __device__ functions required
    for the scalar advection routines for 3D Godunov. It also contains function
@@ -18,56 +19,18 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void Godunov_trans_xbc(
     const amrex::Array4<const amrex::Real>& s,
     amrex::Real& lo,
     amrex::Real& hi,
-    amrex::Real& /* uedge */,
+    amrex::Real macvel,
     const int bclo,
     const int bchi,
     const int domlo,
     const int domhi)
 {
-    using namespace amrex;
-
-    // Low X
     if (i <= domlo) {
-        if (bclo == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (uedge <= small_vel) ? hi : s(domlo-1,j,k,n);
-            // So here we do something simpler...
-            Real st = s(domlo - 1, j, k, n);
-            lo = st;
-            hi = st;
-        }
-
-        else if (
-            bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-            bclo == BCType::reflect_even) {
-            lo = hi;
-
-        } else if (bclo == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
-    }
-
-    // High X
-    if (i > domhi) {
-        if (bchi == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (uedge >= -small_vel)? lo : s(domhi+1,j,k,n);
-            // So here we do something simpler...
-            Real st = s(domhi + 1, j, k, n);
-            lo = st;
-            hi = st;
-        }
-
-        else if (
-            bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-            bchi == BCType::reflect_even) {
-            hi = lo;
-
-        } else if (bchi == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
+        HydroBC::SetEdgeBCsLo(
+            0, i, j, k, n, s, lo, hi, macvel, bclo, domlo, true);
+    } else if (i > domhi) {
+        HydroBC::SetEdgeBCsHi(
+            0, i, j, k, n, s, lo, hi, macvel, bchi, domhi, true);
     }
 }
 
@@ -79,56 +42,18 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void Godunov_trans_ybc(
     const amrex::Array4<const amrex::Real>& s,
     amrex::Real& lo,
     amrex::Real& hi,
-    amrex::Real /* vedge */,
+    amrex::Real macvel,
     const int bclo,
     const int bchi,
     const int domlo,
     const int domhi)
 {
-    using namespace amrex;
-
-    // Low Y
     if (j <= domlo) {
-        if (bclo == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (vedge <= small_vel) ? hi : s(i,domlo-1,k,n);
-            // So here we do something simpler...
-            Real st = s(i, domlo - 1, k, n);
-            lo = st;
-            hi = st;
-        }
-
-        else if (
-            bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-            bclo == BCType::reflect_even) {
-            lo = hi;
-
-        } else if (bclo == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
-    }
-
-    // High Y
-    if (j > domhi) {
-        if (bchi == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (vedge >= -small_vel)? lo : s(i,domhi+1,k,n);
-            // So here we do something simpler...
-            Real st = s(i, domhi + 1, k, n);
-            lo = st;
-            hi = st;
-        }
-
-        else if (
-            bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-            bchi == BCType::reflect_even) {
-            hi = lo;
-
-        } else if (bchi == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
+        HydroBC::SetEdgeBCsLo(
+            1, i, j, k, n, s, lo, hi, macvel, bclo, domlo, true);
+    } else if (j > domhi) {
+        HydroBC::SetEdgeBCsHi(
+            1, i, j, k, n, s, lo, hi, macvel, bchi, domhi, true);
     }
 }
 
@@ -140,54 +65,18 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void Godunov_trans_zbc(
     const amrex::Array4<const amrex::Real>& s,
     amrex::Real& lo,
     amrex::Real& hi,
-    amrex::Real /* wedge */,
+    amrex::Real macvel,
     const int bclo,
     const int bchi,
     const int domlo,
     const int domhi)
 {
-    using namespace amrex;
-
-    // Low Z
     if (k <= domlo) {
-        if (bclo == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (wedge <= small_vel) ? hi : s(i,j,domlo-1,n);
-            // So here we do something simpler...
-            Real st = s(i, j, domlo - 1, n);
-            lo = st;
-            hi = st;
-        }
-
-        else if (
-            bclo == BCType::foextrap || bclo == BCType::hoextrap ||
-            bclo == BCType::reflect_even) {
-            lo = hi;
-
-        } else if (bclo == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
-    }
-
-    // High Z
-    if (k > domhi) {
-        if (bchi == BCType::ext_dir) {
-            // IAMR does this but it breaks lo/hi symmetry
-            // Real st = (wedge >= -small_vel)? lo : s(i,j,domhi+1,n);
-            // So here we do something simpler...
-            Real st = s(i, j, domhi + 1, n);
-            lo = st;
-            hi = st;
-        } else if (
-            bchi == BCType::foextrap || bchi == BCType::hoextrap ||
-            bchi == BCType::reflect_even) {
-            hi = lo;
-
-        } else if (bchi == BCType::reflect_odd) {
-            hi = 0.;
-            lo = 0.;
-        }
+        HydroBC::SetEdgeBCsLo(
+            2, i, j, k, n, s, lo, hi, macvel, bclo, domlo, true);
+    } else if (k > domhi) {
+        HydroBC::SetEdgeBCsHi(
+            2, i, j, k, n, s, lo, hi, macvel, bchi, domhi, true);
     }
 }
 


### PR DESCRIPTION
## Summary

This code change uses new routines in AMReX-Hydro for setting the edge BCs to be consistent with other parts of the Godunov scheme. By doing this, I also won't have to worry about making the correct changes related to the `direction_dependent` BC for `mass_inflow_outflow` as it is already taken care of in Hydro.

All the ctests are passing but I do notice some small changes in the solution for my inflow-outflow test.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU  (macOS, M3 arch, gcc)

