### PR TITLE
Fix GPU segfault introduced in #1066

### DIFF
--- a/amr-wind/equation_systems/icns/icns_advection.cpp
+++ b/amr-wind/equation_systems/icns/icns_advection.cpp
@@ -69,7 +69,7 @@ void MacProjOp::enforce_inout_solvability(
         a_umac) noexcept
 {
     auto& velocity = m_repo.get_field("velocity");
-    amrex::BCRec const* bc_type = velocity.bcrec_device().data();
+    amrex::BCRec const* bc_type = velocity.bcrec().data();
     const amrex::Vector<amrex::Geometry>& geom = m_repo.mesh().Geom();
 
     HydroUtils::enforceInOutSolvability(a_umac, bc_type, geom);

--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -83,7 +83,7 @@ void amr_wind::nodal_projection::enforce_inout_solvability(
     const Vector<Geometry>& geom,
     const int num_levels)
 {
-    BCRec const* bc_type = velocity.bcrec_device().data();
+    BCRec const* bc_type = velocity.bcrec().data();
     Vector<Array<MultiFab*, AMREX_SPACEDIM>> vel_vec(num_levels);
 
     for (int lev = 0; lev < num_levels; ++lev) {


### PR DESCRIPTION
## Summary

Fix GPU segfault introduced in #1066. The code is using the device data of bcrec. It should be using the host version. @mukul1992 would you mind letting me know if you disagree?

This should fix:
- freestream_godunov_inout


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

Closes #1246
