### PR TITLE
Fix unused parmparse variables in the reg tests

### DIFF
--- a/docs/sphinx/user/amr_wind_inputs.txt
+++ b/docs/sphinx/user/amr_wind_inputs.txt
@@ -24,7 +24,6 @@ time.checkpoint_interval                    = 10000
 time.use_force_cfl                          = false
 
 # input/output settings
-io.KE_int                                   = -1
 io.check_file                               = "chk"
 io.plot_file                                = "plt"
 io.restart_file                             = ""

--- a/test/test_files/abl_bds/abl_bds.inp
+++ b/test/test_files/abl_bds/abl_bds.inp
@@ -72,7 +72,6 @@ zhi.temperature = 0.003 # tracer is used to specify potential temperature gradie
 #.......................................#
 incflo.verbose          =   0          # incflo_level
 
-amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
 # needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)

--- a/test/test_files/abl_bndry_input/abl_bndry_input.inp
+++ b/test/test_files/abl_bndry_input/abl_bndry_input.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input/abl_bndry_input.inp
+++ b/test/test_files/abl_bndry_input/abl_bndry_input.inp
@@ -63,7 +63,6 @@ amr.max_level           = 0           # Max AMR level in hierarchy
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_input_amr/abl_bndry_input_amr.inp
+++ b/test/test_files/abl_bndry_input_amr/abl_bndry_input_amr.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_amr/abl_bndry_input_amr.inp
+++ b/test/test_files/abl_bndry_input_amr/abl_bndry_input_amr.inp
@@ -66,7 +66,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_input_amr_inflow/abl_bndry_input_amr_inflow.inp
+++ b/test/test_files/abl_bndry_input_amr_inflow/abl_bndry_input_amr_inflow.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_amr_inflow/abl_bndry_input_amr_inflow.inp
+++ b/test/test_files/abl_bndry_input_amr_inflow/abl_bndry_input_amr_inflow.inp
@@ -68,7 +68,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_input_amr_native/abl_bndry_input_amr_native.inp
+++ b/test/test_files/abl_bndry_input_amr_native/abl_bndry_input_amr_native.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_amr_native/abl_bndry_input_amr_native.inp
+++ b/test/test_files/abl_bndry_input_amr_native/abl_bndry_input_amr_native.inp
@@ -66,7 +66,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_input_amr_native_mlbc/abl_bndry_input_amr_native_mlbc.inp
+++ b/test/test_files/abl_bndry_input_amr_native_mlbc/abl_bndry_input_amr_native_mlbc.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_amr_native_mlbc/abl_bndry_input_amr_native_mlbc.inp
+++ b/test/test_files/abl_bndry_input_amr_native_mlbc/abl_bndry_input_amr_native_mlbc.inp
@@ -68,7 +68,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_input_amr_native_xhi/abl_bndry_input_amr_native_xhi.inp
+++ b/test/test_files/abl_bndry_input_amr_native_xhi/abl_bndry_input_amr_native_xhi.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_amr_native_xhi/abl_bndry_input_amr_native_xhi.inp
+++ b/test/test_files/abl_bndry_input_amr_native_xhi/abl_bndry_input_amr_native_xhi.inp
@@ -66,7 +66,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "pressure_outflow"
 xhi.type = "mass_inflow"

--- a/test/test_files/abl_bndry_input_native/abl_bndry_input_native.inp
+++ b/test/test_files/abl_bndry_input_native/abl_bndry_input_native.inp
@@ -28,7 +28,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_input_native/abl_bndry_input_native.inp
+++ b/test/test_files/abl_bndry_input_native/abl_bndry_input_native.inp
@@ -63,7 +63,6 @@ amr.max_level           = 0           # Max AMR level in hierarchy
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 xlo.type = "mass_inflow"
 xlo.density = 1.0

--- a/test/test_files/abl_bndry_output/abl_bndry_output.inp
+++ b/test/test_files/abl_bndry_output/abl_bndry_output.inp
@@ -27,7 +27,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0
@@ -64,7 +63,6 @@ amr.max_level           = 0           # Max AMR level in hierarchy
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 zlo.type =   "wall_model"
 

