### PR TITLE
For explicit diffusion operations, use designated state of the variable

### DIFF
--- a/amr-wind/core/Field.cpp
+++ b/amr-wind/core/Field.cpp
@@ -266,11 +266,11 @@ void Field::fillphysbc(const amrex::Real time) noexcept
     fillphysbc(time, num_grow());
 }
 
-void Field::apply_bc_funcs(const FieldState rho_state) noexcept
+void Field::apply_bc_funcs(const FieldState state) noexcept
 {
     BL_ASSERT(m_info->bc_initialized() && m_info->m_bc_copied_to_device);
     for (const auto& func : m_info->m_bc_func) {
-        (*func)(*this, rho_state);
+        (*func)(*this, state);
     }
 }
 

--- a/amr-wind/equation_systems/BCOps.H
+++ b/amr-wind/equation_systems/BCOps.H
@@ -39,9 +39,8 @@ struct BCOp<PDE, std::enable_if_t<std::is_base_of_v<ScalarTransport, PDE>>>
     {
         amrex::IntVect ng_diff(1);
         auto& field = m_fields.field.state(state);
-        const auto bc_time = (state == FieldState::Old)
-                                 ? m_time.current_time()
-                                 : m_time.new_time();
+        const auto bc_time = (state == FieldState::Old) ? m_time.current_time()
+                                                        : m_time.new_time();
         if ((state != FieldState::Old && state != FieldState::New)) {
             amrex::Abort(
                 "BCOps.H apply_bcs(): a state other than New or Old was used. "

--- a/amr-wind/equation_systems/BCOps.H
+++ b/amr-wind/equation_systems/BCOps.H
@@ -35,21 +35,21 @@ struct BCOp<PDE, std::enable_if_t<std::is_base_of_v<ScalarTransport, PDE>>>
 
     /**
      */
-    void apply_bcs(const FieldState rho_state)
+    void apply_bcs(const FieldState state)
     {
         amrex::IntVect ng_diff(1);
-        auto& field = m_fields.field;
-        const auto bc_time = (rho_state == FieldState::Old)
+        auto& field = m_fields.field.state(state);
+        const auto bc_time = (state == FieldState::Old)
                                  ? m_time.current_time()
                                  : m_time.new_time();
-        if ((rho_state != FieldState::Old && rho_state != FieldState::New)) {
+        if ((state != FieldState::Old && state != FieldState::New)) {
             amrex::Abort(
                 "BCOps.H apply_bcs(): a state other than New or Old was used. "
                 "The method of setting bc_time must be evaluated before using "
                 "a different state for this routine.");
         }
         field.fillphysbc(bc_time, ng_diff);
-        field.apply_bc_funcs(rho_state);
+        field.apply_bc_funcs(state);
     }
 
     PDEFields& m_fields;

--- a/amr-wind/equation_systems/DiffusionOps.H
+++ b/amr-wind/equation_systems/DiffusionOps.H
@@ -152,7 +152,7 @@ struct DiffusionOp<
         amrex::MLMG mlmg(*this->m_applier);
         mlmg.apply(
             this->m_pdefields.diff_term.state(tau_state).vec_ptrs(),
-            this->m_pdefields.field.vec_ptrs());
+            this->m_pdefields.field.state(fstate).vec_ptrs());
     }
 };
 

--- a/amr-wind/equation_systems/icns/icns_bcop.H
+++ b/amr-wind/equation_systems/icns/icns_bcop.H
@@ -47,21 +47,21 @@ struct BCOp<ICNS>
 
     /** Apply boundary conditions before a linear solve
      */
-    void apply_bcs(const FieldState rho_state)
+    void apply_bcs(const FieldState state)
     {
         amrex::IntVect ng_diff(1);
-        auto& field = m_fields.field;
-        const auto bc_time = (rho_state == FieldState::Old)
+        auto& field = m_fields.field.state(state);
+        const auto bc_time = (state == FieldState::Old)
                                  ? m_time.current_time()
                                  : m_time.new_time();
-        if ((rho_state != FieldState::Old && rho_state != FieldState::New)) {
+        if ((state != FieldState::Old && state != FieldState::New)) {
             amrex::Abort(
                 "icns_bcop.H apply_bcs(): a state other than New or Old was "
                 "used. The method of setting bc_time must be evaluated before "
                 "using a different state for this routine.\n");
         }
         field.fillphysbc(bc_time, ng_diff);
-        field.apply_bc_funcs(rho_state);
+        field.apply_bc_funcs(state);
     }
 
     PDEFields& m_fields;

--- a/amr-wind/equation_systems/icns/icns_bcop.H
+++ b/amr-wind/equation_systems/icns/icns_bcop.H
@@ -51,9 +51,8 @@ struct BCOp<ICNS>
     {
         amrex::IntVect ng_diff(1);
         auto& field = m_fields.field.state(state);
-        const auto bc_time = (state == FieldState::Old)
-                                 ? m_time.current_time()
-                                 : m_time.new_time();
+        const auto bc_time = (state == FieldState::Old) ? m_time.current_time()
+                                                        : m_time.new_time();
         if ((state != FieldState::Old && state != FieldState::New)) {
             amrex::Abort(
                 "icns_bcop.H apply_bcs(): a state other than New or Old was "

--- a/amr-wind/equation_systems/icns/icns_diffusion.H
+++ b/amr-wind/equation_systems/icns/icns_diffusion.H
@@ -42,7 +42,9 @@ public:
         auto& divtau = this->m_pdefields.diff_term.state(tau_state);
 
         amrex::MLMG mlmg(*this->m_applier);
-        mlmg.apply(divtau.vec_ptrs(), this->m_pdefields.field.vec_ptrs());
+        mlmg.apply(
+            divtau.vec_ptrs(),
+            this->m_pdefields.field.state(fstate).vec_ptrs());
     }
 };
 
@@ -162,7 +164,8 @@ public:
         }
 
         amrex::MLMG mlmg(*m_applier_scalar);
-        mlmg.apply(divtau.vec_ptrs(), m_pdefields.field.vec_ptrs());
+        mlmg.apply(
+            divtau.vec_ptrs(), m_pdefields.field.state(fstate).vec_ptrs());
 
         if (!diff_for_RHS) {
             for (int lev = 0; lev < nlevels; ++lev) {
@@ -390,7 +393,7 @@ public:
             }
 
             auto divtau_comp = divtau.subview(i);
-            auto vel_comp = m_pdefields.field.subview(i);
+            auto vel_comp = m_pdefields.field.state(fstate).subview(i);
 
             amrex::MLMG mlmg(*m_applier_scalar[i]);
             mlmg.apply(divtau_comp.vec_ptrs(), vel_comp.vec_ptrs());

--- a/amr-wind/equation_systems/sdr/sdr_ops.H
+++ b/amr-wind/equation_systems/sdr/sdr_ops.H
@@ -108,7 +108,7 @@ struct DiffusionOp<SDR, Scheme> : public DiffSolverIface<typename SDR::MLDiffOp>
         amrex::MLMG mlmg(*this->m_applier);
         mlmg.apply(
             this->m_pdefields.diff_term.state(tau_state).vec_ptrs(),
-            this->m_pdefields.field.vec_ptrs());
+            this->m_pdefields.field.state(fstate).vec_ptrs());
     }
 
     void

--- a/amr-wind/equation_systems/tke/tke_ops.H
+++ b/amr-wind/equation_systems/tke/tke_ops.H
@@ -144,7 +144,7 @@ struct DiffusionOp<TKE, Scheme> : public DiffSolverIface<typename TKE::MLDiffOp>
         amrex::MLMG mlmg(*this->m_applier);
         mlmg.apply(
             this->m_pdefields.diff_term.state(tau_state).vec_ptrs(),
-            this->m_pdefields.field.vec_ptrs());
+            this->m_pdefields.field.state(fstate).vec_ptrs());
     }
 
     void


### PR DESCRIPTION
## Summary

compute_diff_term has different input states, but only uses the new variable. This doesn't fit with fixed point operations. The PR makes compute_diff_term actually use the supplied state, and it modifies the boundary condition calls to fit that.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background
