### PR TITLE
Fix plane bounds checks

### DIFF
--- a/test/test_files/abl_sampling/abl_sampling.inp
+++ b/test/test_files/abl_sampling/abl_sampling.inp
@@ -129,7 +129,7 @@ probe_sampling.probe1.offsets   = 0.0 200.0 400.0 600.0
 plane_sampling.output_frequency     = 1
 plane_sampling.output_format        = native
 plane_sampling.fields               = velocity
-plane_sampling.labels               = plane1
+plane_sampling.labels               = plane1 plane2
 plane_sampling.plane1.type          = PlaneSampler
 plane_sampling.plane1.axis1         = 400.0 0.0 0.0
 plane_sampling.plane1.axis2         = 0.0 0.0 400.0
@@ -137,6 +137,14 @@ plane_sampling.plane1.origin        = 200.0 200.0 200.0
 plane_sampling.plane1.num_points    = 10 10
 plane_sampling.plane1.offset_vector = 0.0 1.0 1.0
 plane_sampling.plane1.offsets       = 0.0 20.0 30.0 200.0
+
+plane_sampling.plane2.type          = PlaneSampler
+plane_sampling.plane2.axis1         = 1000.0 0.0 0.0
+plane_sampling.plane2.axis2         = 0.0 1000.0 0.0
+plane_sampling.plane2.origin        = 0.0 0.0 500.0
+plane_sampling.plane2.num_points    = 10 10
+plane_sampling.plane2.offset_vector = 0.0 0.0 1.0
+plane_sampling.plane2.offsets       = 0.0 499.0
 
 line_sampling.output_frequency     = 1
 line_sampling.output_format        = native

--- a/test/test_files/terrain_box/terrain_box.inp
+++ b/test/test_files/terrain_box/terrain_box.inp
@@ -59,5 +59,5 @@ sampling.fields = velocity
 sampling.int_fields = terrain_blank
 sampling.volume1.type        = VolumeSampler
 sampling.volume1.hi        = 600 600 200
-sampling.volume1.lo      =  400 400 1e-16
+sampling.volume1.lo      =  400 400 0.0
 sampling.volume1.num_points  = 10 10 20


### PR DESCRIPTION
## Summary

If the user wants to specify planes that reach the domain bounds, adjust the `origin`, `axis1` and `axis2` so that the points are within the domain. This isn't a completely fullproof adjustment of the user values but I hope it catches most of them.

The check is based on a small fraction of the cell size so it won't really change the QOIs.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [x] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Closes: #1343