### PR TITLE
Perform prepare_boundaries at correct times

### DIFF
--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -114,7 +114,7 @@ void PDEMgr::prepare_boundaries()
         field_ops::copy(
             nph_field, new_field, 0, 0, new_field.num_comp(),
             new_field.num_grow());
-        // Insert fill physical boundary condition call here
+        nph_field.fillphysbc(nph_time);
     }
     for (auto& eqn : scalar_eqns()) {
         eqn->fields().field.advance_states();
@@ -125,7 +125,7 @@ void PDEMgr::prepare_boundaries()
             field_ops::copy(
                 nph_field, new_field, 0, 0, new_field.num_comp(),
                 new_field.num_grow());
-            // Insert fill physical boundary condition call here
+            nph_field.fillphysbc(nph_time);
         }
     }
 

--- a/amr-wind/wind_energy/ABLBoundaryPlane.H
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.H
@@ -160,8 +160,7 @@ public:
 
     bool is_data_newer_than(const amrex::Real time) const
     {
-        // Will replace with m_in_data.tinterp()
-        return (m_intended_interp_time - time > 1e-12);
+        return (m_in_data.tinterp() - time > 1e-12);
     }
 
     io_mode mode() const { return m_io_mode; }
@@ -194,8 +193,6 @@ private:
 
     //! Start outputting after this time
     amrex::Real m_out_start_time{0.0};
-
-    amrex::Real m_intended_interp_time{0.0};
 
 #ifdef AMR_WIND_USE_NETCDF
     //! NetCDF time output counter

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -767,15 +767,13 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
     }
 
     // populate planes and interpolate
-    const amrex::Real time = m_time.new_time();
-    const amrex::Real conditional_time =
+    const amrex::Real time =
         m_time.new_time() + (nph_target_time ? 0.5 : 0.0) *
                                 (m_time.current_time() - m_time.new_time());
     AMREX_ALWAYS_ASSERT((m_in_times[0] <= time) && (time < m_in_times.back()));
 
     // return early if current data files can still be interpolated in time
     if ((m_in_data.tn() <= time) && (time < m_in_data.tnp1())) {
-        m_intended_interp_time = conditional_time;
         m_in_data.interpolate(time);
         return;
     }
@@ -871,7 +869,6 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
         }
     }
 
-    m_intended_interp_time = conditional_time;
     m_in_data.interpolate(time);
 }
 

--- a/amr-wind/wind_energy/ABLFillInflow.cpp
+++ b/amr-wind/wind_energy/ABLFillInflow.cpp
@@ -50,7 +50,7 @@ void ABLFillInflow::fillphysbc(
     FieldFillPatchOps<FieldBCDirichlet>::fillphysbc(
         lev, time, mfab, nghost, fstate);
 
-    m_bndry_plane.populate_data(lev, m_time.new_time(), m_field, mfab);
+    m_bndry_plane.populate_data(lev, time, m_field, mfab);
 }
 
 void ABLFillInflow::fillpatch_sibling_fields(
@@ -105,10 +105,7 @@ void ABLFillInflow::fillpatch_sibling_fields(
 
     if (!plane_data_unchanged) {
         for (int i = 0; i < static_cast<int>(mfabs.size()); i++) {
-            // use new_time to populate boundary data instead of half-time
-            // to avoid interpolating from precursor data
-            m_bndry_plane.populate_data(
-                lev, m_time.new_time(), m_field, *mfabs[i], 0, i);
+            m_bndry_plane.populate_data(lev, time, m_field, *mfabs[i], 0, i);
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow on to #1274 and fulfilling intention of #1210. Two changes:

1. fillphysbc calls at n+1/2 time to put time-correct values into nph variable states, which are already prepared to be used in advection. Without these calls (as it is after the no-diffs PR #1274), the nph states are just the same as the old (n) states.
2. convert the usage of m_intended_interp_time to actually calculate the interpolation time. This is to interpolate the plane data at n+1/2 prior to the timestep and then at n+1 at the beginning of the timestep.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Expected diffs are in the time-dependent BC cases (freestream_inout, rankine*) and the abl boundary input cases (abl_bndry_input*, abl_godunov_forcetimetable).
