### PR TITLE
Reduce memory usage of the samplers again

### DIFF
--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.H
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.H
@@ -60,7 +60,7 @@ public:
     /** Determine how the subsampling will be done
      *
      */
-    void update_sampling_locations() override;
+    bool update_sampling_locations() override;
 
     void post_sample_actions() override {};
 

--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.cpp
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.cpp
@@ -259,7 +259,7 @@ void DTUSpinnerSampler::get_turbine_data(const std::string& turbine_label)
 }
 #endif // AMR_WIND_USE_OPENFAST
 
-void DTUSpinnerSampler::update_sampling_locations()
+bool DTUSpinnerSampler::update_sampling_locations()
 {
     BL_PROFILE(
         "amr-wind::Sampling::DTUSpinnerSampler::update_sampling_locations");
@@ -435,6 +435,8 @@ void DTUSpinnerSampler::update_sampling_locations()
     m_last_lidar_center = m_lidar_center;
 
     m_update_count = m_update_count + 1;
+
+    return true;
 }
 
 #ifdef AMR_WIND_USE_NETCDF

--- a/amr-wind/utilities/sampling/FreeSurfaceSampler.H
+++ b/amr-wind/utilities/sampling/FreeSurfaceSampler.H
@@ -27,7 +27,7 @@ public:
     }
 
     //! Find heights associated with 2D sample locations
-    void update_sampling_locations() override;
+    bool update_sampling_locations() override;
 
     //! Redo some of the initialization work when the grid changes
     void post_regrid_actions() override;

--- a/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
+++ b/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
@@ -354,7 +354,7 @@ void FreeSurfaceSampler::sampling_locations(SampleLocType& locs) const
     }
 }
 
-void FreeSurfaceSampler::update_sampling_locations()
+bool FreeSurfaceSampler::update_sampling_locations()
 {
 
     BL_PROFILE("amr-wind::FreeSurfaceSampler::update_sampling_locations");
@@ -525,6 +525,8 @@ void FreeSurfaceSampler::update_sampling_locations()
             dout_ptr[n] = plo0[coorddir];
         });
     }
+
+    return true;
 }
 
 void FreeSurfaceSampler::post_regrid_actions()

--- a/amr-wind/utilities/sampling/LidarSampler.H
+++ b/amr-wind/utilities/sampling/LidarSampler.H
@@ -33,7 +33,7 @@ public:
      *
      *
      */
-    void update_sampling_locations() override;
+    bool update_sampling_locations() override;
 
     void post_sample_actions() override {};
 

--- a/amr-wind/utilities/sampling/LidarSampler.cpp
+++ b/amr-wind/utilities/sampling/LidarSampler.cpp
@@ -60,7 +60,7 @@ void LidarSampler::initialize(const std::string& key)
     check_bounds();
 }
 
-void LidarSampler::update_sampling_locations()
+bool LidarSampler::update_sampling_locations()
 {
 
     amrex::Real time = m_sim.time().current_time();
@@ -84,6 +84,8 @@ void LidarSampler::update_sampling_locations()
     m_end[1] = m_start[1] + m_length * std::sin(current_azimuth) *
                                 std::sin(current_elevation);
     m_end[2] = m_start[2] + m_length * std::cos(current_elevation);
+
+    return true;
 }
 
 #ifdef AMR_WIND_USE_NETCDF

--- a/amr-wind/utilities/sampling/RadarSampler.H
+++ b/amr-wind/utilities/sampling/RadarSampler.H
@@ -47,7 +47,7 @@ public:
 
     //! Populate and return a vector of probe locations to be sampled
     void sampling_locations(SampleLocType& /*locs*/) const override;
-    void update_sampling_locations() override;
+    bool update_sampling_locations() override;
     void cone_axis_locations(SampleLocType& /*locs*/) const;
     void output_locations(SampleLocType& locs) const override
     {

--- a/amr-wind/utilities/sampling/RadarSampler.cpp
+++ b/amr-wind/utilities/sampling/RadarSampler.cpp
@@ -188,7 +188,7 @@ double RadarSampler::determine_current_sweep_angle() const
     }
 }
 
-void RadarSampler::update_sampling_locations()
+bool RadarSampler::update_sampling_locations()
 {
     amrex::Real time = m_sim.time().current_time();
     amrex::Real start_time = m_sim.time().start_time();
@@ -306,6 +306,8 @@ void RadarSampler::update_sampling_locations()
     }
 
     m_radar_iter++;
+
+    return true;
 }
 
 void RadarSampler::new_cone()

--- a/amr-wind/utilities/sampling/SamplerBase.H
+++ b/amr-wind/utilities/sampling/SamplerBase.H
@@ -56,7 +56,7 @@ public:
     virtual void output_locations(SampleLocType&) const = 0;
 
     //! Update the sampling locations
