### PR TITLE
Fix interface_band

### DIFF
--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -493,11 +493,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
     const int j,
     const int k,
     amrex::Array4<amrex::Real const> const& volfrac,
-    const int n_band = 1,
-    const amrex::Real tiny = 1e-12) noexcept
+    const int n_band = 1) noexcept
 {
     // n_band must be <= number of vof ghost cells (3)
-
+    const amrex::Real tiny = 1e-12;
     // Check if near interface
     amrex::Real VOF_max = 0.0;
     amrex::Real VOF_min = 1.0;

--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -493,10 +493,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
     const int j,
     const int k,
     amrex::Array4<amrex::Real const> const& volfrac,
-    const int n_band = 1) noexcept
+    const int n_band = 1,
+    const amrex::Real tiny = 1e-12) noexcept
 {
     // n_band must be <= number of vof ghost cells (3)
-    constexpr amrex::Real tiny = 1e-12;
+
     // Check if near interface
     amrex::Real VOF_max = 0.0;
     amrex::Real VOF_min = 1.0;
@@ -507,7 +508,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
                 amrex::Real VOF = volfrac(i + ii, j + jj, k + kk);
                 VOF_max = amrex::max(VOF_max, VOF);
                 VOF_min = amrex::min(VOF_min, VOF);
-                if (VOF - 1.0 < tiny && VOF > tiny) {
+                if (VOF < 1.0 - tiny && VOF > tiny) {
                     VOF_mid = true;
                 }
             }

--- a/amr-wind/equation_systems/vof/volume_fractions.H
+++ b/amr-wind/equation_systems/vof/volume_fractions.H
@@ -496,7 +496,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE bool interface_band(
     const int n_band = 1) noexcept
 {
     // n_band must be <= number of vof ghost cells (3)
-    const amrex::Real tiny = 1e-12;
+    constexpr amrex::Real tiny = 1e-12;
     // Check if near interface
     amrex::Real VOF_max = 0.0;
     amrex::Real VOF_min = 1.0;


### PR DESCRIPTION


## Summary

Looks like the interface_band was turning on in all liquid. That's a problem. Unit test didn't cover that, now it does.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

- correct check against tiny
- allow tiny to be an input argument
- update unit test to cover previous failure

I'll run the reg tests, it will probably affect many of the multiphase tests.