--- a/test/test_files/abl_bndry_output_amr_inflow/abl_bndry_output_amr_inflow.inp
+++ b/test/test_files/abl_bndry_output_amr_inflow/abl_bndry_output_amr_inflow.inp
@@ -27,7 +27,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_output_amr_inflow/abl_bndry_output_amr_inflow.inp
+++ b/test/test_files/abl_bndry_output_amr_inflow/abl_bndry_output_amr_inflow.inp
@@ -69,7 +69,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 zlo.type =   "wall_model"
 

--- a/test/test_files/abl_bndry_output_amr_native/abl_bndry_output_amr_native.inp
+++ b/test/test_files/abl_bndry_output_amr_native/abl_bndry_output_amr_native.inp
@@ -27,7 +27,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_output_amr_native/abl_bndry_output_amr_native.inp
+++ b/test/test_files/abl_bndry_output_amr_native/abl_bndry_output_amr_native.inp
@@ -69,7 +69,6 @@ tagging.static.static_refinement_def = "static_box.txt"
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 zlo.type =   "wall_model"
 

--- a/test/test_files/abl_bndry_output_native/abl_bndry_output_native.inp
+++ b/test/test_files/abl_bndry_output_native/abl_bndry_output_native.inp
@@ -27,7 +27,6 @@ turbulence.model = Smagorinsky
 Smagorinsky_coeffs.Cs = 0.135
 incflo.physics = ABL
 ICNS.source_terms = CoriolisForcing GeostrophicForcing
-BoussinesqBuoyancy.reference_temperature = 290.0
 ABL.reference_temperature = 290.0
 CoriolisForcing.east_vector = 1.0 0.0 0.0
 CoriolisForcing.north_vector = 0.0 1.0 0.0

--- a/test/test_files/abl_bndry_output_native/abl_bndry_output_native.inp
+++ b/test/test_files/abl_bndry_output_native/abl_bndry_output_native.inp
@@ -64,7 +64,6 @@ amr.max_level           = 0           # Max AMR level in hierarchy
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
 geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
-incflo.delp             =   0.  0.  0.  # Prescribed (cyclic) pressure gradient
 # Boundary conditions
 zlo.type =   "wall_model"
 

--- a/test/test_files/abl_kosovic_neutral_ib/abl_kosovic_neutral_ib.inp
+++ b/test/test_files/abl_kosovic_neutral_ib/abl_kosovic_neutral_ib.inp
@@ -36,7 +36,6 @@ transport.turbulent_prandtl                 = 0.333
 # turbulence equation parameters
 turbulence.model                            = Kosovic
 Kosovic.surfaceRANS                         = false 
-Kosovic.surfaceRANSExp                      = 2
 Kosovic.writeTerms                          = false
 Kosovic.refMOL                              = -1e30
 # Atmospheric boundary layer

--- a/test/test_files/ctv_mol_mesh_map/ctv_mol_mesh_map.inp
+++ b/test/test_files/ctv_mol_mesh_map/ctv_mol_mesh_map.inp
@@ -23,7 +23,6 @@ io.derived_outputs = "components(velocity,0,1)" "components(gp,0,1)"
 #               PHYSICS                 #
 #.......................................#
 incflo.use_godunov  = 0
-incflo.godunov_type = "plm"
 incflo.diffusion_type = 2
 transport.viscosity = 1e-3
 transport.laminar_prandtl = 1.0
@@ -41,7 +40,6 @@ amr.max_level           =   0           # Max AMR level in hierarchy
 #.......................................#
 geometry.prob_lo        =   0.  0.  0.  # Lo corner coordinates
 geometry.prob_hi        =   1.  1.  1.  # Hi corner coordinates
-geometry.prob_hi_physical  =   2.  2.  2.
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
 geometry.mesh_mapping = ConstantMap

--- a/test/test_files/ctv_mol_mesh_map_explicit/ctv_mol_mesh_map_explicit.inp
+++ b/test/test_files/ctv_mol_mesh_map_explicit/ctv_mol_mesh_map_explicit.inp
@@ -23,7 +23,6 @@ io.derived_outputs = "components(velocity,0,1)" "components(gp,0,1)"
 #               PHYSICS                 #
 #.......................................#
 incflo.use_godunov  = 0
-incflo.godunov_type = "plm"
 transport.viscosity = 1e-3
 transport.laminar_prandtl = 1.0
 turbulence.model = Laminar

