### PR TITLE
Use linear interpolation in DragForcing

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -117,20 +117,20 @@ void DragForcing::operator()(
         ystart_damping = sponge_strength * yi_start * yi_start;
         yend_damping = sponge_strength * yi_end * yi_end;
 
+        const auto idx = interp::bisection_search(device_vel_ht, device_vel_ht + vsize, z);
         const amrex::Real spongeVelX =
-            (vsize > 0) ? interp::linear(
-                              device_vel_ht, device_vel_ht + vsize,
-                              device_vel_vals, z, 3, 0)
+            (vsize > 0) ? interp::linear_impl(
+                              device_vel_ht, 
+                              device_vel_vals, z, idx)
                         : 0.0;
         const amrex::Real spongeVelY =
-            (vsize > 0) ? interp::linear(
-                              device_vel_ht, device_vel_ht + vsize,
-                              device_vel_vals, z, 3, 1)
+            (vsize > 0) ? interp::linear_impl(
+                              device_vel_ht, 
+                              device_vel_vals, z, idx)
                         : 0.0;
         const amrex::Real spongeVelZ =
-            (vsize > 0) ? interp::linear(
-                              device_vel_ht, device_vel_ht + vsize,
-                              device_vel_vals, z, 3, 2)
+            (vsize > 0) ? interp::linear_impl(
+                              device_vel_ht,  device_vel_vals, z, idx)
                         : 0.0;
         amrex::Real Dxz = 0.0;
         amrex::Real Dyz = 0.0;

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -121,16 +121,16 @@ void DragForcing::operator()(
         const amrex::Real spongeVelX =
             (vsize > 0) ? interp::linear_impl(
                               device_vel_ht, 
-                              device_vel_vals, z, idx)
+                              device_vel_vals, z, idx, 3, 0)
                         : 0.0;
         const amrex::Real spongeVelY =
             (vsize > 0) ? interp::linear_impl(
                               device_vel_ht, 
-                              device_vel_vals, z, idx)
+                              device_vel_vals, z, idx, 3, 1)
                         : 0.0;
         const amrex::Real spongeVelZ =
             (vsize > 0) ? interp::linear_impl(
-                              device_vel_ht,  device_vel_vals, z, idx)
+                              device_vel_ht,  device_vel_vals, z, idx, 3, 2)
                         : 0.0;
         amrex::Real Dxz = 0.0;
         amrex::Real Dyz = 0.0;

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -117,20 +117,19 @@ void DragForcing::operator()(
         ystart_damping = sponge_strength * yi_start * yi_start;
         yend_damping = sponge_strength * yi_end * yi_end;
 
-        const auto idx = interp::bisection_search(device_vel_ht, device_vel_ht + vsize, z);
+        const auto idx =
+            interp::bisection_search(device_vel_ht, device_vel_ht + vsize, z);
         const amrex::Real spongeVelX =
             (vsize > 0) ? interp::linear_impl(
-                              device_vel_ht, 
-                              device_vel_vals, z, idx, 3, 0)
+                              device_vel_ht, device_vel_vals, z, idx, 3, 0)
                         : 0.0;
         const amrex::Real spongeVelY =
             (vsize > 0) ? interp::linear_impl(
-                              device_vel_ht, 
-                              device_vel_vals, z, idx, 3, 1)
+                              device_vel_ht, device_vel_vals, z, idx, 3, 1)
                         : 0.0;
         const amrex::Real spongeVelZ =
             (vsize > 0) ? interp::linear_impl(
-                              device_vel_ht,  device_vel_vals, z, idx, 3, 2)
+                              device_vel_ht, device_vel_vals, z, idx, 3, 2)
                         : 0.0;
         amrex::Real Dxz = 0.0;
         amrex::Real Dyz = 0.0;

--- a/amr-wind/utilities/linear_interpolation.H
+++ b/amr-wind/utilities/linear_interpolation.H
@@ -99,39 +99,46 @@ find_index(const It begin, const It end, const T& x, const int hint = 1)
 template <typename C1, typename C2>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     typename std::iterator_traits<C2>::value_type
