### PR TITLE
Update sampling bounds check

### DIFF
--- a/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
+++ b/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
@@ -346,7 +346,7 @@ void FreeSurfaceSampler::check_bounds()
         }
         if (m_start[d] > prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_hi[d];
         }
         if (m_end[d] < prob_lo[d]) {
             all_ok = false;
@@ -354,7 +354,7 @@ void FreeSurfaceSampler::check_bounds()
         }
         if (m_end[d] > prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_hi[d];
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
+++ b/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
@@ -340,21 +340,21 @@ void FreeSurfaceSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] < prob_lo[d]) {
+        if (m_start[d] <= prob_lo[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_start[d] > prob_hi[d]) {
+        if (m_start[d] >= prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_hi[d];
+            m_start[d] = prob_hi[d] - bounds_tol;
         }
-        if (m_end[d] < prob_lo[d]) {
+        if (m_end[d] <= prob_lo[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_end[d] > prob_hi[d]) {
+        if (m_end[d] >= prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_hi[d];
+            m_end[d] = prob_hi[d] - bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/LineSampler.cpp
+++ b/amr-wind/utilities/sampling/LineSampler.cpp
@@ -29,21 +29,21 @@ void LineSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] < prob_lo[d]) {
+        if (m_start[d] <= prob_lo[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_start[d] > prob_hi[d]) {
+        if (m_start[d] >= prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_hi[d];
+            m_start[d] = prob_hi[d] - bounds_tol;
         }
-        if (m_end[d] < prob_lo[d]) {
+        if (m_end[d] <= prob_lo[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_end[d] > prob_hi[d]) {
+        if (m_end[d] >= prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_hi[d];
+            m_end[d] = prob_hi[d] - bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/LineSampler.cpp
+++ b/amr-wind/utilities/sampling/LineSampler.cpp
@@ -35,7 +35,7 @@ void LineSampler::check_bounds()
         }
         if (m_start[d] > prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_hi[d];
         }
         if (m_end[d] < prob_lo[d]) {
             all_ok = false;
@@ -43,7 +43,7 @@ void LineSampler::check_bounds()
         }
         if (m_end[d] > prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_hi[d];
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/PlaneSampler.cpp
+++ b/amr-wind/utilities/sampling/PlaneSampler.cpp
@@ -65,10 +65,10 @@ void PlaneSampler::check_bounds()
             const amrex::Vector<amrex::Real> points = {
                 point, point + m_axis1[d], point + m_axis2[d]};
             for (const auto& pt : points) {
-                if ((pt < prob_lo[d]) || (pt > prob_hi[d])) {
+                if ((pt <= prob_lo[d]) || (pt >= prob_hi[d])) {
                     amrex::Abort(
                         "PlaneSampler: Point out of domain. Redefine your "
-                        "planes so they are inside the domain.");
+                        "planes so they are completely inside the domain.");
                 }
             }
         }

--- a/amr-wind/utilities/sampling/ProbeSampler.cpp
+++ b/amr-wind/utilities/sampling/ProbeSampler.cpp
@@ -38,13 +38,13 @@ void ProbeSampler::check_bounds()
     bool all_ok = true;
     for (int i = 0; i < m_npts; ++i) {
         for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            if (m_probes[i][d] < prob_lo[d]) {
+            if (m_probes[i][d] <= prob_lo[d]) {
                 all_ok = false;
-                m_probes[i][d] = prob_lo[d];
+                m_probes[i][d] = prob_lo[d] + bounds_tol;
             }
-            if (m_probes[i][d] > prob_hi[d]) {
+            if (m_probes[i][d] >= prob_hi[d]) {
                 all_ok = false;
-                m_probes[i][d] = prob_hi[d];
+                m_probes[i][d] = prob_hi[d] - bounds_tol;
             }
         }
     }

--- a/amr-wind/utilities/sampling/RadarSampler.cpp
+++ b/amr-wind/utilities/sampling/RadarSampler.cpp
@@ -112,7 +112,7 @@ void RadarSampler::check_bounds()
         }
         if (m_start[d] > prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_hi[d];
         }
         if (m_end[d] < prob_lo[d]) {
             all_ok = false;
@@ -120,7 +120,7 @@ void RadarSampler::check_bounds()
         }
         if (m_end[d] > prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_hi[d];
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/RadarSampler.cpp
+++ b/amr-wind/utilities/sampling/RadarSampler.cpp
@@ -106,21 +106,21 @@ void RadarSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] < prob_lo[d]) {
+        if (m_start[d] <= prob_lo[d]) {
             all_ok = false;
-            m_start[d] = prob_lo[d];
+            m_start[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_start[d] > prob_hi[d]) {
+        if (m_start[d] >= prob_hi[d]) {
             all_ok = false;
-            m_start[d] = prob_hi[d];
+            m_start[d] = prob_hi[d] - bounds_tol;
         }
-        if (m_end[d] < prob_lo[d]) {
+        if (m_end[d] <= prob_lo[d]) {
             all_ok = false;
-            m_end[d] = prob_lo[d];
+            m_end[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_end[d] > prob_hi[d]) {
+        if (m_end[d] >= prob_hi[d]) {
             all_ok = false;
-            m_end[d] = prob_hi[d];
+            m_end[d] = prob_hi[d] - bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/SamplerBase.H
+++ b/amr-wind/utilities/sampling/SamplerBase.H
@@ -25,6 +25,9 @@ public:
 
     static std::string base_identifier() { return "SamplerBase"; }
 
+    static constexpr amrex::Real bounds_tol =
+        std::numeric_limits<amrex::Real>::epsilon();
+
     ~SamplerBase() override = default;
 
     //! Name used to refer to this sampler (e.g., myline1)

--- a/amr-wind/utilities/sampling/VolumeSampler.cpp
+++ b/amr-wind/utilities/sampling/VolumeSampler.cpp
@@ -48,7 +48,7 @@ void VolumeSampler::check_bounds()
         }
         if (m_lo[d] > prob_hi[d]) {
             all_ok = false;
-            m_lo[d] = prob_lo[d];
+            m_lo[d] = prob_hi[d];
         }
         if (m_hi[d] < prob_lo[d]) {
             all_ok = false;
@@ -56,7 +56,7 @@ void VolumeSampler::check_bounds()
         }
         if (m_hi[d] > prob_hi[d]) {
             all_ok = false;
-            m_hi[d] = prob_lo[d];
+            m_hi[d] = prob_hi[d];
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/VolumeSampler.cpp
+++ b/amr-wind/utilities/sampling/VolumeSampler.cpp
@@ -42,21 +42,21 @@ void VolumeSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_lo[d] < prob_lo[d]) {
+        if (m_lo[d] <= prob_lo[d]) {
             all_ok = false;
-            m_lo[d] = prob_lo[d];
+            m_lo[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_lo[d] > prob_hi[d]) {
+        if (m_lo[d] >= prob_hi[d]) {
             all_ok = false;
-            m_lo[d] = prob_hi[d];
+            m_lo[d] = prob_hi[d] - bounds_tol;
         }
-        if (m_hi[d] < prob_lo[d]) {
+        if (m_hi[d] <= prob_lo[d]) {
             all_ok = false;
-            m_hi[d] = prob_lo[d];
+            m_hi[d] = prob_lo[d] + bounds_tol;
         }
-        if (m_hi[d] > prob_hi[d]) {
+        if (m_hi[d] >= prob_hi[d]) {
             all_ok = false;
-            m_hi[d] = prob_hi[d];
+            m_hi[d] = prob_hi[d] - bounds_tol;
         }
     }
     if (!all_ok) {

--- a/unit_tests/utilities/test_sampling.cpp
+++ b/unit_tests/utilities/test_sampling.cpp
@@ -272,9 +272,9 @@ TEST_F(SamplingTest, plane_sampler)
         amrex::ParmParse pp("plane");
         pp.addarr("axis1", amrex::Vector<double>{0.0, 1.0, 0.0});
         pp.addarr("axis2", amrex::Vector<double>{0.0, 0.0, 1.0});
-        pp.addarr("origin", amrex::Vector<double>{0.0, 0.0, 0.0});
+        pp.addarr("origin", amrex::Vector<double>{1.0, 1.0, 1.0});
         pp.addarr("num_points", amrex::Vector<int>{3, 3});
-        pp.addarr("offsets", amrex::Vector<double>{1.0, 10.0});
+        pp.addarr("offsets", amrex::Vector<double>{2.0, 10.0});
         pp.addarr("offset_vector", amrex::Vector<double>{1.0, 0.0, 0.0});
     }
 


### PR DESCRIPTION
## Summary

Two things happening:
1. Interestingly, there was actually a bug in the bounds checking for the sampling probes that were not part of #1255. Basically a bunch of these were clipping to prob_lo when they were larger than prob_hi. 
2. This actually fixes the probes so they are completely inside the domain. Any probe on the edge will be shoved by an epsilon into the domain.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