--- a/test/test_files/ctv_mol_mesh_map_explicit/ctv_mol_mesh_map_explicit.inp
+++ b/test/test_files/ctv_mol_mesh_map_explicit/ctv_mol_mesh_map_explicit.inp
@@ -40,7 +40,6 @@ amr.max_level           =   0           # Max AMR level in hierarchy
 #.......................................#
 geometry.prob_lo        =   0.  0.  0.  # Lo corner coordinates
 geometry.prob_hi        =   1.  1.  1.  # Hi corner coordinates
-geometry.prob_hi_physical  =   2.  2.  2.
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
 geometry.mesh_mapping = ConstantMap

--- a/test/test_files/cylinder_refinement/cylinder_refinement.inp
+++ b/test/test_files/cylinder_refinement/cylinder_refinement.inp
@@ -4,7 +4,6 @@ time.max_step                =   10         # Max number of time steps
 time.fixed_dt         =   0.1      # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
 
-io.KE_int = 0
 io.outputs = actuator_src_term
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files

--- a/test/test_files/fat_cored_vortex_ring/fat_cored_vortex_ring.inp
+++ b/test/test_files/fat_cored_vortex_ring/fat_cored_vortex_ring.inp
@@ -44,7 +44,6 @@ amr.blocking_factor     =   16 16 16
 
 tagging.labels = vm geom
 tagging.vm.type = VorticityMagRefinement
-tagging.vm.nondim = true
 tagging.vm.values = 0.01 0.01 0.01 0.01
 time.regrid_interval = 1
 

--- a/test/test_files/freestream_bds/freestream_bds.inp
+++ b/test/test_files/freestream_bds/freestream_bds.inp
@@ -58,7 +58,6 @@ zhi.type =   "slip_wall"
 incflo.verbose          =   0          # incflo_level
 nodal_proj.verbose = 0
 
-amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
 # needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)

--- a/test/test_files/inertial_drop/inertial_drop.inp
+++ b/test/test_files/inertial_drop/inertial_drop.inp
@@ -16,7 +16,7 @@ time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 time.use_force_cfl            = false
-io.output_default_fields = 0
+io.output_default_variables = 0
 io.outputs = density velocity vof
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
+++ b/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
@@ -11,7 +11,6 @@ io.plot_file = plt
 io.check_file = chk
 #               PHYSICS                 #
 #.......................................#
-incflo.gravity          =   0.  0. 0.0  # Gravitational force (3D)
 
 incflo.use_godunov = 1
 incflo.godunov_type = "bds"
@@ -33,12 +32,10 @@ xlo.type = "mass_inflow"
 xlo.velocity = 1.0 1.0 0.0
 xlo.density = 1.0
 xhi.type = "pressure_outflow"
-xhi.pressure = 0.0
 ylo.type = "mass_inflow"
 ylo.velocity = 1.0 1.0 0.0
 ylo.density = 1.0
 yhi.type = "pressure_outflow"
-yhi.pressure = 0.0
 zlo.type = "slip_wall"
 zhi.type = "slip_wall"
 

--- a/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
+++ b/test/test_files/inflow_bds_amr/inflow_bds_amr.inp
@@ -53,7 +53,6 @@ amr.n_cell            = 64 64 4 # Grid cells at coarsest AMRlevel
 amr.blocking_factor = 4
 amr.n_error_buf = 4
 
-amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
 # needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)

--- a/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
+++ b/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
@@ -11,7 +11,6 @@ io.plot_file = plt
 io.check_file = chk
 #               PHYSICS                 #
 #.......................................#
-incflo.gravity          =   0.  0. 0.0  # Gravitational force (3D)
 
 incflo.use_godunov = 1
 incflo.do_initial_proj = 1
@@ -32,12 +31,10 @@ xlo.type = "mass_inflow"
 xlo.velocity = 1.0 1.0 0.0
 xlo.density = 1.0
 xhi.type = "pressure_outflow"
-xhi.pressure = 0.0
 ylo.type = "mass_inflow"
 ylo.velocity = 1.0 1.0 0.0
 ylo.density = 1.0
 yhi.type = "pressure_outflow"
-yhi.pressure = 0.0
 zlo.type = "slip_wall"
 zhi.type = "slip_wall"
 