-    linear(
+    linear_impl(
         const C1 xbegin,
-        const C1 xend,
         const C2 yinp,
         const typename std::iterator_traits<C1>::value_type& xout,
-        const int ncomp = 1,
-        const int comp = 0)
+        const Index& idx)
 {
     using DType1 = typename std::iterator_traits<C1>::value_type;
-    const auto idx = bisection_search(xbegin, xend, xout);
 
     if ((idx.lim == Limits::LOWLIM) || (idx.lim == Limits::UPLIM)) {
-        return yinp[ncomp * idx.idx + comp];
+        return yinp[idx.idx];
     }
     static constexpr DType1 eps = 1.0e-8;
     const int j = idx.idx;
     const auto denom = (xbegin[j + 1] - xbegin[j]);
     const auto facR = (denom > eps) ? ((xout - xbegin[j]) / denom) : 1.0;
     const auto facL = static_cast<DType1>(1.0) - facR;
-    return facL * yinp[ncomp * j + comp] + facR * yinp[ncomp * (j + 1) + comp];
+    return facL * yinp[j] + facR * yinp[j + 1];
+}
+
+template <typename C1, typename C2>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    typename std::iterator_traits<C2>::value_type
+    linear(
+        const C1 xbegin,
+        const C1 xend,
+        const C2 yinp,
+        const typename std::iterator_traits<C1>::value_type& xout)
+{
+    const auto idx = bisection_search(xbegin, xend, xout);
+    return linear_impl(xbegin, yinp, xout, idx);
 }
 
 template <typename C1, typename C2>
 inline typename C2::value_type linear(
     const C1& xinp,
     const C2& yinp,
-    const typename C1::value_type& xout,
-    const int ncomp = 1,
-    const int comp = 0)
+    const typename C1::value_type& xout)
 {
     return linear(
-        xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout, ncomp,
-        comp);
+        xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout);
 }
 
 template <typename C1, typename C2>
@@ -167,9 +174,7 @@ inline void linear(
     const C1& xinp,
     const C2& yinp,
     const C1& xout,
-    C2& yout,
-    const int ncomp = 1,
-    const int comp = 0)
+    C2& yout)
 {
     AMREX_ASSERT(
         static_cast<amrex::Long>(xinp.size()) ==
@@ -180,7 +185,7 @@ inline void linear(
 
     int npts = xout.size();
     for (int i = 0; i < npts; ++i) {
-        yout[i] = linear(xinp, yinp, xout[i], ncomp, comp);
+        yout[i] = linear(xinp, yinp, xout[i]);
     }
 }
 

--- a/amr-wind/utilities/linear_interpolation.H
+++ b/amr-wind/utilities/linear_interpolation.H
@@ -128,8 +128,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const C1 xend,
         const C2 yinp,
         const typename std::iterator_traits<C1>::value_type& xout,
-    const int ncomp = 1,
-    const int comp = 0)
+        const int ncomp = 1,
+        const int comp = 0)
 {
     const auto idx = bisection_search(xbegin, xend, xout);
     return linear_impl(xbegin, yinp, xout, idx, ncomp, comp);
@@ -144,12 +144,16 @@ inline typename C2::value_type linear(
     const int comp = 0)
 {
     return linear(
-      xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout, ncomp, comp);
+        xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout, ncomp,
+        comp);
 }
 
 template <typename C1, typename C2>
-inline void
-linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout,
+inline void linear_monotonic(
+    const C1& xinp,
+    const C2& yinp,
+    const C1& xout,
+    C2& yout,
     const int ncomp = 1,
     const int comp = 0)
 {
@@ -171,7 +175,9 @@ linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout,
             const auto denom = (xinp[j + 1] - xinp[j]);
             const auto facR = (denom > eps) ? ((x - xinp[j]) / denom) : 1.0;
             const auto facL = static_cast<typename C1::value_type>(1.0) - facR;
-            yout[i] = facL * yinp[ncomp * j + comp] + facR * yinp[ncomp * (j + 1) + comp];;
+            yout[i] = facL * yinp[ncomp * j + comp] +
+                      facR * yinp[ncomp * (j + 1) + comp];
+            ;
         }
         hint = idx.idx + 1;
     }
@@ -195,7 +201,7 @@ inline void linear(
 
     int npts = xout.size();
     for (int i = 0; i < npts; ++i) {
-      yout[i] = linear(xinp, yinp, xout[i], ncomp, comp);
+        yout[i] = linear(xinp, yinp, xout[i], ncomp, comp);
     }
 }
 

--- a/amr-wind/utilities/linear_interpolation.H
+++ b/amr-wind/utilities/linear_interpolation.H
@@ -63,6 +63,23 @@ bisection_search(const It begin, const It end, const T& x)
 
 template <typename It, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Index
