### PR TITLE
Add dry run capability

### DIFF
--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -174,6 +174,9 @@ private:
     // Prescribe advection velocity
     bool m_prescribe_vel = false;
 
+    // Perform a dry run (0 steps, output plotfile)
+    bool m_dry_run = false;
+
     // Fixed point iterations every timestep
     int m_fixed_point_iterations{1};
 
@@ -204,6 +207,7 @@ private:
     //
     ///////////////////////////////////////////////////////////////////////////
 
+    void CheckAndSetUpDryRun();
     void ReadParameters();
     void InitialProjection();
     void InitialIterations();

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -23,8 +23,11 @@ incflo::incflo()
     // constructor. No valid BoxArray and DistributionMapping have been defined.
     // But the arrays for them have been resized.
 
+    // Check if dry run is requested and set up if so
+    CheckAndSetUpDryRun();
+
+    // Read top-level parameters using ParmParse
     m_time.parse_parameters();
-    // Read inputs file using ParmParse
     ReadParameters();
 
     init_physics_and_pde();
@@ -124,7 +127,8 @@ void incflo::prepare_for_time_integration()
 {
     BL_PROFILE("amr-wind::incflo::prepare_for_time_integration");
     // Don't perform initial work if this is a restart
-    if (m_sim.io_manager().is_restart()) {
+    // but still need to write plot file for dry run of restart
+    if (m_sim.io_manager().is_restart() && !m_dry_run) {
         return;
     }
 

--- a/amr-wind/setup/init.cpp
+++ b/amr-wind/setup/init.cpp
@@ -29,7 +29,7 @@ void incflo::CheckAndSetUpDryRun()
     // Zero time steps, write plotfile and not checkpoint
     {
         ParmParse pp("time");
-        pp.add("max_step",(int)0);
+        pp.add("max_step", (int)0);
         pp.add("plot_interval", (int)1);
         pp.add("checkpoint_inteval", (int)-1);
     }

--- a/amr-wind/setup/init.cpp
+++ b/amr-wind/setup/init.cpp
@@ -10,6 +10,38 @@
 
 using namespace amrex;
 
+void incflo::CheckAndSetUpDryRun()
+{
+    // Check if dry run is requested; exit if not
+    {
+        ParmParse pp("incflo");
+        pp.query("dry_run", m_dry_run);
+        if (!m_dry_run) {
+            return;
+        }
+    }
+    // Disable additional computations associated with initialization
+    {
+        ParmParse pp("incflo");
+        pp.add("initial_iterations", (int)0);
+        pp.add("do_initial_proj", (bool)false);
+    }
+    // Zero time steps, write plotfile and not checkpoint
+    {
+        ParmParse pp("time");
+        pp.add("max_step",(int)0);
+        pp.add("plot_interval", (int)1);
+        pp.add("checkpoint_inteval", (int)-1);
+    }
+    // Give prefix to plotfile
+    {
+        ParmParse pp("io");
+        std::string current_plt{"plt"};
+        pp.query("plot_file", current_plt);
+        pp.add("plot_file", (std::string) "dry_run_" + current_plt);
+    }
+}
+
 /** Parse the input file and populate parameters
  */
 void incflo::ReadParameters()

--- a/docs/sphinx/user/inputs_incflo.rst
+++ b/docs/sphinx/user/inputs_incflo.rst
@@ -69,6 +69,16 @@ as initial conditions and discretization options.
    Godunov the default approach and has many advantages over the method of lines (MOL): better accuracy,
    stability at larger CFL numbers, and greater computational efficiency. Setting this argument to false is 
    not recommended, and active use or development relying on the method of lines (MOL) is very sparse.
+
+.. input_param:: incflo.dry_run
+
+   **type** Boolean, optional, default = false
+
+   Setting this option to true enables a "dry run" of the code. This is intended for checking if an input
+   file is set up properly and for investigating the initial state of a simulation. A dry run will make sure
+   that initial iterations and the initial projection are skipped, and it will complete no time steps. This is
+   to minimize the computational demands of such a run. A plot file with the prefix ``dry_run`` will be output
+   regardless of whether the simulation restarts from a checkpoint file or from scratch.
    
 .. _inputs_incflo_advection:
 


### PR DESCRIPTION
## Summary

Had a request for a dry run capability so the setup could be viewed without running a simulation. This is a sort-of automated way of doing the least amount of work while still populating arrays and outputting a plotfile. I also made sure that a plotfile will still be written when doing a dry run for a restart.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Before merging, I'll need to add this to the documentation. I could incorporate it into it's own reg test, but I'm not sure it's worth the hassle. 