--- a/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
+++ b/test/test_files/inflow_godunov_amr/inflow_godunov_amr.inp
@@ -52,7 +52,6 @@ amr.n_cell            = 64 64 4 # Grid cells at coarsest AMRlevel
 amr.blocking_factor = 4
 amr.n_error_buf = 4
 
-amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
 

--- a/test/test_files/joukowsky_disk/joukowsky_disk.inp
+++ b/test/test_files/joukowsky_disk/joukowsky_disk.inp
@@ -4,7 +4,6 @@ time.max_step                =   10         # Max number of time steps
 time.fixed_dt         =   0.1      # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
 
-io.KE_int = 0
 io.outputs = actuator_src_term
 time.plot_interval            =  1       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files

--- a/test/test_files/joukowsky_disk/joukowsky_disk.inp
+++ b/test/test_files/joukowsky_disk/joukowsky_disk.inp
@@ -33,7 +33,6 @@ Actuator.JoukowskyDisk.thrust_coeff = 0.0 0.7 1.2
 Actuator.JoukowskyDisk.wind_speed = 0.0 10.0 12.0
 Actuator.JoukowskyDisk.rpm = 0.0 9.549296585513720146133 14.3239448782705802192
 Actuator.JoukowskyDisk.epsilon = 20.0
-Actuator.JoukowskyDisk.density = 1.225
 Actuator.JoukowskyDisk.diameters_to_sample = 1.0
 Actuator.JoukowskyDisk.num_points_r = 5
 Actuator.JoukowskyDisk.num_points_t = 3

--- a/test/test_files/linear_bds_amr/linear_bds_amr.inp
+++ b/test/test_files/linear_bds_amr/linear_bds_amr.inp
@@ -64,7 +64,6 @@ tagging.labels = static
 tagging.static.type = "CartBoxRefinement"
 tagging.static.static_refinement_def = "static_box.txt"
 
-amrex.abort_on_out_of_memory=1
 amrex.the_arena_is_managed=1
 amrex.async_out=0
 # needed because a debug build using BDS + amrex.the_arena_is_managed=0 OOMs the GPU (problem is in incflo as well)

--- a/test/test_files/mms/mms.inp
+++ b/test/test_files/mms/mms.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
   
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.probtype         =  0
 incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS

--- a/test/test_files/mms/mms.inp
+++ b/test/test_files/mms/mms.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
   
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS
 MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"

--- a/test/test_files/mms_bds/mms_bds.inp
+++ b/test/test_files/mms_bds/mms_bds.inp
@@ -25,7 +25,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS
 MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"

--- a/test/test_files/mms_bds/mms_bds.inp
+++ b/test/test_files/mms_bds/mms_bds.inp
@@ -25,7 +25,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.probtype         =  0
 incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS

--- a/test/test_files/mms_godunov/mms_godunov.inp
+++ b/test/test_files/mms_godunov/mms_godunov.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS
 MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"

--- a/test/test_files/mms_godunov/mms_godunov.inp
+++ b/test/test_files/mms_godunov/mms_godunov.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.probtype         =  0
 incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS

--- a/test/test_files/mms_godunov_plm/mms_godunov_plm.inp
+++ b/test/test_files/mms_godunov_plm/mms_godunov_plm.inp
@@ -25,7 +25,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS
 MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"

--- a/test/test_files/mms_godunov_plm/mms_godunov_plm.inp
+++ b/test/test_files/mms_godunov_plm/mms_godunov_plm.inp
@@ -25,7 +25,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.probtype         =  0
 incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS

--- a/test/test_files/mms_mol/mms_mol.inp
+++ b/test/test_files/mms_mol/mms_mol.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS
 MMS.masa_name = "navierstokes_3d_incompressible_homogeneous"

--- a/test/test_files/mms_mol/mms_mol.inp
+++ b/test/test_files/mms_mol/mms_mol.inp
@@ -24,7 +24,6 @@ geometry.prob_hi        =  3.14159265358979323  3.14159265358979323  3.141592653
 
 geometry.is_periodic    =   1   1   1   # Periodicity x y z (0/1)
 
-incflo.probtype         =  0
 incflo.gravity          = 0. 0. 0.
 
 incflo.physics = MMS

--- a/test/test_files/rain_drop/rain_drop.inp
+++ b/test/test_files/rain_drop/rain_drop.inp
@@ -16,7 +16,7 @@ time.cfl              =   0.95         # CFL factor
 time.plot_interval            =  20       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
 time.use_force_cfl            = false
