### PR TITLE
Physics module: Intermittency

### DIFF
--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -199,7 +199,6 @@ void TiogaInterface::register_solution(
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
-            AMREX_ALWAYS_ASSERT(amrex::IntVect(num_ghost) == fld.num_grow());
             field_ops::copy(*m_qcell, fld, 0, icomp, ncomp, num_ghost);
             icomp += ncomp;
         }

--- a/amr-wind/overset/TiogaInterface.cpp
+++ b/amr-wind/overset/TiogaInterface.cpp
@@ -199,6 +199,7 @@ void TiogaInterface::register_solution(
             auto& fld = repo.get_field(cvar);
             const int ncomp = fld.num_comp();
             fld.fillpatch(m_sim.time().new_time());
+            AMREX_ALWAYS_ASSERT(amrex::IntVect(num_ghost) == fld.num_grow());
             field_ops::copy(*m_qcell, fld, 0, icomp, ncomp, num_ghost);
             icomp += ncomp;
         }

--- a/amr-wind/physics/CMakeLists.txt
+++ b/amr-wind/physics/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(${amr_wind_lib_name}
   VortexDipole.cpp
   BurggrafFlow.cpp
   ActuatorSourceTagging.cpp
+  Intermittency.cpp
   )
 
 add_subdirectory(multiphase)

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -1,0 +1,40 @@
+#ifndef Intermittency_H
+#define Intermittency_H
+
+#include "amr-wind/core/Physics.H"
+#include "amr-wind/core/Field.H"
+
+namespace amr_wind {
+
+/** Dummy transition model for overset exchange of the gamma variable 
+ *  \ingroup physics
+ */
+class Intermittency : public Physics::Register<Intermittency>
+{
+public:
+    static std::string identifier() { return "Intermittency"; }
+
+    explicit Intermittency(const CFDSim& sim);
+
+    ~Intermittency() override = default;
+    //! Initialize the intermittency (gamma) field
+    void initialize_fields(int level, const amrex::Geometry& geom) override;
+
+    void post_init_actions() override {}
+
+    void post_regrid_actions() override {}
+
+    void pre_advance_work() override {}
+
+    void post_advance_work() override {}
+
+private:
+    Field& m_intermittency;
+
+    //! initial density value
+    amrex::Real m_gamma{1.0};
+};
+
+} // namespace amr_wind
+
+#endif /* TaylorGreenVortex_H */

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -6,7 +6,7 @@
 
 namespace amr_wind {
 
-/** Dummy transition model for overset exchange of the gamma variable 
+/** Dummy transition model for overset exchange of the gamma variable
  *  \ingroup physics
  */
 class Intermittency : public Physics::Register<Intermittency>

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -17,7 +17,6 @@ public:
     explicit Intermittency(const CFDSim& sim);
 
     ~Intermittency() override = default;
-    //! Initialize the intermittency (gamma) field
     void initialize_fields(int level, const amrex::Geometry& geom) override;
 
     void post_init_actions() override {}

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -31,7 +31,7 @@ public:
 private:
     Field& m_intermittency;
 
-    //! initial density value
+    //! initial intermittency value
     amrex::Real m_gamma{1.0};
 };
 

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -28,7 +28,7 @@ public:
     void post_advance_work() override {}
 
 private:
-    const Field& m_intermittency;
+    Field& m_intermittency;
 
     //! initial intermittency value
     amrex::Real m_gamma{1.0};

--- a/amr-wind/physics/Intermittency.H
+++ b/amr-wind/physics/Intermittency.H
@@ -28,7 +28,7 @@ public:
     void post_advance_work() override {}
 
 private:
-    Field& m_intermittency;
+    const Field& m_intermittency;
 
     //! initial intermittency value
     amrex::Real m_gamma{1.0};

--- a/amr-wind/physics/Intermittency.cpp
+++ b/amr-wind/physics/Intermittency.cpp
@@ -6,17 +6,19 @@
 namespace amr_wind {
 
 Intermittency::Intermittency(const CFDSim& sim)
-    : m_intermittency(sim.repo().declare_field("intermittency",1,0,1))
+    : m_intermittency(sim.repo().declare_field(
+          "intermittency", 1, sim.pde_manager().num_ghost_state()))
 {
     amrex::ParmParse pp("incflo");
     pp.query("gamma_intermittency", m_gamma);
+    auto& gamma_int_fld = sim.repo().get_field("intermittency");
+    gamma_int_fld.set_default_fillpatch_bc(sim.time());
 }
 
 /** Initialize the intermittency field at the beginning of the
  *  simulation.
  */
-void Intermittency::initialize_fields(
-    int level, const amrex::Geometry& geom)
+void Intermittency::initialize_fields(int level, const amrex::Geometry& geom)
 {
     using namespace utils;
 

--- a/amr-wind/physics/Intermittency.cpp
+++ b/amr-wind/physics/Intermittency.cpp
@@ -1,0 +1,28 @@
+#include "amr-wind/physics/Intermittency.H"
+#include "amr-wind/CFDSim.H"
+#include "AMReX_ParmParse.H"
+#include "amr-wind/utilities/trig_ops.H"
+
+namespace amr_wind {
+
+Intermittency::Intermittency(const CFDSim& sim)
+    : m_intermittency(sim.repo().declare_field("intermittency",1,0,1))
+{
+    amrex::ParmParse pp("incflo");
+    pp.query("gamma_intermittency", m_gamma);
+}
+
+/** Initialize the intermittency field at the beginning of the
+ *  simulation.
+ */
+void Intermittency::initialize_fields(
+    int level, const amrex::Geometry& geom)
+{
+    using namespace utils;
+
+    auto& gamma = m_intermittency(level);
+
+    gamma.setVal(m_gamma);
+}
+
+} // namespace amr_wind

--- a/amr-wind/physics/Intermittency.cpp
+++ b/amr-wind/physics/Intermittency.cpp
@@ -18,7 +18,7 @@ Intermittency::Intermittency(const CFDSim& sim)
 /** Initialize the intermittency field at the beginning of the
  *  simulation.
  */
-void Intermittency::initialize_fields(int level, const amrex::Geometry& geom)
+void Intermittency::initialize_fields(int level, const amrex::Geometry& /*geom*/)
 {
     using namespace utils;
 

--- a/amr-wind/physics/Intermittency.cpp
+++ b/amr-wind/physics/Intermittency.cpp
@@ -18,7 +18,8 @@ Intermittency::Intermittency(const CFDSim& sim)
 /** Initialize the intermittency field at the beginning of the
  *  simulation.
  */
-void Intermittency::initialize_fields(int level, const amrex::Geometry& /*geom*/)
+void Intermittency::initialize_fields(
+    int level, const amrex::Geometry& /*geom*/)
 {
     using namespace utils;
 


### PR DESCRIPTION
Adding an Intermittency physics module to create an intermittency field that can be passed to Tioga for hybrid solver simulations that use the transition model that resides in Nalu-Wind