### PR TITLE
bdy plane interp time: match expressions to pass assertion

### DIFF
--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -893,7 +893,7 @@ void ABLBoundaryPlane::populate_data(
 
     AMREX_ALWAYS_ASSERT(
         ((m_in_data.tn() <= time) || (time <= m_in_data.tnp1())));
-    AMREX_ALWAYS_ASSERT(std::abs(time - m_in_data.tinterp()) < 1e-12);
+    AMREX_ALWAYS_ASSERT(std::abs(time - m_in_data.tinterp()) < 1e-6);
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         auto ori = oit();

--- a/amr-wind/wind_energy/ABLBoundaryPlane.cpp
+++ b/amr-wind/wind_energy/ABLBoundaryPlane.cpp
@@ -770,8 +770,8 @@ void ABLBoundaryPlane::read_file(const bool nph_target_time)
 
     // populate planes and interpolate
     const amrex::Real time =
-        m_time.new_time() + (nph_target_time ? 0.5 : 0.0) *
-                                (m_time.current_time() - m_time.new_time());
+        nph_target_time ? m_time.current_time() + 0.5 * m_time.delta_t()
+                        : m_time.new_time();
     AMREX_ALWAYS_ASSERT((m_in_times[0] <= time) && (time < m_in_times.back()));
 
     // return early if current data files can still be interpolated in time
@@ -893,7 +893,7 @@ void ABLBoundaryPlane::populate_data(
 
     AMREX_ALWAYS_ASSERT(
         ((m_in_data.tn() <= time) || (time <= m_in_data.tnp1())));
-    AMREX_ALWAYS_ASSERT(std::abs(time - m_in_data.tinterp()) < 1e-6);
+    AMREX_ALWAYS_ASSERT(std::abs(time - m_in_data.tinterp()) < 1e-12);
 
     for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
         auto ori = oit();


### PR DESCRIPTION
## Summary

Due to recent changes to the boundary plane times being used, this assertion can sometimes get false negatives. This is because the calculation of n+1/2 time is done two different ways, leading to floating point differences. This PR changes the expressions that calculate n+1/2 time to be the same (current_time + 0.5*dt).

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Before the overhaul of the boundary planes, which introduced getting planes at n+1/2 and at n+1, it made sense for this assertion to be very tight, because the expectation was that the variables would be identical. new_time is saved as m_tinterp when the data is interpolated, then when new_time is passed in later, it should be no different. However, in the new implementation, the n+1/2 time is calculated initially using new_time + 0.5 * (current_time - new_time), which gets stored as m_tinterp, and then later that gets compared with current_time + 0.5 * dt. Apparently, these calculations are sufficiently different to occasionally trip the assertion (this is what @hgopalan has seen on a few different runs). By changing the expressions to be the same, the assertion shouldn't get tripped.