-    virtual void update_sampling_locations() {}
+    virtual bool update_sampling_locations() { return false; }
 
     //! Run actions after sample (useful in interpolated subsampling)
     virtual void post_sample_actions() {}

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -164,10 +164,14 @@ void Sampling::update_sampling_locations()
 {
     BL_PROFILE("amr-wind::Sampling::update_sampling_locations");
 
-    if (std::any_of(m_samplers.begin(), m_samplers.end(), [](const auto& obj) {
-            return obj->update_sampling_locations();
-        })) {
-        update_container();
+    amrex::Vector<bool> updated_position(false);
+    for (const auto& obj : m_samplers) {
+      const bool updated_pos = obj->update_sampling_locations();
+      updated_position.push_back(updated_pos);
+    }
+
+    if (std::any_of(updated_position.begin(), updated_position.end(), [](const auto& v) { return v; })) {
+      update_container();
     }
 }
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -164,7 +164,7 @@ void Sampling::update_sampling_locations()
 {
     BL_PROFILE("amr-wind::Sampling::update_sampling_locations");
 
-    amrex::Vector<bool> updated_position(false);
+    amrex::Vector<bool> updated_position;
     for (const auto& obj : m_samplers) {
         const bool updated_pos = obj->update_sampling_locations();
         updated_position.push_back(updated_pos);

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -164,11 +164,11 @@ void Sampling::update_sampling_locations()
 {
     BL_PROFILE("amr-wind::Sampling::update_sampling_locations");
 
-    for (const auto& obj : m_samplers) {
-        obj->update_sampling_locations();
+    if (std::any_of(m_samplers.begin(), m_samplers.end(), [](const auto& obj) {
+            return obj->update_sampling_locations();
+        })) {
+        update_container();
     }
-
-    update_container();
 }
 
 void Sampling::post_advance_work()

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -166,12 +166,14 @@ void Sampling::update_sampling_locations()
 
     amrex::Vector<bool> updated_position(false);
     for (const auto& obj : m_samplers) {
-      const bool updated_pos = obj->update_sampling_locations();
-      updated_position.push_back(updated_pos);
+        const bool updated_pos = obj->update_sampling_locations();
+        updated_position.push_back(updated_pos);
     }
 
-    if (std::any_of(updated_position.begin(), updated_position.end(), [](const auto& v) { return v; })) {
-      update_container();
+    if (std::any_of(
+            updated_position.begin(), updated_position.end(),
+            [](const auto& v) { return v; })) {
+        update_container();
     }
 }
 

--- a/test/test_files/dam_break_godunov/dam_break_godunov.inp
+++ b/test/test_files/dam_break_godunov/dam_break_godunov.inp
@@ -8,7 +8,7 @@ time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 
 incflo.post_processing        = sampling
-sampling.output_frequency     = 30
+sampling.output_frequency     = 10
 sampling.output_format        = native
 sampling.labels               = fs
 sampling.fields               = velocity


### PR DESCRIPTION
## Summary

Another round of memory optimization for the samplers. It is only necessary to reallocate the container if the positions of the sample points are updated. So this changes it such that if the particles have changed positions, then the container is updated. Otherwise, it skips it. See below for more information.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

This is using the same case I described here: https://github.com/Exawind/amr-wind/issues/1186#issuecomment-2294018942, using 30 planes.

### Main branch (after #1207, my previous optimization)
![memory_30plane_v1](https://github.com/user-attachments/assets/bfc7a768-ae7a-44c3-984e-36f86263b96a)

```
Time spent in InitData():    17.13284979
Time spent in Evolve():      17.09655093
TinyProfiler total time across processes [min...avg...max]: 34.09 ... 34.23 ... 34.25
``` 

### This PR
![memory_30plane_v2](https://github.com/user-attachments/assets/5d79c20c-aa55-4c1d-9b3e-77399608d2b3)

```
Time spent in InitData():    10.87862356
Time spent in Evolve():      4.578913001
TinyProfiler total time across processes [min...avg...max]: 15.3 ... 15.44 ... 15.46
```

### Conclusion

- This PR removes (over 2 time steps), 3 of the 4 huge memory spikes on rank 0.
- Instead of 40GB of memory spike, it is now only a single 10GB memory spike, or a 4x improvement
- We also got a speedup: 4.25X per time step (2X over the total run time, 1.7 for init)

### Next steps:

See if I can remove the memory spike all together by allocating the particles in parallel instead of rank 0 + redistribute. Or maybe I go back to looking at the netcdf path.

Following up on issue #1186 and PR #1207