### PR TITLE
Changes for coupling with ERF using MultiBlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,10 @@ endif()
 
 include(set_compile_flags)
 
+if(ERF_ENABLE_MULTIBLOCK)
+    target_compile_definitions(${amr_wind_lib_name} PUBLIC ERF_USE_MULTIBLOCK)
+endif()
+
 if (AMR_WIND_ENABLE_W2A)
   # Turn on the use of the library via bool, it has already been included above
   target_compile_definitions(${amr_wind_lib_name} PUBLIC AMR_WIND_USE_W2A)
@@ -185,7 +189,7 @@ if(AMR_WIND_ENABLE_ASCENT)
   target_compile_definitions(${amr_wind_lib_name} PRIVATE AMR_WIND_USE_ASCENT)
 endif()
 
-# Link with HELICS module 
+# Link with HELICS module
 if(AMR_WIND_ENABLE_HELICS)
   set(CMAKE_PREFIX_PATH ${HELICS_DIR} ${CMAKE_PREFIX_PATH})
   find_package(HELICS 3 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ endif()
 
 include(set_compile_flags)
 
-if(ERF_ENABLE_MULTIBLOCK)
-    target_compile_definitions(${amr_wind_lib_name} PUBLIC ERF_USE_MULTIBLOCK)
+if(ERF_AW_MULTIBLOCK)
+    target_compile_definitions(${amr_wind_lib_name} PUBLIC ERF_AW_MULTIBLOCK)
 endif()
 
 if (AMR_WIND_ENABLE_W2A)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ endif()
 
 include(set_compile_flags)
 
-if(ERF_AW_MULTIBLOCK)
-    target_compile_definitions(${amr_wind_lib_name} PUBLIC ERF_AW_MULTIBLOCK)
+if(ERF_AMR_WIND_MULTIBLOCK)
+    target_compile_definitions(${amr_wind_lib_name} PUBLIC ERF_AMR_WIND_MULTIBLOCK)
 endif()
 
 if (AMR_WIND_ENABLE_W2A)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required (VERSION 3.20 FATAL_ERROR)
 project(AMR-Wind CXX C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 include(amr-wind-utils)

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -9,7 +9,7 @@
 #include "amr-wind/core/MeshMap.H"
 #include "amr-wind/helics.H"
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -63,7 +63,7 @@ public:
     SimTime& time() { return m_time; }
     const SimTime& time() const { return m_time; }
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     void set_mbc(MultiBlockContainer* mbc) { m_mbc = mbc; }
     MultiBlockContainer** mbc() { return &m_mbc; }
 
@@ -159,7 +159,7 @@ private:
 
     bool m_mesh_mapping{false};
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     MultiBlockContainer* m_mbc = nullptr;
     ReadERFFunction m_read_erf{nullptr};
 #endif

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -67,8 +67,8 @@ public:
     void set_mbc(MultiBlockContainer* mbc) { m_mbc = mbc; }
     MultiBlockContainer** mbc() { return &m_mbc; }
 
-    void set_read_erf(ReadERFFcn fcn) { m_read_erf = fcn; }
-    ReadERFFcn* get_read_erf() { return &m_read_erf; }
+    void set_read_erf(ReadERFFunction fcn) { m_read_erf = fcn; }
+    ReadERFFunction* get_read_erf() { return &m_read_erf; }
 #endif
 
     //! Return the field repository
@@ -161,7 +161,7 @@ private:
 
 #ifdef ERF_AW_MULTIBLOCK
     MultiBlockContainer* m_mbc = nullptr;
-    ReadERFFcn m_read_erf {nullptr};
+    ReadERFFunction m_read_erf {nullptr};
 #endif
 };
 

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -10,6 +10,7 @@
 #include "amr-wind/helics.H"
 
 #ifdef ERF_USE_MULTIBLOCK
+#include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
 
@@ -63,8 +64,11 @@ public:
     const SimTime& time() const { return m_time; }
 
 #ifdef ERF_USE_MULTIBLOCK
-    void set_mbc(MultiBlockContainer* mbc) {m_mbc = mbc;}
-    MultiBlockContainer** mbc() {return &m_mbc;}
+    void set_mbc(MultiBlockContainer* mbc) { m_mbc = mbc; }
+    MultiBlockContainer** mbc() { return &m_mbc; }
+
+    void set_read_erf(ReadERFFcn fcn) { m_read_erf = fcn; }
+    ReadERFFcn* get_read_erf() { return &m_read_erf; }
 #endif
 
     //! Return the field repository
@@ -157,6 +161,7 @@ private:
 
 #ifdef ERF_USE_MULTIBLOCK
     MultiBlockContainer* m_mbc = nullptr;
+    ReadERFFcn m_read_erf {nullptr};
 #endif
 };
 

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -9,6 +9,10 @@
 #include "amr-wind/core/MeshMap.H"
 #include "amr-wind/helics.H"
 
