### PR TITLE
Fix two regression tests by increasing n_error_buf

### DIFF
--- a/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
+++ b/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
@@ -54,7 +54,7 @@ nodal_proj.mg_atol = 1.0e-10
 # Mesh Refinement
 amr.n_cell            = 64 64 4 # Grid cells at coarsest AMRlevel
 amr.blocking_factor = 4
-amr.n_error_buf = 2
+amr.n_error_buf = 4
 
 amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1

--- a/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
+++ b/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
@@ -53,7 +53,7 @@ nodal_proj.mg_atol = 1.0e-10
 # Mesh Refinement
 amr.n_cell            = 64 64 4 # Grid cells at coarsest AMRlevel
 amr.blocking_factor = 4
-amr.n_error_buf = 2
+amr.n_error_buf = 4
 
 amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1


### PR DESCRIPTION
## Summary

This fixes the FPEs that are showing up in debug builds of `inflow_godunov_amr` and `inflow_bds_amr` by making "good grids". You can see the failures here: https://my.cdash.org/tests/195392812 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional information

### Comparison of the grids for `inflow_godunov_amr`. This PR (left), main (right)

You can see that there are only 2 cells on level 1 between level 0 and level 2. 
 
<img width="1080" alt="Screenshot 2024-08-28 at 8 41 13 AM" src="https://github.com/user-attachments/assets/817b277a-6cc4-4d8a-ba0b-27d008c33e5e">


