### PR TITLE
Improve initialization of zalesak case

### DIFF
--- a/amr-wind/physics/multiphase/ZalesakDisk.H
+++ b/amr-wind/physics/multiphase/ZalesakDisk.H
@@ -49,8 +49,8 @@ private:
     //! sphere radius value
     amrex::Real m_radius{0.16};
 
-    //! slot width value
-    amrex::Real m_width{0.04};
+    //! slot half width value
+    amrex::Real m_halfwidth{0.04};
 
     //! slot depth
     amrex::Real m_depth{0.2};

--- a/amr-wind/physics/multiphase/ZalesakDisk.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDisk.cpp
@@ -95,9 +95,9 @@ void ZalesakDisk::initialize_fields(int level, const amrex::Geometry& geom)
                 const amrex::Real sd_r = -std::sqrt(
                     std::pow(r_2D - reduced_radius, 2) + std::pow(sd_x, 2));
 
-                bool in_slot_x_ymin =
+                const bool in_slot_x_ymin =
                     y - yc > radius - depth && std::abs(x - xc) < hwidth;
-                bool in_slot_r = r_2D < reduced_radius;
+                const bool in_slot_r = r_2D < reduced_radius;
 
                 if (in_slot_x_ymin) {
                     // Prescribe slot distances directly (overwrite sphere)

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
@@ -68,8 +68,8 @@ private:
     //! sphere radius value
     amrex::Real m_radius{0.16};
 
-    //! slot width value
-    amrex::Real m_width{0.04};
+    //! slot half-width value
+    amrex::Real m_hwidth{0.04};
 
     //! slot depth
     amrex::Real m_depth{0.2};

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.H
@@ -69,7 +69,7 @@ private:
     amrex::Real m_radius{0.16};
 
     //! slot half-width value
-    amrex::Real m_hwidth{0.04};
+    amrex::Real m_halfwidth{0.04};
 
     //! slot depth
     amrex::Real m_depth{0.2};

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
@@ -80,7 +80,7 @@ void ZalesakDiskScalarVel::initialize_fields(
     const amrex::Real zc = m_loc[2];
     const amrex::Real radius = m_radius;
     const amrex::Real TT = m_TT;
-    const amrex::Real width = m_width;
+    const amrex::Real hwidth = m_hwidth;
     const amrex::Real depth = m_depth;
 
     for (amrex::MFIter mfi(levelset); mfi.isValid(); ++mfi) {
@@ -103,33 +103,48 @@ void ZalesakDiskScalarVel::initialize_fields(
 
                 vel(i, j, k, 1) = 0.0;
                 vel(i, j, k, 2) = 0.0;
+
                 // First define the sphere
+                const amrex::Real r = std::sqrt(
+                    (x - xc) * (x - xc) + (y - yc) * (y - yc) +
+                    (z - zc) * (z - zc));
+                phi(i, j, k) = radius - r;
 
-                phi(i, j, k) =
-                    radius - std::sqrt(
-                                 (x - xc) * (x - xc) + (y - yc) * (y - yc) +
-                                 (z - zc) * (z - zc));
-                // then the slot
-                amrex::Real eps = std::cbrt(dx[0] * dx[1] * dx[2]);
-                if (y - yc <= radius && y - yc >= radius - depth &&
-                    std::abs(x - xc) <= width &&
-                    std::sqrt(
-                        (x - xc) * (x - xc) + (y - yc) * (y - yc) +
-                        (z - zc) * (z - zc)) < radius + eps) {
-                    amrex::Real d1;
-                    if (x > xc) {
-                        d1 = std::abs(xc + width - x);
+                // Then the slot
+                // Signed distances in lateral (x, y) directions
+                const amrex::Real sd_xr = -hwidth + (x - xc);
+                const amrex::Real sd_xl = -hwidth - (x - xc);
+                const amrex::Real sd_x = amrex::max(sd_xr, sd_xl);
+
+                const amrex::Real sd_y = radius - depth - (y - yc);
+                const amrex::Real min_signed_dist = amrex::max(sd_x, sd_y);
+
+                // Additional distance if past sphere (distance to corners)
+                const amrex::Real reduced_radius =
+                    std::sqrt(radius * radius - hwidth * hwidth);
+                const amrex::Real r_2D =
+                    std::sqrt(std::pow(y - yc, 2) + std::pow(z - zc, 2));
+                const amrex::Real sd_r = -std::sqrt(
+                    std::pow(r_2D - reduced_radius, 2) + std::pow(sd_x, 2));
+
+                bool in_slot_x_ymin =
+                    y - yc > radius - depth && std::abs(x - xc) < hwidth;
+                bool in_slot_r = r_2D < reduced_radius;
+
+                if (in_slot_x_ymin) {
+                    // Prescribe slot distances directly (overwrite sphere)
+                    if (in_slot_r) {
+                        phi(i, j, k) = min_signed_dist;
                     } else {
-                        d1 = std::abs(xc - width - x);
+                        phi(i, j, k) = sd_r;
                     }
-                    const amrex::Real d2 = std::abs(y - (yc + radius - depth));
-                    const amrex::Real min_dist = amrex::min(d1, d2);
-
-                    phi(i, j, k) = -min_dist;
+                } else {
+                    // Select the minimum of the two
+                    phi(i, j, k) = amrex::min(phi(i, j, k), min_signed_dist);
                 }
 
                 amrex::Real smooth_heaviside;
-                eps = std::cbrt(2. * dx[0] * dx[1] * dx[2]);
+                const amrex::Real eps = std::cbrt(2. * dx[0] * dx[1] * dx[2]);
                 if (phi(i, j, k) > eps) {
                     smooth_heaviside = 1.0;
                 } else if (phi(i, j, k) < -eps) {

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
@@ -80,7 +80,7 @@ void ZalesakDiskScalarVel::initialize_fields(
     const amrex::Real zc = m_loc[2];
     const amrex::Real radius = m_radius;
     const amrex::Real TT = m_TT;
-    const amrex::Real hwidth = m_hwidth;
+    const amrex::Real hwidth = m_halfwidth;
     const amrex::Real depth = m_depth;
 
     for (amrex::MFIter mfi(levelset); mfi.isValid(); ++mfi) {
@@ -127,9 +127,9 @@ void ZalesakDiskScalarVel::initialize_fields(
                 const amrex::Real sd_r = -std::sqrt(
                     std::pow(r_2D - reduced_radius, 2) + std::pow(sd_x, 2));
 
-                bool in_slot_x_ymin =
+                const bool in_slot_x_ymin =
                     y - yc > radius - depth && std::abs(x - xc) < hwidth;
-                bool in_slot_r = r_2D < reduced_radius;
+                const bool in_slot_r = r_2D < reduced_radius;
 
                 if (in_slot_x_ymin) {
                     // Prescribe slot distances directly (overwrite sphere)

--- a/test/test_files/zalesak_disk_godunov/zalesak_disk_godunov.inp
+++ b/test/test_files/zalesak_disk_godunov/zalesak_disk_godunov.inp
@@ -15,22 +15,13 @@ time.cfl              =   0.95         # CFL factor
 #.......................................#
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
-io.output_default_fields = 0
-io.outputs = density velocity velocity_mueff vof
+io.outputs = density velocity levelset vof
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #               PHYSICS                 #
 #.......................................#
 incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
-incflo.use_godunov = 1
-incflo.godunov_type = "weno"
-transport.model = TwoPhaseTransport
-transport.viscosity_fluid1=0.0
-transport.viscosity_fluid2=0.0
-transport.laminar_prandtl = 0.7
-transport.turbulent_prandtl = 0.3333
-turbulence.model = Laminar 
 
 incflo.physics = MultiPhase ZalesakDisk
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
+++ b/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
@@ -23,8 +23,7 @@ io.outputs = density velocity vof
 #.......................................#
 incflo.initial_iterations = 0
 incflo.do_initial_proj = 0
-incflo.use_godunov = 1
-incflo.godunov_type = "weno"
+incflo.godunov_type = "weno_z"
 incflo.mflux_type = "minmod"
 
 MultiPhase.density_fluid1 = 1e3


### PR DESCRIPTION
## Summary

Improve the setup of the levelset field for the zalesak case. Spurious artifacts can be created at different resolutions with the current approach.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

There will be significant diffs in the two zalesak reg tests

## Additional background

This didn't actually do much to change the convergence behavior, but since I went through the effort of trying it, we might as well add the improvement.
