### PR TITLE
Correcting some, but not all, fillpatch(0.0) calls to have correct times

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -213,9 +213,9 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
     }
     // This helps for having periodic boundaries, but will need to be addressed
     // for the general case
-    vof.fillpatch(0.0);
-    velocity.fillpatch(0.0);
-    density.fillpatch(0.0);
+    vof.fillpatch(time);
+    velocity.fillpatch(time);
+    density.fillpatch(time);
 }
 
 void prepare_netcdf_file(

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -615,8 +615,8 @@ struct UpdateRelaxZonesOp<W2AWaves>
                         sim.mesh().refRatio(lev - 1));
                 }
                 // Fill patch to get correct ghost cells after average down
-                m_ow_velocity.fillpatch(0.0);
-                m_ow_levelset.fillpatch(0.0);
+                m_ow_velocity.fillpatch(sim.time().new_time());
+                m_ow_levelset.fillpatch(sim.time().new_time());
 
                 // Prior t_last (corresponding to ow fields)
                 t_last = (wdata.ntime - 1) * wdata.dt_modes;
@@ -645,8 +645,8 @@ struct UpdateRelaxZonesOp<W2AWaves>
                     sim.mesh().refRatio(lev - 1));
             }
             // Fill patch to get correct ghost cells after average down
-            w2a_velocity.fillpatch(0.0);
-            w2a_levelset.fillpatch(0.0);
+            w2a_velocity.fillpatch(sim.time().new_time());
+            w2a_levelset.fillpatch(sim.time().new_time());
         }
 
         // Temporally interpolate at every timestep to get target solution

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -465,7 +465,7 @@ void MultiPhase::favre_filtering()
                 });
         }
     }
-    m_velocity.fillpatch(0.0);
+    m_velocity.fillpatch(m_sim.time().current_time());
 }
 
 // Reconstructing the volume fraction from a levelset function
@@ -513,8 +513,8 @@ void MultiPhase::levelset2vof()
                 });
         }
     }
-    // Fill ghost and boundary cells before simulation begins
-    (*m_vof).fillpatch(0.0);
+    // Fill ghost and boundary cells
+    (*m_vof).fillpatch(m_sim.time().current_time());
 }
 
 // Do levelset2vof with iblank neumann and into supplied scratch field

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -578,7 +578,7 @@ void MultiPhase::levelset2vof(
         }
     }
     // Fill ghost and boundary cells before simulation begins
-    vof_scr.fillpatch(0.0);
+    vof_scr.fillpatch(m_sim.time().current_time());
 }
 
 } // namespace amr_wind

--- a/amr-wind/physics/multiphase/VortexPatchScalarVel.cpp
+++ b/amr-wind/physics/multiphase/VortexPatchScalarVel.cpp
@@ -112,7 +112,7 @@ void VortexPatchScalarVel::initialize_fields(
                 }
             });
     }
-    m_velocity.fillpatch(0.0);
+    m_velocity.fillpatch(m_sim.time().current_time());
 }
 
 void VortexPatchScalarVel::pre_advance_work()

--- a/amr-wind/physics/multiphase/ZalesakDisk.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDisk.cpp
@@ -127,9 +127,9 @@ void ZalesakDisk::initialize_fields(int level, const amrex::Geometry& geom)
                     rho1 * smooth_heaviside + rho2 * (1.0 - smooth_heaviside);
             });
     }
-    m_levelset.fillpatch(0.0);
-    m_velocity.fillpatch(0.0);
-    m_density.fillpatch(0.0);
+    m_levelset.fillpatch(m_sim.time().current_time());
+    m_velocity.fillpatch(m_sim.time().current_time());
+    m_density.fillpatch(m_sim.time().current_time());
 }
 
 void ZalesakDisk::pre_advance_work()

--- a/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
+++ b/amr-wind/physics/multiphase/ZalesakDiskScalarVel.cpp
@@ -168,9 +168,9 @@ void ZalesakDiskScalarVel::initialize_fields(
                 vel(i, j, k, 0) = amrex::min(1.0, amrex::max(0.0, 1.5 - dnorm));
             });
     }
-    m_levelset.fillpatch(0.0);
-    m_velocity.fillpatch(0.0);
-    m_density.fillpatch(0.0);
+    m_levelset.fillpatch(m_sim.time().current_time());
+    m_velocity.fillpatch(m_sim.time().current_time());
+    m_density.fillpatch(m_sim.time().current_time());
     output_error();
 }
 


### PR DESCRIPTION
## Summary

A combination of laziness and a lack of understanding led to several fillpatch(0.0) calls in the code, mainly multiphase-related things. This PR addresses most of those cases, leaving two for the future, one related to vof advection and one in derived quantities. These are inconsequential, but shouldn't be there. Reg tests pass.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