+nearest_search(const It begin, const It end, const T& x)
+{
+
+    auto idx = bisection_search(begin, end, x);
+    if ((idx.lim == Limits::LOWLIM) || (idx.lim == Limits::UPLIM)) {
+        return idx;
+    }
+
+    if ((x - begin[idx.idx]) > (begin[idx.idx + 1] - x)) {
+        idx.idx += 1;
+    }
+
+    return idx;
+}
+
+template <typename It, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Index
 find_index(const It begin, const It end, const T& x, const int hint = 1)
 {
     auto idx = check_bounds(begin, end, x);
@@ -86,27 +103,35 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const C1 xbegin,
         const C1 xend,
         const C2 yinp,
-        const typename std::iterator_traits<C1>::value_type& xout)
+        const typename std::iterator_traits<C1>::value_type& xout,
+        const int ncomp = 1,
+        const int comp = 0)
 {
     using DType1 = typename std::iterator_traits<C1>::value_type;
     const auto idx = bisection_search(xbegin, xend, xout);
 
     if ((idx.lim == Limits::LOWLIM) || (idx.lim == Limits::UPLIM)) {
-        return yinp[idx.idx];
+        return yinp[ncomp * idx.idx + comp];
     }
     static constexpr DType1 eps = 1.0e-8;
     const int j = idx.idx;
     const auto denom = (xbegin[j + 1] - xbegin[j]);
     const auto facR = (denom > eps) ? ((xout - xbegin[j]) / denom) : 1.0;
     const auto facL = static_cast<DType1>(1.0) - facR;
-    return facL * yinp[j] + facR * yinp[j + 1];
+    return facL * yinp[ncomp * j + comp] + facR * yinp[ncomp * (j + 1) + comp];
 }
 
 template <typename C1, typename C2>
-inline typename C2::value_type
-linear(const C1& xinp, const C2& yinp, const typename C1::value_type& xout)
+inline typename C2::value_type linear(
+    const C1& xinp,
+    const C2& yinp,
+    const typename C1::value_type& xout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
-    return linear(xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout);
+    return linear(
+        xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout, ncomp,
+        comp);
 }
 
 template <typename C1, typename C2>
@@ -138,7 +163,13 @@ linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout)
 }
 
 template <typename C1, typename C2>
-inline void linear(const C1& xinp, const C2& yinp, const C1& xout, C2& yout)
+inline void linear(
+    const C1& xinp,
+    const C2& yinp,
+    const C1& xout,
+    C2& yout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
     AMREX_ASSERT(
         static_cast<amrex::Long>(xinp.size()) ==
@@ -149,7 +180,7 @@ inline void linear(const C1& xinp, const C2& yinp, const C1& xout, C2& yout)
 
     int npts = xout.size();
     for (int i = 0; i < npts; ++i) {
-        yout[i] = linear(xinp, yinp, xout[i]);
+        yout[i] = linear(xinp, yinp, xout[i], ncomp, comp);
     }
 }
 

--- a/amr-wind/utilities/linear_interpolation.H
+++ b/amr-wind/utilities/linear_interpolation.H
@@ -103,19 +103,21 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const C1 xbegin,
         const C2 yinp,
         const typename std::iterator_traits<C1>::value_type& xout,
-        const Index& idx)
+        const Index& idx,
+        const int ncomp = 1,
+        const int comp = 0)
 {
     using DType1 = typename std::iterator_traits<C1>::value_type;
 
     if ((idx.lim == Limits::LOWLIM) || (idx.lim == Limits::UPLIM)) {
-        return yinp[idx.idx];
+        return yinp[ncomp * idx.idx + comp];
     }
     static constexpr DType1 eps = 1.0e-8;
     const int j = idx.idx;
     const auto denom = (xbegin[j + 1] - xbegin[j]);
     const auto facR = (denom > eps) ? ((xout - xbegin[j]) / denom) : 1.0;
     const auto facL = static_cast<DType1>(1.0) - facR;
-    return facL * yinp[j] + facR * yinp[j + 1];
+    return facL * yinp[ncomp * j + comp] + facR * yinp[ncomp * (j + 1) + comp];
 }
 
 template <typename C1, typename C2>
@@ -125,25 +127,31 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const C1 xbegin,
         const C1 xend,
         const C2 yinp,
-        const typename std::iterator_traits<C1>::value_type& xout)
+        const typename std::iterator_traits<C1>::value_type& xout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
     const auto idx = bisection_search(xbegin, xend, xout);
