### PR TITLE
Ocean Waves: expand area of valid target wave velocity for all current wave types

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -73,7 +73,9 @@ struct InitDataOp<LinearWaves>
 
                         phi(i, j, k) = eta - zc;
 
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *
                                 std::cosh(
@@ -95,7 +97,9 @@ struct InitDataOp<LinearWaves>
                     gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zsl - z;
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = 0.0;
                             vel(i, j, k, 1) = 0.0;
                             vel(i, j, k, 2) = 0.0;
@@ -157,7 +161,9 @@ struct UpdateRelaxZonesOp<LinearWaves>
 
                         phi(i, j, k) = eta - zc;
 
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *
                                 std::cosh(

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -162,7 +162,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
                         phi(i, j, k) = eta - zc;
 
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -74,7 +74,7 @@ struct InitDataOp<LinearWaves>
                         phi(i, j, k) = eta - zc;
 
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]));
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -74,7 +74,7 @@ struct InitDataOp<LinearWaves>
                         phi(i, j, k) = eta - zc;
 
                         const amrex::Real cell_length_2D =
-                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -98,7 +98,7 @@ struct InitDataOp<LinearWaves>
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zsl - z;
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = 0.0;
                             vel(i, j, k, 1) = 0.0;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -124,7 +124,7 @@ struct InitDataOp<StokesWaves>
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zero_sea_level - z;
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = 0.0;
                             vel(i, j, k, 1) = 0.0;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -110,7 +110,7 @@ struct InitDataOp<StokesWaves>
 
                         phi(i, j, k) = eta - z;
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = u_w;
                             vel(i, j, k, 1) = v_w;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -183,7 +183,7 @@ struct UpdateRelaxZonesOp<StokesWaves>
 
                         phi(i, j, k) = eta - z;
                         const amrex::Real cell_length_2D =
-                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                         if (phi(i, j, k) + cell_length_2D >= 0) {
                             // Wave velocity within a cell of interface
                             vel(i, j, k, 0) = u_w;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -109,7 +109,9 @@ struct InitDataOp<StokesWaves>
                             zero_sea_level, g, x, z, 0.0, eta, u_w, v_w, w_w);
 
                         phi(i, j, k) = eta - z;
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = u_w;
                             vel(i, j, k, 1) = v_w;
                             vel(i, j, k, 2) = w_w;
@@ -121,7 +123,9 @@ struct InitDataOp<StokesWaves>
                     gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
                         phi(i, j, k) = zero_sea_level - z;
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
                             vel(i, j, k, 0) = 0.0;
                             vel(i, j, k, 1) = 0.0;
                             vel(i, j, k, 2) = 0.0;
@@ -178,7 +182,10 @@ struct UpdateRelaxZonesOp<StokesWaves>
                             zero_sea_level, g, x, z, time, eta, u_w, v_w, w_w);
 
                         phi(i, j, k) = eta - z;
-                        if (phi(i, j, k) + 0.5 * dx[2] >= 0) {
+                        const amrex::Real cell_length_2D =
+                            std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                        if (phi(i, j, k) + cell_length_2D >= 0) {
+                            // Wave velocity within a cell of interface
                             vel(i, j, k, 0) = u_w;
                             vel(i, j, k, 1) = v_w;
                             vel(i, j, k, 2) = w_w;

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -90,7 +90,9 @@ void postprocess_velocity_mfab_liquid(
         amrex::ParallelFor(
             gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 // Set velocity to zero if no liquid present
-                if (phi(i, j, k) + 0.5 * dx[2] < 0.0) {
+                const amrex::Real cell_length_2D =
+                    std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                if (phi(i, j, k) + cell_length_2D >= 0) {
                     vel(i, j, k, 0) = 0.0;
                     vel(i, j, k, 1) = 0.0;
                     vel(i, j, k, 2) = 0.0;

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -91,7 +91,7 @@ void postprocess_velocity_mfab_liquid(
             gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 // Set velocity to zero if no liquid present
                 const amrex::Real cell_length_2D =
-                    std::sqrt(std::pow(dx[0], 2) + std::pow(dx[2], 2));
+                    std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
                 if (phi(i, j, k) + cell_length_2D >= 0) {
                     vel(i, j, k, 0) = 0.0;
                     vel(i, j, k, 1) = 0.0;


### PR DESCRIPTION
## Summary

I saw that some cells with tiny amounts of target_vof had a target velocity of 0. This PR expands where the target velocity is populated according to the wave profile and should eliminate the issue.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Could lead to small diffs for the ocean waves cases. Might not lead to any, though, because it is likely to only show up with sufficient cell resolution around the interface.