-io.output_default_fields = 0
+io.output_default_variables = 0
 io.outputs = density velocity vof gp p
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/uniform_ct_disk/uniform_ct_disk.inp
+++ b/test/test_files/uniform_ct_disk/uniform_ct_disk.inp
@@ -4,7 +4,6 @@ time.max_step                =   10         # Max number of time steps
 time.fixed_dt         =   0.1      # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
 
-io.KE_int = 0
 io.outputs = actuator_src_term
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files

--- a/test/test_files/uniform_ct_disk_gaussian/uniform_ct_disk_gaussian.inp
+++ b/test/test_files/uniform_ct_disk_gaussian/uniform_ct_disk_gaussian.inp
@@ -4,7 +4,6 @@ time.max_step                =   10         # Max number of time steps
 time.fixed_dt         =   0.1      # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
 
-io.KE_int = 0
 io.outputs = actuator_src_term
 time.plot_interval            =  10       # Steps between plot files
 time.checkpoint_interval      =  -1       # Steps between checkpoint files

--- a/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
+++ b/test/test_files/vortex_patch_godunov/vortex_patch_godunov.inp
@@ -15,7 +15,7 @@ time.cfl              =   0.95         # CFL factor
 #.......................................#
 time.plot_interval            =  20       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
-io.output_default_fields = 0
+io.output_default_variables = 0
 io.outputs = density velocity velocity_mueff vof
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/vortex_patch_scalar_vel/vortex_patch_scalar_vel.inp
+++ b/test/test_files/vortex_patch_scalar_vel/vortex_patch_scalar_vel.inp
@@ -15,7 +15,7 @@ time.cfl              =   0.45         # CFL factor
 #.......................................#
 time.plot_interval            =  400       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
-io.output_default_fields = 0
+io.output_default_variables = 0
 io.outputs = density velocity vof
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/vortex_ring_collision/vortex_ring_collision.inp
+++ b/test/test_files/vortex_ring_collision/vortex_ring_collision.inp
@@ -44,7 +44,6 @@ amr.blocking_factor     =   4 4 4
 tagging.labels = vm geom
 
 tagging.vm.type = VorticityMagRefinement
-tagging.vm.nondim = true
 tagging.vm.values = 0.1 0.1 0.1 0.1
 time.regrid_interval = 10
 

--- a/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
+++ b/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
@@ -7,7 +7,7 @@ time.max_step                =   300          # Max number of time steps
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #
 #.......................................#
-time.inital_dt        =   0.01        # Use this constant dt if > 0
+time.initial_dt       =   0.01        # Use this constant dt if > 0
 time.cfl              =   0.45        # CFL factor
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
+++ b/test/test_files/zalesak_disk_scalar_vel/zalesak_disk_scalar_vel.inp
@@ -15,7 +15,7 @@ time.cfl              =   0.45        # CFL factor
 #.......................................#
 time.plot_interval            =  300       # Steps between plot files
 time.checkpoint_interval      =  -100       # Steps between checkpoint files
-io.output_default_fields = 0
+io.output_default_variables = 0
 io.outputs = density velocity vof
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#

--- a/tools/README.md
+++ b/tools/README.md
@@ -46,8 +46,6 @@ time.cfl                       = 0.95                           # CFL factor
 #---------------------------------------#
 time.plot_interval             = 1000                           # Steps between plot files
 time.checkpoint_interval       = 1000                           # Steps between checkpoint files
-io.KE_int                      = 1                              
-io.line_plot_int               = 1                              
 
 [...snip...]
 ```

--- a/tools/naluwind2amrwind.py
+++ b/tools/naluwind2amrwind.py
@@ -211,10 +211,7 @@ else:
 cfl               = 0.95
 
 # AMR defaults
-AMRdefaults=[
-    ['io.KE_int',        1, ''],
-    ['io.line_plot_int', 1, ''],
-]
+AMRdefaults=[]
 
 # Physics defaults
 physicsdefaults = [


### PR DESCRIPTION
## Summary

Fix unused parmparse variables in the reg tests. Many of these were plain unused, some were typos (e.g. zalesak_disk_scalar_vel.inp), some were calling things that did not exist anymore.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

