### PR TITLE
Fix unused member function in tests for cuda

### DIFF
--- a/unit_tests/core/test_field_fillpatch_ops.cpp
+++ b/unit_tests/core/test_field_fillpatch_ops.cpp
@@ -195,6 +195,7 @@ public:
         }
         using InflowOp =
             amr_wind::BCOpCreator<TestProfile, amr_wind::ConstDirichlet>;
+        AMREX_ALWAYS_ASSERT(TestProfile(*m_vel).identifier() == "TestProfile");
         (*m_vel).register_fill_patch_op<amr_wind::FieldFillPatchOps<InflowOp>>(
             mesh(), time(), InflowOp(*m_vel));
         (*m_vel).copy_bc_to_device();


### PR DESCRIPTION
## Summary

Fix unused member function in tests for cuda. Reported error:
```
/mnt/vdb/home/jrood/exawind-manager/stage/spack-stage-amr-wind-main-kwfxnfqpf6r7ihjrmvozilxvylr2gbxz/spack-src/unit_tests/core/test_field_fillpatch_ops.cpp(33): warning #177-D: function "amr_wind_tests::<unnamed>::TestProfile::identifier" was declared but never referenced
```

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->