### PR TITLE
Fix the ow_linear_init_waves FPE

### DIFF
--- a/amr-wind/equation_systems/vof/vof_ops.H
+++ b/amr-wind/equation_systems/vof/vof_ops.H
@@ -23,8 +23,6 @@ struct FieldRegOp<VOF, Scheme>
         auto& curvature = repo.declare_cc_field("interface_curvature", 1, 1, 1);
 
         levelset.set_default_fillpatch_bc(sim.time());
-        levelset.register_fill_patch_op<amr_wind::FieldFillPatchOps<FieldBCDirichlet>>(
-            repo.mesh(), sim.time());
 
         curvature.set_default_fillpatch_bc(sim.time());
 

--- a/amr-wind/equation_systems/vof/vof_ops.H
+++ b/amr-wind/equation_systems/vof/vof_ops.H
@@ -23,6 +23,9 @@ struct FieldRegOp<VOF, Scheme>
         auto& curvature = repo.declare_cc_field("interface_curvature", 1, 1, 1);
 
         levelset.set_default_fillpatch_bc(sim.time());
+        levelset.register_fill_patch_op<amr_wind::FieldFillPatchOps<FieldBCDirichlet>>(
+            repo.mesh(), sim.time());
+
         curvature.set_default_fillpatch_bc(sim.time());
 
         // Register fields for output/restart

--- a/amr-wind/equation_systems/vof/vof_ops.H
+++ b/amr-wind/equation_systems/vof/vof_ops.H
@@ -23,7 +23,6 @@ struct FieldRegOp<VOF, Scheme>
         auto& curvature = repo.declare_cc_field("interface_curvature", 1, 1, 1);
 
         levelset.set_default_fillpatch_bc(sim.time());
-
         curvature.set_default_fillpatch_bc(sim.time());
 
         // Register fields for output/restart

--- a/amr-wind/physics/multiphase/MultiPhase.cpp
+++ b/amr-wind/physics/multiphase/MultiPhase.cpp
@@ -32,7 +32,7 @@ MultiPhase::MultiPhase(CFDSim& sim)
         // Create levelset as a auxiliary field only !
         m_levelset = &(m_sim.repo().get_field("levelset"));
         const amrex::Real levelset_default = 0.0;
-        BCScalar bc_ls(*m_levelset);
+        BCFillPatchExtrap bc_ls(*m_levelset);
         bc_ls(levelset_default);
         m_levelset->fillpatch(sim.time().current_time());
     } else if (amrex::toLower(m_interface_model) == "levelset") {


### PR DESCRIPTION
## Summary

Use an hoextrap BC for the levelset field when using VOF. This fixes the FPE currently in the dashboard.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
