### PR TITLE
Update reg tests to remove some warnings

### DIFF
--- a/test/test_files/dam_break_godunov/dam_break_godunov.inp
+++ b/test/test_files/dam_break_godunov/dam_break_godunov.inp
@@ -28,7 +28,6 @@ transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=1.e-6
 transport.viscosity_fluid2=1.48e-5
 
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar 
 

--- a/test/test_files/inertial_drop/inertial_drop.inp
+++ b/test/test_files/inertial_drop/inertial_drop.inp
@@ -27,7 +27,6 @@ incflo.godunov_type = "weno"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0
 transport.viscosity_fluid2=0.0
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar
 

--- a/test/test_files/ow_linear/ow_linear.inp
+++ b/test/test_files/ow_linear/ow_linear.inp
@@ -26,7 +26,6 @@ incflo.godunov_type="weno_z"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0
 transport.viscosity_fluid2=0.0
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar 
 

--- a/test/test_files/ow_stokes/ow_stokes.inp
+++ b/test/test_files/ow_stokes/ow_stokes.inp
@@ -26,7 +26,6 @@ incflo.godunov_type="weno_z"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0
 transport.viscosity_fluid2=0.0
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar 
 

--- a/test/test_files/rain_drop/rain_drop.inp
+++ b/test/test_files/rain_drop/rain_drop.inp
@@ -29,7 +29,6 @@ incflo.mflux_type = "minmod"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=1e-3
 transport.viscosity_fluid2=2e-5
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar
 

--- a/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
+++ b/test/test_files/rayleigh_taylor_mol/rayleigh_taylor_mol.inp
@@ -1,6 +1,6 @@
 time.max_step                = 20
 
-time.fixed_dt         = 0.1
+time.fixed_dt         = 0.05
 time.cfl              = 0.49           # CFL factor
 time.init_shrink      = 1.0
 

--- a/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
+++ b/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
@@ -28,7 +28,6 @@ incflo.godunov_type="weno"
 transport.model = TwoPhaseTransport
 transport.viscosity_fluid1=0.0
 transport.viscosity_fluid2=0.0
-transport.laminar_prandtl = 0.7
 transport.turbulent_prandtl = 0.3333
 turbulence.model = Laminar 
 


### PR DESCRIPTION
## Summary

Update reg tests to remove some warnings. Things like:

```
./rayleigh_taylor_mol/rayleigh_taylor_mol.log:302:WARNING: fixed_dt does not satisfy CFL condition.
./vortex_patch_godunov/vortex_patch_godunov.log:47:WARNING: single-phase laminar_prandtl has been specified but will not be used! (TwoPhaseTransport)
```

The only test I expect diffs on is `rayleigh_taylor_mol`

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