-    return linear_impl(xbegin, yinp, xout, idx);
+    return linear_impl(xbegin, yinp, xout, idx, ncomp, comp);
 }
 
 template <typename C1, typename C2>
 inline typename C2::value_type linear(
     const C1& xinp,
     const C2& yinp,
-    const typename C1::value_type& xout)
+    const typename C1::value_type& xout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
     return linear(
-        xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout);
+      xinp.data(), (xinp.data() + xinp.size()), yinp.data(), xout, ncomp, comp);
 }
 
 template <typename C1, typename C2>
 inline void
-linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout)
+linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
     static constexpr typename C1::value_type eps = 1.0e-8;
     AMREX_ASSERT(xinp.size() == yinp.size());
@@ -157,13 +165,13 @@ linear_monotonic(const C1& xinp, const C2& yinp, const C1& xout, C2& yout)
             find_index(xinp.data(), (xinp.data() + xinp.size()), x, hint);
 
         if ((idx.lim == Limits::LOWLIM) || (idx.lim == Limits::UPLIM)) {
-            yout[i] = yinp[idx.idx];
+            yout[i] = yinp[ncomp * idx.idx + comp];
         } else if (idx.lim == Limits::VALID) {
             int j = idx.idx;
             const auto denom = (xinp[j + 1] - xinp[j]);
             const auto facR = (denom > eps) ? ((x - xinp[j]) / denom) : 1.0;
             const auto facL = static_cast<typename C1::value_type>(1.0) - facR;
-            yout[i] = facL * yinp[j] + facR * yinp[j + 1];
+            yout[i] = facL * yinp[ncomp * j + comp] + facR * yinp[ncomp * (j + 1) + comp];;
         }
         hint = idx.idx + 1;
     }
@@ -174,7 +182,9 @@ inline void linear(
     const C1& xinp,
     const C2& yinp,
     const C1& xout,
-    C2& yout)
+    C2& yout,
+    const int ncomp = 1,
+    const int comp = 0)
 {
     AMREX_ASSERT(
         static_cast<amrex::Long>(xinp.size()) ==
@@ -185,7 +195,7 @@ inline void linear(
 
     int npts = xout.size();
     for (int i = 0; i < npts; ++i) {
-        yout[i] = linear(xinp, yinp, xout[i]);
+      yout[i] = linear(xinp, yinp, xout[i], ncomp, comp);
     }
 }
 

--- a/unit_tests/utilities/test_linear_interpolation.cpp
+++ b/unit_tests/utilities/test_linear_interpolation.cpp
@@ -148,6 +148,31 @@ TEST(LinearInterpolation, lin_interp_single)
     }
 }
 
+TEST(LinearInterpolation, lin_interp_single_multicomponent)
+{
+    namespace interp = amr_wind::interp;
+
+    const int ncomp = 3;
+    std::vector<amrex::Real> xvec(10), yvec(ncomp * 10);
+    std::iota(xvec.begin(), xvec.end(), 0.0);
+    const amrex::Vector<amrex::Real> mult_facs = {
+        2.0 + 10.0 * amrex::Random(), 2.0 + 10.0 * amrex::Random(),
+        2.0 + 10.0 * amrex::Random()};
+    for (int i = 0; i < static_cast<int>(xvec.size()); i++) {
+        for (int n = 0; n < ncomp; n++) {
+            yvec[ncomp * i + n] = mult_facs[n] * xvec[i];
+        }
+    }
+
+    std::vector<amrex::Real> xtest{2.5, 4.5, 6.3, 8.8};
+    for (const auto& x : xtest) {
+        for (int n = 0; n < ncomp; n++) {
+            const auto y = interp::linear(xvec, yvec, x, 3, n);
+            EXPECT_NEAR(y, mult_facs[n] * x, 1.0e-12);
+        }
+    }
+}
+
 TEST(LinearInterpolation, lin_interp)
 {
     namespace interp = amr_wind::interp;

--- a/unit_tests/utilities/test_linear_interpolation.cpp
+++ b/unit_tests/utilities/test_linear_interpolation.cpp
@@ -148,31 +148,6 @@ TEST(LinearInterpolation, lin_interp_single)
     }
 }
 
