### PR TITLE
Remove unnecessary warning for ABL inflow planes.

### DIFF
--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -902,11 +902,6 @@ void ABLBoundaryPlane::populate_data(
             amrex::Abort("No inflow data at this level.");
         }
 
-        if (ori.isHigh()) {
-            amrex::Warning(
-                "We typically don't inflow boundary planes on the high side.");
-        }
-
         const size_t nc = mfab.nComp();
 
 #ifdef AMREX_USE_OMP


### PR DESCRIPTION
## Summary

Currently when boundary plane faces are used on the `xhi` or `yhi` faces, amr-wind outputs the following warning:
```
We typically don't inflow boundary planes on the high side.!
```
However, depending on the wind direction, boundary planes can be on the `xhi` or `yhi` faces, and AMR-Wind should be capable of handling them.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [X] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
