### PR TITLE
Add offsets to probe sampler with new unit test

### DIFF
--- a/amr-wind/utilities/sampling/ProbeSampler.H
+++ b/amr-wind/utilities/sampling/ProbeSampler.H
@@ -52,6 +52,9 @@ private:
     const CFDSim& m_sim;
     SampleLocType m_probes;
 
+    amrex::Vector<amrex::Real> m_offset_vector{0.0, 0.0, 0.0};
+    amrex::Vector<amrex::Real> m_poffsets;
+
     std::string m_label;
     int m_id{-1};
     int m_npts{0};

--- a/amr-wind/utilities/sampling/ProbeSampler.cpp
+++ b/amr-wind/utilities/sampling/ProbeSampler.cpp
@@ -20,13 +20,38 @@ void ProbeSampler::initialize(const std::string& key)
         amrex::Abort("Cannot find probe location file: " + pfile);
     }
 
-    ifh >> m_npts;
+    pp.queryarr("offsets", m_poffsets);
+    if (m_poffsets.size() > 0) {
+        pp.getarr("offset_vector", m_offset_vector);
+        AMREX_ALWAYS_ASSERT(
+            static_cast<int>(m_offset_vector.size()) == AMREX_SPACEDIM);
+    } else {
+        // No offsets is implemented as 1 offset of 0.
+        m_poffsets.push_back(0.0);
+    }
+
+    int npts_file = 0;
+    ifh >> npts_file;
     ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    SampleLocType probes_file;
+    probes_file.resize(npts_file);
+    m_npts = m_poffsets.size() * npts_file;
     m_probes.resize(m_npts);
-    for (int i = 0; i < m_npts; ++i) {
-        ifh >> m_probes[i][0] >> m_probes[i][1] >> m_probes[i][2];
+    // Read through points in file
+    for (int i = 0; i < npts_file; ++i) {
+        ifh >> probes_file[i][0] >> probes_file[i][1] >> probes_file[i][2];
         ifh.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
     }
+    // Incorporate offsets
+    for (int n = 0; n < m_poffsets.size(); ++n) {
+        for (int i = 0; i < npts_file; ++i) {
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                m_probes[i + n * npts_file][d] =
+                    probes_file[i][d] + m_poffsets[n] * m_offset_vector[d];
+            }
+        }
+    }
+
     check_bounds();
 }
 

--- a/amr-wind/utilities/sampling/ProbeSampler.cpp
+++ b/amr-wind/utilities/sampling/ProbeSampler.cpp
@@ -94,6 +94,8 @@ void ProbeSampler::sampling_locations(SampleLocType& locs) const
 void ProbeSampler::define_netcdf_metadata(const ncutils::NCGroup& grp) const
 {
     grp.put_attr("sampling_type", identifier());
+    grp.put_attr("offset_vector", m_offset_vector);
+    grp.put_attr("offsets", m_poffsets);
 }
 #else
 void ProbeSampler::define_netcdf_metadata(

--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -158,6 +158,10 @@ Example::
 
 The first line of the file contains the total number of probes for this set.
 This is followed by the coordinates (three real numbers), one line per probe.
+This type of sampler also supports the ``offset_vector`` and ``offsets`` options
+implemented with the plane sampler, shown above. For the probe sampler, 
+these options apply offsets to the positions of all the points provided in the
+probe location file.
 
 Sampling on a volume
 `````````````````````

--- a/unit_tests/utilities/test_sampling.cpp
+++ b/unit_tests/utilities/test_sampling.cpp
@@ -298,12 +298,11 @@ TEST_F(SamplingTest, probe_sampler)
     cloud.sampling_locations(locs);
 
     ASSERT_EQ(locs.size(), 3 * 2);
-    const amrex::Vector<const amrex::Real> xprobe_golds{0.2, 60.2, 100.2,
-                                                        0.5, 60.5, 100.5};
-    const amrex::Vector<const amrex::Real> yprobe_golds{0.5,  2.5,  8.5,
-                                                        1.25, 3.25, 9.25};
-    const amrex::Vector<const amrex::Real> zprobe_golds{1.0, 4.0, 6.0,
-                                                        2.5, 5.5, 7.5};
+    const amrex::Vector<amrex::Real> xprobe_golds{0.2, 60.2, 100.2,
+                                                  0.5, 60.5, 100.5};
+    const amrex::Vector<amrex::Real> yprobe_golds{0.5,  2.5,  8.5,
+                                                  1.25, 3.25, 9.25};
+    const amrex::Vector<amrex::Real> zprobe_golds{1.0, 4.0, 6.0, 2.5, 5.5, 7.5};
     for (int n = 0; n < locs.size(); ++n) {
         EXPECT_NEAR(locs[n][0], xprobe_golds[n], tol);
         EXPECT_NEAR(locs[n][1], yprobe_golds[n], tol);


### PR DESCRIPTION
## Summary

Similar to the PlaneSampler, this PR adds the offset capability to the ProbeSampler. Offsets are added to the entire cloud of points within a given file.

## Pull request type

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

requested to go with terrain capability, e.g. terrain-aligned sampling