-TEST(LinearInterpolation, lin_interp_single_multicomponent)
-{
-    namespace interp = amr_wind::interp;
-
-    const int ncomp = 3;
-    std::vector<amrex::Real> xvec(10), yvec(ncomp * 10);
-    std::iota(xvec.begin(), xvec.end(), 0.0);
-    const amrex::Vector<amrex::Real> mult_facs = {
-        2.0 + 10.0 * amrex::Random(), 2.0 + 10.0 * amrex::Random(),
-        2.0 + 10.0 * amrex::Random()};
-    for (int i = 0; i < static_cast<int>(xvec.size()); i++) {
-        for (int n = 0; n < ncomp; n++) {
-            yvec[ncomp * i + n] = mult_facs[n] * xvec[i];
-        }
-    }
-
-    std::vector<amrex::Real> xtest{2.5, 4.5, 6.3, 8.8};
-    for (const auto& x : xtest) {
-        for (int n = 0; n < ncomp; n++) {
-            const auto y = interp::linear(xvec, yvec, x, 3, n);
-            EXPECT_NEAR(y, mult_facs[n] * x, 1.0e-12);
-        }
-    }
-}
-
 TEST(LinearInterpolation, lin_interp)
 {
     namespace interp = amr_wind::interp;

--- a/unit_tests/utilities/test_linear_interpolation.cpp
+++ b/unit_tests/utilities/test_linear_interpolation.cpp
@@ -60,6 +60,46 @@ TEST(LinearInterpolation, bisection_search)
     }
 }
 
+TEST(LinearInterpolation, nearest_search)
+{
+    namespace interp = amr_wind::interp;
+    std::vector<amrex::Real> xvec(10);
+    std::iota(xvec.begin(), xvec.end(), 0.0);
+
+    const auto* start = xvec.data();
+    const auto* end = xvec.data() + xvec.size();
+    {
+        const auto idx = interp::nearest_search(start, end, 5.0);
+        EXPECT_EQ(idx.idx, 5);
+        EXPECT_EQ(idx.lim, interp::Limits::VALID);
+    }
+    {
+        const auto idx = interp::nearest_search(start, end, 1.1);
+        EXPECT_EQ(idx.idx, 1);
+        EXPECT_EQ(idx.lim, interp::Limits::VALID);
+    }
+    {
+        const auto idx = interp::nearest_search(start, end, 1.6);
+        EXPECT_EQ(idx.idx, 2);
+        EXPECT_EQ(idx.lim, interp::Limits::VALID);
+    }
+    {
+        const auto idx = interp::nearest_search(start, end, 3.5);
+        EXPECT_EQ(idx.idx, 3);
+        EXPECT_EQ(idx.lim, interp::Limits::VALID);
+    }
+    {
+        const auto idx = interp::nearest_search(start, end, -1.0);
+        EXPECT_EQ(idx.idx, 0);
+        EXPECT_EQ(idx.lim, interp::Limits::LOWLIM);
+    }
+    {
+        const auto idx = interp::nearest_search(start, end, 9.1);
+        EXPECT_EQ(idx.idx, 9);
+        EXPECT_EQ(idx.lim, interp::Limits::UPLIM);
+    }
+}
+
 TEST(LinearInterpolation, find_index)
 {
     namespace interp = amr_wind::interp;
@@ -105,6 +145,31 @@ TEST(LinearInterpolation, lin_interp_single)
     for (const auto& x : xtest) {
         const auto y = interp::linear(xvec, yvec, x);
         EXPECT_NEAR(y, mult_fac * x, 1.0e-12);
+    }
+}
+
+TEST(LinearInterpolation, lin_interp_single_multicomponent)
+{
+    namespace interp = amr_wind::interp;
+
+    const int ncomp = 3;
+    std::vector<amrex::Real> xvec(10), yvec(ncomp * 10);
+    std::iota(xvec.begin(), xvec.end(), 0.0);
+    const amrex::Vector<amrex::Real> mult_facs = {
+        2.0 + 10.0 * amrex::Random(), 2.0 + 10.0 * amrex::Random(),
+        2.0 + 10.0 * amrex::Random()};
+    for (int i = 0; i < static_cast<int>(xvec.size()); i++) {
+        for (int n = 0; n < ncomp; n++) {
+            yvec[ncomp * i + n] = mult_facs[n] * xvec[i];
+        }
+    }
+
+    std::vector<amrex::Real> xtest{2.5, 4.5, 6.3, 8.8};
+    for (const auto& x : xtest) {
+        for (int n = 0; n < ncomp; n++) {
+            const auto y = interp::linear(xvec, yvec, x, 3, n);
+            EXPECT_NEAR(y, mult_facs[n] * x, 1.0e-12);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This is much more efficient than the current implementation since it does a bisection search. Also instead of a nearest neighbor it uses a linear interpolation. One can recover the previous implementation by just using the new `nearest_search`. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

