### PR TITLE
Avoid OOB for hi boundary planes

### DIFF
--- a/amr-wind/utilities/index_operations.H
+++ b/amr-wind/utilities/index_operations.H
@@ -39,6 +39,8 @@ AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
 /** Get the intersection with a boundary box while considering if on face or
  * cell. Intended for auxiliary boundary fill calls.
  *
+ *  \param shift_to_cc output index vector to shift from output box to
+ *  a cell-centered representation.
  *  \param grown_interior_box box grown from domain interior to overlap with
  * boundary
  *  \param domain_boundary_box box representing domain boundary containing data
@@ -48,10 +50,12 @@ AMREX_FORCE_INLINE T perpendicular_idx(const int normal)
  * grown_interior_box
  */
 inline amrex::Box face_aware_boundary_box_intersection(
+    amrex::IntVect& shift_to_cc,
     amrex::Box grown_interior_box,
     const amrex::Box& domain_boundary_box,
     const amrex::Orientation& ori)
 {
+    shift_to_cc = {0, 0, 0};
     const auto& field_location_vector = grown_interior_box.type();
     if (!grown_interior_box.cellCentered()) {
         grown_interior_box.enclosedCells();
@@ -63,8 +67,20 @@ inline amrex::Box face_aware_boundary_box_intersection(
 
     if (ori.isHigh() && field_location_vector[ori.coordDir()] == 1) {
         bx.shift(field_location_vector);
+        shift_to_cc = -field_location_vector;
     }
     return bx;
+}
+
+// This version omits the shift to cell-centered data, often not needed
+inline amrex::Box face_aware_boundary_box_intersection(
+    amrex::Box grown_interior_box,
+    const amrex::Box& domain_boundary_box,
+    const amrex::Orientation& ori)
+{
+    amrex::IntVect shift_to_cc = {0, 0, 0};
+    return face_aware_boundary_box_intersection(
+        shift_to_cc, grown_interior_box, domain_boundary_box, ori);
 }
 
 /** Convert a bounding box into amrex::Box index space at a given level

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -922,8 +922,9 @@ void ABLBoundaryPlane::populate_data(
 
             auto sbx = mfi.growntilebox(1);
             const auto& src = m_in_data.interpolate_data(ori, lev);
+            auto shift_to_cc = amrex::IntVect(0);
             const auto& bx = utils::face_aware_boundary_box_intersection(
-                sbx, src.box(), ori);
+                shift_to_cc, sbx, src.box(), ori);
             if (bx.isEmpty()) {
                 continue;
             }
@@ -934,8 +935,9 @@ void ABLBoundaryPlane::populate_data(
             amrex::ParallelFor(
                 bx, nc,
                 [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-                    dest(i, j, k, n + dcomp) =
-                        src_arr(i, j, k, n + nstart + orig_comp);
+                    dest(i, j, k, n + dcomp) = src_arr(
+                        i + shift_to_cc[0], j + shift_to_cc[1],
+                        k + shift_to_cc[2], n + nstart + orig_comp);
                 });
         }
     }

--- a/unit_tests/core/test_auxiliary_fill.cpp
+++ b/unit_tests/core/test_auxiliary_fill.cpp
@@ -171,7 +171,7 @@ amrex::Real get_field_err(
                                 error += std::abs(f_arr(i, j, k) - 3.0);
                                 if (k == 9) {
                                     error += std::abs((amrex::Real)(
-                                        i_arr(i, j, k - 1, 6)  - 0));
+                                        i_arr(i, j, k - 1, 6) - 0));
                                     error += std::abs((amrex::Real)(
                                         i_arr(i, j, k - 1, 7) - 0));
                                     error += std::abs((amrex::Real)(
@@ -226,6 +226,10 @@ amrex::Real get_field_err(
                             error += std::abs(f_arr(i, j, k, 0) - 1.0);
                             error += std::abs(f_arr(i, j, k, 1) - 2.0);
                             error += std::abs(f_arr(i, j, k, 2) - 3.0);
+                            for (int ni = 0; ni < 9; ++ni) {
+                                error += std::abs(
+                                    (amrex::Real)(i_arr(i, j, k, ni) - 0));
+                            }
                         } else {
                             error += std::abs(f_arr(i, j, k, 0) - 0.0);
                             error += std::abs(f_arr(i, j, k, 1) - 0.0);
@@ -252,6 +256,7 @@ public:
         m_ind = &frepo.declare_int_field("indices", 9, 1);
 
         (*m_vel).setVal(0.);
+        (*m_ind).setVal(5);
     }
 
     void set_up_fields_face()
@@ -267,6 +272,7 @@ public:
         (*m_umac).setVal(0.);
         (*m_vmac).setVal(0.);
         (*m_wmac).setVal(0.);
+        (*m_ind).setVal(5);
     }
 
     void prep_test(const bool is_cc)


### PR DESCRIPTION
## Summary

With the previous fix for hi boundary planes, I corrected the indices of the face velocities but did not account for the fact that the plane data being referenced is still at cell centers. This PR accounts for that, supplying the IntVect to shift the indices back to cell-centered if needed. Augmented unit test to make sure it works.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
