### PR TITLE
User control of the number of plot and checkpoint files

### DIFF
--- a/amr-wind/utilities/IOManager.H
+++ b/amr-wind/utilities/IOManager.H
@@ -162,6 +162,9 @@ private:
     std::string m_hdf5_compression{"None@0"};
 #endif
 #endif
+
+    //! Number of plot and checkpoint data files per write
+    int m_nfiles{256};
 };
 
 } // namespace amr_wind

--- a/amr-wind/utilities/IOManager.cpp
+++ b/amr-wind/utilities/IOManager.cpp
@@ -51,6 +51,7 @@ void IOManager::initialize_io()
     pp.query("hdf5_compression", m_hdf5_compression);
 #endif
 #endif
+    pp.query("nfiles", m_nfiles);
 
     // ParmParse requires us to read in a vector
     pp.queryarr("outputs", out_vars);
@@ -124,6 +125,8 @@ void IOManager::initialize_io()
         auto& fld = repo.get_field(fname);
         m_chk_fields.emplace_back(&fld);
     }
+
+    amrex::VisMF::SetNOutFiles(m_nfiles);
 }
 
 void IOManager::write_plot_file()

--- a/docs/sphinx/user/inputs_io.rst
+++ b/docs/sphinx/user/inputs_io.rst
@@ -103,4 +103,4 @@ controls when these files are output.
 
    **type:** Int, optional, default = 256
 
-   Number of plot and checkpoint data files per write. If our system's IO prefers fewer or more files, this number can be modified with this option.
+   Number of plot and checkpoint data files per write. If the system's IO prefers fewer or more files, this number can be modified with this option.

--- a/docs/sphinx/user/inputs_io.rst
+++ b/docs/sphinx/user/inputs_io.rst
@@ -3,10 +3,10 @@
 Section: io
 ~~~~~~~~~~~~~~~~~
 
-This section deals with parameters that affect input/output to the simulation, 
-solely the checkpoint and plot files. These inputs do not affect when these files 
-are output, but they address file naming and high-level parameters. The "time" section 
-controls when these files are output. 
+This section deals with parameters that affect input/output to the simulation,
+solely the checkpoint and plot files. These inputs do not affect when these files
+are output, but they address file naming and high-level parameters. The "time" section
+controls when these files are output.
 
 | Primary location in code: ``amr-wind/utilities/IOManager.cpp``.
 
@@ -14,16 +14,16 @@ controls when these files are output.
 
    **type:** String, optional, default = "chk"
 
-   If :input_param:`time.checkpoint_interval` or :input_param:`time.checkpoint_time_interval` is greater than zero this is the name of the checkpoint 
+   If :input_param:`time.checkpoint_interval` or :input_param:`time.checkpoint_time_interval` is greater than zero this is the name of the checkpoint
    file appended with the current timestep
-   
+
 .. input_param:: io.plot_file
 
    **type:** String, optional, default = "plt"
 
    If :input_param:`time.plot_interval` or :input_param:`time.plot_time_interval` is greater than zero this is the name of the plot
    file appended with the current timestep.
-   
+
 .. input_param:: io.restart_file
 
    **type:** String, optional, default = ""
@@ -41,7 +41,7 @@ controls when these files are output.
    **type:** Boolean, optional, default = true
 
    Based on what fields are active in a simulation, `amr-wind` generates a list of variables to output to plotfiles (e.g., velocity, density, and p). If these defaults are not desired, this input argument can be set to false.
-   
+
 .. input_param:: io.allow_missing_restart_fields
 
    **type:** Boolean, optional, default = true
@@ -70,7 +70,7 @@ controls when these files are output.
    to add them to the plotfile output. These are derived
    quantities that are functions of real variables that exist
    in the simulation. Currently, the available derived quantity definitions
-   that operate on the velocity field are vorticity magnitude 
+   that operate on the velocity field are vorticity magnitude
    (``mag_vorticity``), q-criterion (``q_criterion``),
    non-dimensional q-criterion (``q_criterion_nondim``),
    and strain rate magnitude (``mag_strainrate``). Generic
@@ -86,3 +86,21 @@ controls when these files are output.
    **type:** List of strings, optional, default = ""
 
    Add variable names to this input argument to omit them from the plotfile output. These refer to variables that are be real numbers, and this is a way to individually omit default output variables.
+
+.. input_param:: io.output_hdf5_plotfile
+
+   **type:** Boolean, optional, default = false
+
+   Flag indicating whether or not to output HDF5 plot files.
+
+.. input_param:: io.hdf5_compression
+
+   **type:** String, optional, default = "None@0"
+
+   String for requesting a particular ZFP compression in HDF5 plot files.
+
+.. input_param:: io.nfiles
+
+   **type:** Int, optional, default = 256
+
+   Number of plot and checkpoint data files per write. If our system's IO prefers fewer or more files, this number can be modified with this option.


### PR DESCRIPTION
## Summary

Provide user control on the number of plot and checkpoint files. Some clusters have IO limitations and this option might help users on those clusters to get around them. Here's an example:

### Main branch, 10 ranks:
```
❯ tree np10/plt00000
np10/plt00000
├── Header
├── Level_0
│   ├── Cell_D_00000
│   ├── Cell_D_00001
│   ├── Cell_D_00002
│   ├── Cell_D_00003
│   ├── Cell_D_00004
│   ├── Cell_D_00005
│   ├── Cell_D_00006
│   ├── Cell_D_00007
│   ├── Cell_D_00008
│   ├── Cell_D_00009
│   └── Cell_H
├── Level_1
│   ├── Cell_D_00000
│   ├── Cell_D_00001
│   ├── Cell_D_00002
│   ├── Cell_D_00003
│   ├── Cell_D_00004
│   ├── Cell_D_00005
│   ├── Cell_D_00006
│   ├── Cell_D_00007
│   ├── Cell_D_00008
│   ├── Cell_D_00009
│   └── Cell_H
└── amr_wind_info

3 directories, 24 files
```

### This PR, 10 ranks with the new user option `io.nfiles=1`
```
❯ tree plt00000
plt00000
├── Header
├── Level_0
│   ├── Cell_D_00000
│   └── Cell_H
├── Level_1
│   ├── Cell_D_00000
│   └── Cell_H
└── amr_wind_info

3 directories, 6 files
```

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background


Issue Number: #1186 
