### PR TITLE
Correct parsing logic for ABLMeanBoussinesq

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -36,7 +36,12 @@ ABLMeanBoussinesq::ABLMeanBoussinesq(const CFDSim& sim) : m_mesh(sim.mesh())
     amrex::ParmParse pp_incflo("incflo");
     pp_incflo.queryarr("gravity", m_gravity);
 
-    if (pp_boussinesq_buoyancy.contains("read_temperature_profile")) {
+    bool read_temp_prof = false;
+    pp_boussinesq_buoyancy.query("read_temperature_profile", read_temp_prof);
+
+    if ((!pp_boussinesq_buoyancy.contains("read_temperature_profile") &&
+         pp_boussinesq_buoyancy.contains("tprofile_filename")) ||
+        read_temp_prof) {
 
         m_const_profile = true;
 


### PR DESCRIPTION
## Summary

Previously, the read_temperature_profile input could be specified to "false" but would still be used. This is replaced with the following logic:

If read_temperature_profile is not in the input file, but tprofile_name is, then the temperature profile will be used. Alternatively, the temperature profile will not be used unless read_temperature_profile is present and true.

Any oppositions to this new approach?

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Need to run reg tests with ABLMeanBoussinesq

Issue Number: closes #1237
