### PR TITLE
Fix python particle reader for multilevel particles

### DIFF
--- a/tools/amrex_particle.py
+++ b/tools/amrex_particle.py
@@ -70,8 +70,10 @@ class AmrexParticleFile:
             self.num_grids = np.empty((self.finest_level+1,), dtype=int)
             self.grid_info = []
             for lev in range(self.finest_level+1):
-                ginfo = []
                 self.num_grids[lev] = int(fh.readline().strip())
+
+            for lev in range(self.finest_level+1):
+                ginfo = []
                 for _ in range(self.num_grids[lev]):
                     ginfo.append(
                         [int(ix) for ix in fh.readline().strip().split()])


### PR DESCRIPTION
## Summary

Fix the python amrex particle reader for multilevel particles.

Before this commit, it would error with things like
```
Traceback (most recent call last):
  File "/Users/mhenryde/exawind/source/amr-wind/tools/fcompare_particles.py", line 51, in <module>
    main()
  File "/Users/mhenryde/exawind/source/amr-wind/tools/fcompare_particles.py", line 34, in main
    p0df = AmrexParticleFile(Path(args.f0) / "particles")().drop(cols_to_drop, axis=1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mhenryde/exawind/source/amr-wind/tools/amrex_particle.py", line 48, in __call__
    self.parse_header()
  File "/Users/mhenryde/exawind/source/amr-wind/tools/amrex_particle.py", line 74, in parse_header
    self.num_grids[lev] = int(fh.readline().strip())
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0 0 683100'
```

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