+#ifdef ERF_USE_MULTIBLOCK
+class MultiBlockContainer;
+#endif
+
 /** AMR-Wind
  *
  *  All C++ code in AMR-Wind is organized within the amr_wind namespace.
@@ -57,6 +61,11 @@ public:
     //! Return simulation time control
     SimTime& time() { return m_time; }
     const SimTime& time() const { return m_time; }
+
+#ifdef ERF_USE_MULTIBLOCK
+    void set_mbc(MultiBlockContainer* mbc) {m_mbc = mbc;}
+    MultiBlockContainer** mbc() {return &m_mbc;}
+#endif
 
     //! Return the field repository
     FieldRepo& repo() { return m_repo; }
@@ -145,6 +154,10 @@ private:
     std::unique_ptr<HelicsStorage> m_helics;
 
     bool m_mesh_mapping{false};
+
+#ifdef ERF_USE_MULTIBLOCK
+    MultiBlockContainer* m_mbc = nullptr;
+#endif
 };
 
 } // namespace amr_wind

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -9,7 +9,7 @@
 #include "amr-wind/core/MeshMap.H"
 #include "amr-wind/helics.H"
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -63,7 +63,7 @@ public:
     SimTime& time() { return m_time; }
     const SimTime& time() const { return m_time; }
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     void set_mbc(MultiBlockContainer* mbc) { m_mbc = mbc; }
     MultiBlockContainer** mbc() { return &m_mbc; }
 
@@ -159,7 +159,7 @@ private:
 
     bool m_mesh_mapping{false};
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     MultiBlockContainer* m_mbc = nullptr;
     ReadERFFcn m_read_erf {nullptr};
 #endif

--- a/amr-wind/CFDSim.H
+++ b/amr-wind/CFDSim.H
@@ -161,7 +161,7 @@ private:
 
 #ifdef ERF_AW_MULTIBLOCK
     MultiBlockContainer* m_mbc = nullptr;
-    ReadERFFunction m_read_erf {nullptr};
+    ReadERFFunction m_read_erf{nullptr};
 #endif
 };
 

--- a/amr-wind/CMakeLists.txt
+++ b/amr-wind/CMakeLists.txt
@@ -38,7 +38,7 @@ include(AMReXBuildInfo)
 generate_buildinfo(${amr_wind_lib_name} ${CMAKE_SOURCE_DIR})
 
 # Generate AMR-Wind version header
-configure_file("${CMAKE_SOURCE_DIR}/cmake/AMRWindVersion.H.in"
+configure_file("${PROJECT_SOURCE_DIR}/cmake/AMRWindVersion.H.in"
   "${CMAKE_CURRENT_BINARY_DIR}/AMRWindVersion.H" @ONLY)
 
 target_link_libraries_system(${amr_wind_lib_name} PUBLIC AMReX::amrex AMReX-Hydro::amrex_hydro_api)

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -101,7 +101,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index_ubound(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
@@ -154,7 +154,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     const auto& dt = m_time.delta_t();
 
     // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index_ubound(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -92,7 +92,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     currtime = m_time.current_time();
 
     // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index_ubound(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
@@ -145,7 +145,7 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     const auto& dt = m_time.delta_t();
 
     // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
+    m_idx_time = utils::closest_index_ubound(ncfile->meso_times(), currtime);
 
     amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -13,6 +13,9 @@
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/overset/OversetOps.H"
 
+#ifdef ERF_USE_MULTIBLOCK
+  class MultiBlockContainer;
+#endif
 namespace amr_wind {
 namespace pde {
 class PDEBase;

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -14,7 +14,7 @@
 #include "amr-wind/overset/OversetOps.H"
 
 #ifdef ERF_USE_MULTIBLOCK
-  class MultiBlockContainer;
+class MultiBlockContainer;
 #endif
 namespace amr_wind {
 namespace pde {

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -62,8 +62,10 @@ public:
     // Evolve solution to final time through repeated calls to Advance()
     void Evolve();
 
+#ifdef ERF_USE_MULTIBLOCK
     // Evolve solution in a multiblock framework by desired number of steps
     void Evolve_MB(int MBstep, int max_block_step);
+#endif
 
     // Tag cells for refinement
     void

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -64,7 +64,7 @@ public:
 
 #ifdef ERF_AW_MULTIBLOCK
     // Evolve solution in a multiblock framework by desired number of steps
-    void Evolve_MB(int MBstep, int max_block_step);
+    void Evolve_MultiBlock(int multiblock_step, int max_block_step);
 #endif
 
     // Tag cells for refinement

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -161,8 +161,8 @@ public:
     void ReadCheckpointFile();
 
 #ifdef ERF_AW_MULTIBLOCK
-    void SetMultiBlockPointer(MultiBlockContainer *mbc) { m_sim.set_mbc(mbc); }
-    void set_read_erf(ReadERFFunction fcn) {m_sim.set_read_erf(fcn);}
+    void SetMultiBlockPointer(MultiBlockContainer* mbc) { m_sim.set_mbc(mbc); }
+    void set_read_erf(ReadERFFunction fcn) { m_sim.set_read_erf(fcn); }
 #endif
 
 private:

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -13,7 +13,7 @@
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/overset/OversetOps.H"
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -62,7 +62,7 @@ public:
     // Evolve solution to final time through repeated calls to Advance()
     void Evolve();
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     // Evolve solution in a multiblock framework by desired number of steps
     void Evolve_MultiBlock(int multiblock_step, int max_block_step);
 #endif
@@ -160,7 +160,7 @@ public:
 
     void ReadCheckpointFile();
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     void SetMultiBlockPointer(MultiBlockContainer* mbc) { m_sim.set_mbc(mbc); }
     void set_read_erf(ReadERFFunction fcn) { m_sim.set_read_erf(fcn); }
 #endif

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -58,6 +58,9 @@ public:
     // Evolve solution to final time through repeated calls to Advance()
     void Evolve();
 
+    // Evolve solution in a multiblock framework by desired number of steps
+    void Evolve_MB(int MBstep, int max_block_step);
+
     // Tag cells for refinement
     void
     ErrorEst(int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow)
@@ -150,6 +153,10 @@ public:
     void init_physics_and_pde();
 
     void ReadCheckpointFile();
+
+#ifdef ERF_USE_MULTIBLOCK
+    void SetMultiBlockPointer(MultiBlockContainer *mbc) { m_sim.set_mbc(mbc); }
+#endif
 
 private:
     //

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -162,7 +162,7 @@ public:
 
 #ifdef ERF_AW_MULTIBLOCK
     void SetMultiBlockPointer(MultiBlockContainer *mbc) { m_sim.set_mbc(mbc); }
-    void set_read_erf(ReadERFFcn fcn) {m_sim.set_read_erf(fcn);}
+    void set_read_erf(ReadERFFunction fcn) {m_sim.set_read_erf(fcn);}
 #endif
 
 private:

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -14,6 +14,7 @@
 #include "amr-wind/overset/OversetOps.H"
 
 #ifdef ERF_USE_MULTIBLOCK
+#include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
 namespace amr_wind {
@@ -159,6 +160,7 @@ public:
 
 #ifdef ERF_USE_MULTIBLOCK
     void SetMultiBlockPointer(MultiBlockContainer *mbc) { m_sim.set_mbc(mbc); }
+    void set_read_erf(ReadERFFcn fcn) {m_sim.set_read_erf(fcn);}
 #endif
 
 private:

--- a/amr-wind/incflo.H
+++ b/amr-wind/incflo.H
@@ -13,7 +13,7 @@
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/overset/OversetOps.H"
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -62,7 +62,7 @@ public:
     // Evolve solution to final time through repeated calls to Advance()
     void Evolve();
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     // Evolve solution in a multiblock framework by desired number of steps
     void Evolve_MB(int MBstep, int max_block_step);
 #endif
@@ -160,7 +160,7 @@ public:
 
     void ReadCheckpointFile();
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     void SetMultiBlockPointer(MultiBlockContainer *mbc) { m_sim.set_mbc(mbc); }
     void set_read_erf(ReadERFFcn fcn) {m_sim.set_read_erf(fcn);}
 #endif

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -23,7 +23,9 @@ incflo::incflo()
     // constructor. No valid BoxArray and DistributionMapping have been defined.
     // But the arrays for them have been resized.
 
-    std::cout << std::endl << std::endl << " AMR-WIND IS INITIALIZING "<< std::endl << std::endl;
+#ifdef ERF_USE_MULTIBLOCK
+    amrex::Print() << std::endl << "AMR-Wind is initializing.. "<< std::endl << std::endl;
+#endif
 
     // Check if dry run is requested and set up if so
     CheckAndSetUpDryRun();

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -23,7 +23,7 @@ incflo::incflo()
     // constructor. No valid BoxArray and DistributionMapping have been defined.
     // But the arrays for them have been resized.
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     amrex::Print() << std::endl
                    << "AMR-Wind is initializing.. " << std::endl
                    << std::endl;

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -24,7 +24,9 @@ incflo::incflo()
     // But the arrays for them have been resized.
 
 #ifdef ERF_AW_MULTIBLOCK
-    amrex::Print() << std::endl << "AMR-Wind is initializing.. "<< std::endl << std::endl;
+    amrex::Print() << std::endl
+                   << "AMR-Wind is initializing.. " << std::endl
+                   << std::endl;
 #endif
 
     // Check if dry run is requested and set up if so

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -23,7 +23,7 @@ incflo::incflo()
     // constructor. No valid BoxArray and DistributionMapping have been defined.
     // But the arrays for them have been resized.
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     amrex::Print() << std::endl << "AMR-Wind is initializing.. "<< std::endl << std::endl;
 #endif
 

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -138,7 +138,7 @@ void incflo::prepare_for_time_integration()
         return;
     }
 
-    if (m_do_initial_proj || m_initial_iterations > 0) {
+    if (m_initial_iterations > 0) {
         m_sim.pde_manager().prepare_boundaries();
     }
 

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -324,68 +324,6 @@ void incflo::Evolve()
     }
 }
 
-/** Perform time-integration with multiblock coupled with ERF
- */
-void incflo::Evolve_MB(int MBstep, int max_block_step)
-{
-    BL_PROFILE("amr-wind::incflo::Evolve()");
-
-    int step = 0;
-
-    amrex::Print() << "\n======================================================"
-      "========================\n";
-    amrex::Print() << "AMR_WIND STEP" << std::endl;
-    while (step < max_block_step) {
-        m_time.new_timestep();
-        step+=1;
-        amrex::Real time0 = amrex::ParallelDescriptor::second();
-
-        regrid_and_update();
-
-        if (m_prescribe_vel) {
-            pre_advance_stage2();
-            ComputePrescribeDt();
-        } else {
-            pre_advance_stage1();
-            pre_advance_stage2();
-        }
-
-        amrex::Real time1 = amrex::ParallelDescriptor::second();
-        // Advance to time t + dt
-        do_advance();
-        amrex::Print() << std::endl;
-        amrex::Real time2 = amrex::ParallelDescriptor::second();
-        post_advance_work();
-        amrex::Real time3 = amrex::ParallelDescriptor::second();
-
-        amrex::Print() << "WallClockTime: " << m_time.time_index()
-                       << " Pre: " << std::setprecision(3) << (time1 - time0)
-                       << " Solve: " << std::setprecision(4) << (time2 - time1)
-                       << " Post: " << std::setprecision(3) << (time3 - time2)
-                       << " Total: " << std::setprecision(4) << (time3 - time0)
-                       << std::endl;
-
-        amrex::Print() << "Solve time per cell: " << std::setprecision(4)
-                       << amrex::ParallelDescriptor::NProcs() *
-                              (time2 - time1) /
-                              static_cast<amrex::Real>(m_cell_count)
-                       << std::endl;
-    }
-    amrex::Print() << "\n======================================================"
-                      "========================\n"
-                   << std::endl;
-
-    // Output at final time
-    /*
-    if (m_time.write_last_plot_file()) {
-        m_sim.io_manager().write_plot_file();
-    }
-    if (m_time.write_last_checkpoint()) {
-        m_sim.io_manager().write_checkpoint_file();
-    }
-    */
-}
-
 void incflo::do_advance(const int fixed_point_iteration)
 {
     if (m_sim.has_overset()) {

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -23,6 +23,8 @@ incflo::incflo()
     // constructor. No valid BoxArray and DistributionMapping have been defined.
     // But the arrays for them have been resized.
 
+    std::cout << std::endl << std::endl << " AMR-WIND IS INITIALIZING "<< std::endl << std::endl;
+
     // Check if dry run is requested and set up if so
     CheckAndSetUpDryRun();
 
@@ -318,6 +320,68 @@ void incflo::Evolve()
     if (m_time.write_last_checkpoint()) {
         m_sim.io_manager().write_checkpoint_file();
     }
+}
+
+/** Perform time-integration with multiblock coupled with ERF
+ */
+void incflo::Evolve_MB(int MBstep, int max_block_step)
+{
+    BL_PROFILE("amr-wind::incflo::Evolve()");
+
+    int step = 0;
+
+    amrex::Print() << "\n======================================================"
+      "========================\n";
+    amrex::Print() << "AMR_WIND STEP" << std::endl;
+    while (step < max_block_step) {
+        m_time.new_timestep();
+        step+=1;
+        amrex::Real time0 = amrex::ParallelDescriptor::second();
+
+        regrid_and_update();
+
+        if (m_prescribe_vel) {
+            pre_advance_stage2();
+            ComputePrescribeDt();
+        } else {
+            pre_advance_stage1();
+            pre_advance_stage2();
+        }
+
+        amrex::Real time1 = amrex::ParallelDescriptor::second();
+        // Advance to time t + dt
+        do_advance();
+        amrex::Print() << std::endl;
+        amrex::Real time2 = amrex::ParallelDescriptor::second();
+        post_advance_work();
+        amrex::Real time3 = amrex::ParallelDescriptor::second();
+
+        amrex::Print() << "WallClockTime: " << m_time.time_index()
+                       << " Pre: " << std::setprecision(3) << (time1 - time0)
+                       << " Solve: " << std::setprecision(4) << (time2 - time1)
+                       << " Post: " << std::setprecision(3) << (time3 - time2)
+                       << " Total: " << std::setprecision(4) << (time3 - time0)
+                       << std::endl;
+
+        amrex::Print() << "Solve time per cell: " << std::setprecision(4)
+                       << amrex::ParallelDescriptor::NProcs() *
+                              (time2 - time1) /
+                              static_cast<amrex::Real>(m_cell_count)
+                       << std::endl;
+    }
+    amrex::Print() << "\n======================================================"
+                      "========================\n"
+                   << std::endl;
+
+    // Output at final time
+    /*
+    if (m_time.write_last_plot_file()) {
+        m_sim.io_manager().write_plot_file();
+    }
+    if (m_time.write_last_checkpoint()) {
+        m_sim.io_manager().write_checkpoint_file();
+    }
+    */
 }
 
 void incflo::do_advance(const int fixed_point_iteration)

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -24,7 +24,8 @@ closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 AMREX_FORCE_INLINE int
 closest_index_lbound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {
-    auto const it = std::lower_bound(vec.begin(), vec.end(), value);
+    amrex::Real one_minus_eps = 1.0 - 1.e-8;
+    auto const it = std::lower_bound(vec.begin(), vec.end(), one_minus_eps*value);
     AMREX_ALWAYS_ASSERT(it != vec.end());
 
     const int idx = static_cast<int>(std::distance(vec.begin(), it));

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -20,6 +20,17 @@ closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
     return std::max(idx - 1, 0);
 }
 
+//! This version is required for the ERF coupling
+AMREX_FORCE_INLINE int
+closest_index_lbound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
+{
+    auto const it = std::lower_bound(vec.begin(), vec.end(), value);
+    AMREX_ALWAYS_ASSERT(it != vec.end());
+
+    const int idx = static_cast<int>(std::distance(vec.begin(), it));
+    return std::max(idx - 1, 0);
+}
+
 //! Return indices perpendicular to normal
 template <typename T = amrex::GpuArray<int, 2>>
 AMREX_FORCE_INLINE T perpendicular_idx(const int normal)

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -9,9 +9,9 @@
 
 namespace amr_wind::utils {
 
-//! Return closest index (from lower) of value in vector
+//! Return closest index (from lower) of value in vector, lbound verion for ERF coupling
 AMREX_FORCE_INLINE int
-closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
+closest_index_ubound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {
     auto const it = std::upper_bound(vec.begin(), vec.end(), value);
     AMREX_ALWAYS_ASSERT(it != vec.end());
@@ -20,7 +20,6 @@ closest_index(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
     return std::max(idx - 1, 0);
 }
 
-//! This version is required for the ERF coupling
 AMREX_FORCE_INLINE int
 closest_index_lbound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -9,9 +9,10 @@
 
 namespace amr_wind::utils {
 
-//! Return closest index (from lower) of value in vector, lbound verion for ERF coupling
-AMREX_FORCE_INLINE int
-closest_index_ubound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
+//! Return closest index (from lower) of value in vector
+//! lbound verion is required for ERF coupling
+AMREX_FORCE_INLINE int closest_index_ubound(
+    const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {
     auto const it = std::upper_bound(vec.begin(), vec.end(), value);
     AMREX_ALWAYS_ASSERT(it != vec.end());
@@ -20,11 +21,12 @@ closest_index_ubound(const amrex::Vector<amrex::Real>& vec, const amrex::Real va
     return std::max(idx - 1, 0);
 }
 
-AMREX_FORCE_INLINE int
-closest_index_lbound(const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
+AMREX_FORCE_INLINE int closest_index_lbound(
+    const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {
     amrex::Real one_minus_eps = 1.0 - 1.e-8;
-    auto const it = std::lower_bound(vec.begin(), vec.end(), one_minus_eps*value);
+    auto const it =
+        std::lower_bound(vec.begin(), vec.end(), one_minus_eps * value);
     AMREX_ALWAYS_ASSERT(it != vec.end());
 
     const int idx = static_cast<int>(std::distance(vec.begin(), it));

--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -10,7 +10,7 @@
 namespace amr_wind::utils {
 
 //! Return closest index (from lower) of value in vector
-//! lbound verion is required for ERF coupling
+//! lbound version is required for ERF coupling
 AMREX_FORCE_INLINE int closest_index_ubound(
     const amrex::Vector<amrex::Real>& vec, const amrex::Real value)
 {

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -7,6 +7,10 @@
 #include "amr-wind/utilities/ncutils/nc_interface.H"
 #include <AMReX_BndryRegister.H>
 
+#ifdef ERF_USE_MULTIBLOCK
+#include "amr-wind/wind_energy/ABLReadERFFcn.H"
+class MultiBlockContainer;
+#endif
 namespace amr_wind {
 
 enum struct io_mode { output, input, undefined };
@@ -57,7 +61,8 @@ public:
         const int lev,
         const Field* /*fld*/,
         const amrex::Real time,
-        const amrex::Vector<amrex::Real>& /*times*/);
+        const amrex::Vector<amrex::Real>& /*times*/,
+        const bool erf_multiblock = false);
 
     void interpolate(const amrex::Real /*time*/);
     bool is_populated(amrex::Orientation /*ori*/) const;
@@ -165,10 +170,23 @@ public:
 
     io_mode mode() const { return m_io_mode; }
 
+#ifdef ERF_USE_MULTIBLOCK
+    MultiBlockContainer* mbc() {return *m_mbc;}
+#endif
+
 private:
     const amr_wind::SimTime& m_time;
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
+
+#ifdef ERF_USE_MULTIBLOCK
+    // pointer to pointer : when ABL boundary plane gets intiialized, amr-wind
+    // CFDsim does not yet have the up to date pointer to the mbc or the read_erf function
+    // be careful: if this is used before amr-wind gets the mbc pointer set
+    // bad things will happen
+    MultiBlockContainer** m_mbc;
+    ReadERFFcn* m_read_erf {nullptr};
+#endif
 
 #ifdef AMR_WIND_USE_NETCDF
     void write_data(

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -185,7 +185,7 @@ private:
     // be careful: if this is used before amr-wind gets the mbc pointer set
     // bad things will happen
     MultiBlockContainer** m_mbc;
-    ReadERFFcn* m_read_erf {nullptr};
+    ReadERFFunction* m_read_erf {nullptr};
 #endif
 
 #ifdef AMR_WIND_USE_NETCDF

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -180,7 +180,7 @@ private:
     const amrex::AmrCore& m_mesh;
 
 #ifdef ERF_AMR_WIND_MULTIBLOCK
-    // pointer to pointer : when ABL boundary plane gets intiialized, amr-wind
+    // pointer to pointer : when ABL boundary plane gets initialized, amr-wind
     // CFDsim does not yet have the up to date pointer to the mbc or the
     // read_erf function, be careful: if this is used before amr-wind gets the
     // mbc pointer set bad things will happen

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -171,7 +171,7 @@ public:
     io_mode mode() const { return m_io_mode; }
 
 #ifdef ERF_AW_MULTIBLOCK
-    MultiBlockContainer* mbc() {return *m_mbc;}
+    MultiBlockContainer* mbc() { return *m_mbc; }
 #endif
 
 private:
@@ -181,11 +181,11 @@ private:
 
 #ifdef ERF_AW_MULTIBLOCK
     // pointer to pointer : when ABL boundary plane gets intiialized, amr-wind
-    // CFDsim does not yet have the up to date pointer to the mbc or the read_erf function
-    // be careful: if this is used before amr-wind gets the mbc pointer set
-    // bad things will happen
+    // CFDsim does not yet have the up to date pointer to the mbc or the
+    // read_erf function, be careful: if this is used before amr-wind gets the
+    // mbc pointer set bad things will happen
     MultiBlockContainer** m_mbc;
-    ReadERFFunction* m_read_erf {nullptr};
+    ReadERFFunction* m_read_erf{nullptr};
 #endif
 
 #ifdef AMR_WIND_USE_NETCDF

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -7,7 +7,7 @@
 #include "amr-wind/utilities/ncutils/nc_interface.H"
 #include <AMReX_BndryRegister.H>
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -170,7 +170,7 @@ public:
 
     io_mode mode() const { return m_io_mode; }
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     MultiBlockContainer* mbc() {return *m_mbc;}
 #endif
 
@@ -179,7 +179,7 @@ private:
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
 
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     // pointer to pointer : when ABL boundary plane gets intiialized, amr-wind
     // CFDsim does not yet have the up to date pointer to the mbc or the read_erf function
     // be careful: if this is used before amr-wind gets the mbc pointer set

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -7,7 +7,7 @@
 #include "amr-wind/utilities/ncutils/nc_interface.H"
 #include <AMReX_BndryRegister.H>
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
 #include "amr-wind/wind_energy/ABLReadERFFcn.H"
 class MultiBlockContainer;
 #endif
@@ -170,7 +170,7 @@ public:
 
     io_mode mode() const { return m_io_mode; }
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     MultiBlockContainer* mbc() { return *m_mbc; }
 #endif
 
@@ -179,7 +179,7 @@ private:
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     // pointer to pointer : when ABL boundary plane gets intiialized, amr-wind
     // CFDsim does not yet have the up to date pointer to the mbc or the
     // read_erf function, be careful: if this is used before amr-wind gets the

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -254,7 +254,7 @@ bool InletData::is_populated(amrex::Orientation ori) const
 
 ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
     : m_time(sim.time()), m_repo(sim.repo()), m_mesh(sim.mesh())
-#ifdef ERF_USE_MULTIBLOCK
+#ifdef ERF_AW_MULTIBLOCK
     , m_mbc(sim.mbc()), m_read_erf(sim.get_read_erf())
 #endif
 {

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -167,7 +167,8 @@ void InletData::read_data_native(
 
     auto ori = oit();
 
-    AMREX_ALWAYS_ASSERT(((m_tn <= time) && (time <= m_tnp1)));
+    amrex::Real one_plus_eps = 1.0 + 1.e-8;
+    AMREX_ALWAYS_ASSERT(((m_tn <= one_plus_eps*time) && (time <= one_plus_eps*m_tnp1)));
     AMREX_ALWAYS_ASSERT(fld->num_comp() == bndry_n[ori].nComp());
     AMREX_ASSERT(bndry_n[ori].boxArray() == bndry_np1[ori].boxArray());
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -811,6 +811,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         return;
     }
 
+#ifdef ERF_AW_MULTIBLOCK
     if (m_out_fmt == "erf-multiblock") {
         //m_read_erf = sim.get_read_erf();
         ReadERFFcn read_erf = *m_read_erf;
@@ -822,6 +823,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         }
         return;
     }
+#endif
 
     // populate planes and interpolate
     const amrex::Real time =

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -819,12 +819,17 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         return;
     }
 
+    // populate planes and interpolate
+    const amrex::Real time =
+        m_time.new_time() + (nph_target_time ? 0.5 : 0.0) *
+                                (m_time.current_time() - m_time.new_time());
+
 #ifdef ERF_AMR_WIND_MULTIBLOCK
     if (m_out_fmt == "erf-multiblock") {
         // m_read_erf = sim.get_read_erf();
         ReadERFFunction read_erf = *m_read_erf;
         if (read_erf) {
-            read_erf(m_time, m_in_times, m_in_data, m_fields, mbc());
+            read_erf(time, m_in_times, m_in_data, m_fields, mbc());
         } else {
             amrex::Abort("read_erf function is undefined.");
         }
@@ -832,10 +837,6 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
     }
 #endif
 
-    // populate planes and interpolate
-    const amrex::Real time =
-        m_time.new_time() + (nph_target_time ? 0.5 : 0.0) *
-                                (m_time.current_time() - m_time.new_time());
     AMREX_ALWAYS_ASSERT((m_in_times[0] <= time) && (time < m_in_times.back()));
 
     // return early if current data files can still be interpolated in time

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -258,7 +258,7 @@ ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
     : m_time(sim.time())
     , m_repo(sim.repo())
     , m_mesh(sim.mesh())
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     , m_mbc(sim.mbc())
     , m_read_erf(sim.get_read_erf())
 #endif
@@ -819,7 +819,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         return;
     }
 
-#ifdef ERF_AW_MULTIBLOCK
+#ifdef ERF_AMR_WIND_MULTIBLOCK
     if (m_out_fmt == "erf-multiblock") {
         // m_read_erf = sim.get_read_erf();
         ReadERFFunction read_erf = *m_read_erf;

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -357,7 +357,7 @@ void ABLBoundaryPlane::initialize_data()
                 "ABLBoundaryPlane: invalid variable requested: " + fname);
         }
     }
-    if (m_io_mode == io_mode::output and m_out_fmt == "erf-multiblock") {
+    if ((m_io_mode == io_mode::output) && (m_out_fmt == "erf-multiblock")) {
       amrex::Abort("ABLBoundaryPlane: can't output data in erf-multiblock mode");
     }
 }

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -168,7 +168,8 @@ void InletData::read_data_native(
     auto ori = oit();
 
     amrex::Real one_plus_eps = 1.0 + 1.e-8;
-    AMREX_ALWAYS_ASSERT(((m_tn <= one_plus_eps*time) && (time <= one_plus_eps*m_tnp1)));
+    AMREX_ALWAYS_ASSERT(
+        ((m_tn <= one_plus_eps * time) && (time <= one_plus_eps * m_tnp1)));
     AMREX_ALWAYS_ASSERT(fld->num_comp() == bndry_n[ori].nComp());
     AMREX_ASSERT(bndry_n[ori].boxArray() == bndry_np1[ori].boxArray());
 
@@ -254,9 +255,12 @@ bool InletData::is_populated(amrex::Orientation ori) const
 }
 
 ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
-    : m_time(sim.time()), m_repo(sim.repo()), m_mesh(sim.mesh())
+    : m_time(sim.time())
+    , m_repo(sim.repo())
+    , m_mesh(sim.mesh())
 #ifdef ERF_AW_MULTIBLOCK
-    , m_mbc(sim.mbc()), m_read_erf(sim.get_read_erf())
+    , m_mbc(sim.mbc())
+    , m_read_erf(sim.get_read_erf())
 #endif
 {
     amrex::ParmParse pp("ABL");
@@ -294,7 +298,8 @@ ABLBoundaryPlane::ABLBoundaryPlane(CFDSim& sim)
     }
 #endif
 
-    if (!(m_out_fmt == "native" || m_out_fmt == "netcdf" || m_out_fmt == "erf-multiblock")) {
+    if (!((m_out_fmt == "native") || (m_out_fmt == "netcdf") ||
+          (m_out_fmt == "erf-multiblock"))) {
         amrex::Print() << "Warning: boundary output format not recognized, "
                           "changing to native format"
                        << std::endl;
@@ -358,7 +363,8 @@ void ABLBoundaryPlane::initialize_data()
         }
     }
     if ((m_io_mode == io_mode::output) && (m_out_fmt == "erf-multiblock")) {
-      amrex::Abort("ABLBoundaryPlane: can't output data in erf-multiblock mode");
+        amrex::Abort(
+            "ABLBoundaryPlane: can't output data in erf-multiblock mode");
     }
 }
 
@@ -776,7 +782,8 @@ void ABLBoundaryPlane::read_header()
         }
     } else if (m_out_fmt == "erf-multiblock") {
 
-        m_in_times.push_back(-1.0e13); // create space for storing time at erf old and new timestep
+        m_in_times.push_back(-1.0e13); // create space for storing time at erf
+                                       // old and new timestep
         m_in_times.push_back(-1.0e13);
 
         int nc = 0;
@@ -814,10 +821,9 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
 
 #ifdef ERF_AW_MULTIBLOCK
     if (m_out_fmt == "erf-multiblock") {
-        //m_read_erf = sim.get_read_erf();
+        // m_read_erf = sim.get_read_erf();
         ReadERFFunction read_erf = *m_read_erf;
-        if (read_erf)
-        {
+        if (read_erf) {
             read_erf(m_time, m_in_times, m_in_data, m_fields, mbc());
         } else {
             amrex::Abort("read_erf function is undefined.");

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -77,7 +77,7 @@ void InletData::read_data(
     const size_t nc = fld->num_comp();
     const int nstart = m_components[static_cast<int>(fld->id())];
 
-    const int idx = utils::closest_index(times, time);
+    const int idx = utils::closest_index_ubound(times, time);
     const int idxp1 = idx + 1;
     m_tn = times[idx];
     m_tnp1 = times[idxp1];
@@ -158,7 +158,7 @@ void InletData::read_data_native(
         // otherwise it will abort
         idx = utils::closest_index_lbound(times, time);
     } else {
-        idx = utils::closest_index(times, time);
+        idx = utils::closest_index_ubound(times, time);
     }
     const int idxp1 = idx + 1;
 
@@ -866,7 +866,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
 
     if (m_out_fmt == "native") {
 
-        const int index = utils::closest_index(m_in_times, time);
+        const int index = utils::closest_index_ubound(m_in_times, time);
         const int t_step1 = m_in_timesteps[index];
         const int t_step2 = m_in_timesteps[index + 1];
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -810,7 +810,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
     if (m_io_mode != io_mode::input) {
         return;
     }
-#ifdef ERF_USE_MULTIBLOCK
+
     if (m_out_fmt == "erf-multiblock") {
         //m_read_erf = sim.get_read_erf();
         ReadERFFcn read_erf = *m_read_erf;
@@ -822,7 +822,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         }
         return;
     }
-#endif
+
     // populate planes and interpolate
     const amrex::Real time =
         m_time.new_time() + (nph_target_time ? 0.5 : 0.0) *

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -815,7 +815,7 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
 #ifdef ERF_AW_MULTIBLOCK
     if (m_out_fmt == "erf-multiblock") {
         //m_read_erf = sim.get_read_erf();
-        ReadERFFcn read_erf = *m_read_erf;
+        ReadERFFunction read_erf = *m_read_erf;
         if (read_erf)
         {
             read_erf(m_time, m_in_times, m_in_data, m_fields, mbc());

--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -47,6 +47,20 @@ public:
     void init_tke(const amrex::Geometry& geom, amrex::MultiFab& tke) const;
 
 private:
+    // ABL-with-bubble
+
+    //! Initial bubble location
+    amrex::Vector<amrex::Real> m_bubble_loc{{0.25, 0.25, 0.5}};
+
+    //! Initial bubble radius
+    amrex::Real m_bubble_radius{0.1};
+
+    //! Initial bubble
+    amrex::Real m_bubble_temp_ratio{1.1};
+
+    //! Whether or not to have temperature bubble
+    bool m_use_bubble{0};
+
     //! Initial velocity components
     amrex::Vector<amrex::Real> m_vel;
 

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -41,6 +41,17 @@ void ABLFieldInit::initialize_from_inputfile()
             }
         }
     }
+    // ABL-with-bubble
+    pp_abl.query("use_bubble", m_use_bubble);
+    if (m_use_bubble) {
+      amrex::Print() << "Initializing with bubble" << std::endl;
+      pp_abl.getarr("bubble_loc", m_bubble_loc);
+      pp_abl.query("bubble_radius", m_bubble_radius);
+      pp_abl.query("bubble_temp_ratio", m_bubble_temp_ratio);
+    } else {
+      amrex::Print() << "Not initializing with bubble" << std::endl;
+    }
+
     // Temperature variation as a function of height
     pp_abl.getarr("temperature_heights", m_theta_heights);
     pp_abl.getarr("temperature_values", m_theta_values);
@@ -282,8 +293,14 @@ void ABLFieldInit::operator()(
         const amrex::Real bottom_v_vel = m_bottom_vel[1];
         const amrex::Real bottom_w_vel = m_bottom_vel[2];
 
+        const amrex::Real bcx = m_bubble_loc[0];
+        const amrex::Real bcy = m_bubble_loc[1];
+        const amrex::Real bcz = m_bubble_loc[2];
+
         amrex::ParallelFor(
             vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                const amrex::Real y = problo[1] + (j + 0.5) * dx[1];
                 const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
                 density(i, j, k) = rho_init;
@@ -302,6 +319,13 @@ void ABLFieldInit::operator()(
                 }
 
                 temperature(i, j, k, 0) += theta;
+
+                amrex::Real ratio = 1.0;
+                if (m_use_bubble) {
+                  amrex::Real radius = std::sqrt((x-bcx)*(x-bcx) + (y-bcy)*(y-bcy) + (z-bcz)*(z-bcz));
+                  ratio = 1.0 + (m_bubble_temp_ratio - 1.0) * exp(-0.5 * radius* radius / (m_bubble_radius * m_bubble_radius));
+                }
+                temperature(i, j, k, 0) *= ratio;
 
                 if (linear_profile) {
                     velocity(i, j, k, 0) =

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -44,12 +44,12 @@ void ABLFieldInit::initialize_from_inputfile()
     // ABL-with-bubble
     pp_abl.query("use_bubble", m_use_bubble);
     if (m_use_bubble) {
-      amrex::Print() << "Initializing with bubble" << std::endl;
-      pp_abl.getarr("bubble_loc", m_bubble_loc);
-      pp_abl.query("bubble_radius", m_bubble_radius);
-      pp_abl.query("bubble_temp_ratio", m_bubble_temp_ratio);
+        amrex::Print() << "Initializing with bubble" << std::endl;
+        pp_abl.getarr("bubble_loc", m_bubble_loc);
+        pp_abl.query("bubble_radius", m_bubble_radius);
+        pp_abl.query("bubble_temp_ratio", m_bubble_temp_ratio);
     } else {
-      amrex::Print() << "Not initializing with bubble" << std::endl;
+        amrex::Print() << "Not initializing with bubble" << std::endl;
     }
 
     // Temperature variation as a function of height
@@ -322,8 +322,12 @@ void ABLFieldInit::operator()(
 
                 amrex::Real ratio = 1.0;
                 if (m_use_bubble) {
-                  amrex::Real radius = std::sqrt((x-bcx)*(x-bcx) + (y-bcy)*(y-bcy) + (z-bcz)*(z-bcz));
-                  ratio = 1.0 + (m_bubble_temp_ratio - 1.0) * exp(-0.5 * radius* radius / (m_bubble_radius * m_bubble_radius));
+                    amrex::Real radius = std::sqrt(
+                        (x - bcx) * (x - bcx) + (y - bcy) * (y - bcy) +
+                        (z - bcz) * (z - bcz));
+                    ratio = 1.0 + (m_bubble_temp_ratio - 1.0) *
+                                      exp(-0.5 * radius * radius /
+                                          (m_bubble_radius * m_bubble_radius));
                 }
                 temperature(i, j, k, 0) *= ratio;
 

--- a/amr-wind/wind_energy/ABLReadERFFcn.H
+++ b/amr-wind/wind_energy/ABLReadERFFcn.H
@@ -1,0 +1,17 @@
+#ifndef ABLREADERFFCN_H
+#define ABLREADERFFCN_H
+#include <functional>
+
+class MultiBlockContainer;
+namespace amr_wind {
+    class InletData;
+}
+
+using ReadERFFcn = std::function <void (
+                    const amr_wind::SimTime&,
+                    amrex::Vector<amrex::Real>&,
+                    amr_wind::InletData&,
+                    const amrex::Vector<amr_wind::Field*>&,
+                    MultiBlockContainer* )>;
+
+#endif /* ABLREADERFFCN_H */

--- a/amr-wind/wind_energy/ABLReadERFFcn.H
+++ b/amr-wind/wind_energy/ABLReadERFFcn.H
@@ -4,14 +4,14 @@
 
 class MultiBlockContainer;
 namespace amr_wind {
-    class InletData;
+class InletData;
 }
 
-using ReadERFFunction = std::function <void (
-                    const amr_wind::SimTime&,
-                    amrex::Vector<amrex::Real>&,
-                    amr_wind::InletData&,
-                    const amrex::Vector<amr_wind::Field*>&,
-                    MultiBlockContainer* )>;
+using ReadERFFunction = std::function<void(
+    const amr_wind::SimTime&,
+    amrex::Vector<amrex::Real>&,
+    amr_wind::InletData&,
+    const amrex::Vector<amr_wind::Field*>&,
+    MultiBlockContainer*)>;
 
 #endif /* ABLREADERFFCN_H */

--- a/amr-wind/wind_energy/ABLReadERFFcn.H
+++ b/amr-wind/wind_energy/ABLReadERFFcn.H
@@ -7,7 +7,7 @@ namespace amr_wind {
     class InletData;
 }
 
-using ReadERFFcn = std::function <void (
+using ReadERFFunction = std::function <void (
                     const amr_wind::SimTime&,
                     amrex::Vector<amrex::Real>&,
                     amr_wind::InletData&,

--- a/amr-wind/wind_energy/ABLReadERFFcn.H
+++ b/amr-wind/wind_energy/ABLReadERFFcn.H
@@ -8,7 +8,7 @@ class InletData;
 }
 
 using ReadERFFunction = std::function<void(
-    const amr_wind::SimTime&,
+    const amrex::Real time,
     amrex::Vector<amrex::Real>&,
     amr_wind::InletData&,
     const amrex::Vector<amr_wind::Field*>&,

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -28,8 +28,8 @@ endfunction(set_cuda_build_properties)
 
 macro(init_amrex)
   if (${AMR_WIND_USE_INTERNAL_AMREX})
-    set(AMREX_SUBMOD_LOCATION "${CMAKE_SOURCE_DIR}/submods/amrex")
-    include(${CMAKE_SOURCE_DIR}/cmake/set_amrex_options.cmake)
+    set(AMREX_SUBMOD_LOCATION "${PROJECT_SOURCE_DIR}/submods/amrex")
+    include(${PROJECT_SOURCE_DIR}/cmake/set_amrex_options.cmake)
     list(APPEND CMAKE_MODULE_PATH "${AMREX_SUBMOD_LOCATION}/Tools/CMake")
     add_subdirectory(${AMREX_SUBMOD_LOCATION})
     set(FCOMPARE_EXE ${CMAKE_BINARY_DIR}/submods/amrex/Tools/Plotfile/amrex_fcompare
@@ -70,8 +70,8 @@ endmacro(init_amrex)
 
 macro(init_amrex_hydro)
   if (${AMR_WIND_USE_INTERNAL_AMREX_HYDRO})
-    set(AMREX_HYDRO_SUBMOD_LOCATION "${CMAKE_SOURCE_DIR}/submods/AMReX-Hydro")
-    include(${CMAKE_SOURCE_DIR}/cmake/set_amrex_hydro_options.cmake)
+    set(AMREX_HYDRO_SUBMOD_LOCATION "${PROJECT_SOURCE_DIR}/submods/AMReX-Hydro")
+    include(${PROJECT_SOURCE_DIR}/cmake/set_amrex_hydro_options.cmake)
     add_subdirectory(${AMREX_HYDRO_SUBMOD_LOCATION})
   else()
     set(CMAKE_PREFIX_PATH ${AMReX-Hydro_DIR} ${CMAKE_PREFIX_PATH})
@@ -124,7 +124,7 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" ${CMAKE_BINARY_DIR}/compile_commands.json > cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --suppress=missingIncludeSystem --std=c++17 --language=c++ --enable=all --project=cppcheck_compile_commands.json -i ${CMAKE_SOURCE_DIR}/submods/amrex/Src -i ${CMAKE_SOURCE_DIR}/submods/AMReX-Hydro -i ${CMAKE_SOURCE_DIR}/submods/Waves2AMR -i ${CMAKE_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --suppress=missingIncludeSystem --std=c++17 --language=c++ --enable=all --project=cppcheck_compile_commands.json -i ${PROJECT_SOURCE_DIR}/submods/amrex/Src -i ${PROJECT_SOURCE_DIR}/submods/AMReX-Hydro -i ${PROJECT_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
           COMMENT "Run cppcheck on project compile_commands.json"
           BYPRODUCTS cppcheck-full-report.txt
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck

--- a/cmake/amr-wind-utils.cmake
+++ b/cmake/amr-wind-utils.cmake
@@ -124,7 +124,7 @@ macro(init_code_checks)
           COMMAND ${CMAKE_COMMAND} -E make_directory cppcheck
           # cppcheck ignores -isystem directories, so we change them to regular -I include directories (with no spaces either)
           COMMAND sed "s/isystem /I/g" ${CMAKE_BINARY_DIR}/compile_commands.json > cppcheck_compile_commands.json
-          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --suppress=missingIncludeSystem --std=c++17 --language=c++ --enable=all --project=cppcheck_compile_commands.json -i ${PROJECT_SOURCE_DIR}/submods/amrex/Src -i ${PROJECT_SOURCE_DIR}/submods/AMReX-Hydro -i ${PROJECT_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
+          COMMAND ${CPPCHECK_EXE} --template=gcc --inline-suppr --suppress=unusedFunction --suppress=useStlAlgorithm --suppress=missingIncludeSystem --std=c++17 --language=c++ --enable=all --project=cppcheck_compile_commands.json -i ${PROJECT_SOURCE_DIR}/submods/amrex/Src -i ${PROJECT_SOURCE_DIR}/submods/AMReX-Hydro -i ${PROJECT_SOURCE_DIR}/submods/Waves2AMR -i ${PROJECT_SOURCE_DIR}/submods/googletest --output-file=cppcheck-full-report.txt -j ${NP}
           COMMENT "Run cppcheck on project compile_commands.json"
           BYPRODUCTS cppcheck-full-report.txt
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/cppcheck


### PR DESCRIPTION
## Summary

These changes allow coupling with ERF via the MultiBlock mechanism. It includes maintaining a pointer to the multiblock container which is defined in the coupling driver. For reading ERF data, it uses the ABL boundary plane mechanism by defining a `read_erf` function in the driver and passing it to a function pointer in AMR-Wind.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU (MacOS M3 arch, GCC 13)
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU (MacOS M3 arch, GCC 13)

