### PR TITLE
Use interp::linear instead of hand rolled interpolation

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -77,7 +77,7 @@ void ABLMeanBoussinesq::operator()(
     const int idir = m_axis;
     const amrex::Real* theights = m_theta_ht.data();
     const amrex::Real* tvals = m_theta_vals.data();
-    const amrex::Real* theights_end = m_theta_ht.data() + m_theta_ht.size();
+    const amrex::Real* theights_end = m_theta_ht.end();
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         amrex::IntVect iv(i, j, k);

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -73,7 +73,7 @@ void ABLMeanBoussinesq::operator()(
         m_gravity[0], m_gravity[1], m_gravity[2]};
 
     // Mean temperature profile used to compute background forcing term
-    
+
     const int idir = m_axis;
     const amrex::Real* theights = m_theta_ht.data();
     const amrex::Real* tvals = m_theta_vals.data();
@@ -82,8 +82,8 @@ void ABLMeanBoussinesq::operator()(
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         amrex::IntVect iv(i, j, k);
         const amrex::Real ht = problo[idir] + (iv[idir] + 0.5) * dx[idir];
-        const amrex::Real temp = amr_wind::interp::linear(
-	    theights, theights_end, tvals, ht);
+        const amrex::Real temp =
+            amr_wind::interp::linear(theights, theights_end, tvals, ht);
         const amrex::Real fac = beta * (temp - T0);
         src_term(i, j, k, 0) += gravity[0] * fac;
         src_term(i, j, k, 1) += gravity[1] * fac;

--- a/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -2,7 +2,7 @@
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/core/FieldUtils.H"
 #include "amr-wind/wind_energy/ABL.H"
-
+#include "amr-wind/utilities/linear_interpolation.H"
 #include "AMReX_ParmParse.H"
 
 namespace amr_wind::pde::icns {
@@ -73,28 +73,17 @@ void ABLMeanBoussinesq::operator()(
         m_gravity[0], m_gravity[1], m_gravity[2]};
 
     // Mean temperature profile used to compute background forcing term
-    //
-    // Assumes that the temperature profile is at the cell-centers of the level
-    // 0 grid. For finer meshes, it will extrapolate beyond the Level0
-    // cell-centers for the lo/hi cells.
-    //
+    
     const int idir = m_axis;
-    const int nh_max = static_cast<int>(m_theta_ht.size()) - 2;
-    const int lp1 = lev + 1;
     const amrex::Real* theights = m_theta_ht.data();
     const amrex::Real* tvals = m_theta_vals.data();
+    const amrex::Real* theights_end = m_theta_ht.data() + m_theta_ht.size();
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        amrex::Real temp = T0;
         amrex::IntVect iv(i, j, k);
         const amrex::Real ht = problo[idir] + (iv[idir] + 0.5) * dx[idir];
-
-        const int il = amrex::min(k / lp1, nh_max);
-        const int ir = il + 1;
-        temp = tvals[il] +
-               ((tvals[ir] - tvals[il]) / (theights[ir] - theights[il])) *
-                   (ht - theights[il]);
-
+        const amrex::Real temp = amr_wind::interp::linear(
+	    theights, theights_end, tvals, ht);
         const amrex::Real fac = beta * (temp - T0);
         src_term(i, j, k, 0) += gravity[0] * fac;
         src_term(i, j, k, 1) += gravity[1] * fac;

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -338,9 +338,8 @@ void ABLMesoForcingMom::operator()(
     // averaged velocities (non tendency)
     const amrex::Real* vheights_begin =
         (m_tendency) ? m_meso_ht.data() : m_vavg_ht.data();
-    const amrex::Real* vheights_end = (m_tendency)
-                                          ? m_meso_ht.data() + m_meso_ht.size()
-                                          : m_vavg_ht.data() + m_vavg_ht.size();
+    const amrex::Real* vheights_end =
+        (m_tendency) ? m_meso_ht.end() : m_vavg_ht.end();
     const amrex::Real* u_error_val = m_error_meso_avg_U.data();
     const amrex::Real* v_error_val = m_error_meso_avg_V.data();
     const int idir = (int)m_axis;

--- a/amr-wind/equation_systems/icns/source_terms/BodyForce.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/BodyForce.cpp
@@ -123,7 +123,7 @@ void BodyForce::operator()(
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
 
     const amrex::Real* force_ht = m_ht.data();
-    const amrex::Real* force_ht_end = m_ht.data() + m_ht.size();
+    const amrex::Real* force_ht_end = m_ht.end();
     const amrex::Real* force_x = m_prof_x.data();
     const amrex::Real* force_y = m_prof_y.data();
 

--- a/amr-wind/equation_systems/icns/source_terms/HurricaneForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/HurricaneForcing.cpp
@@ -65,7 +65,7 @@ void HurricaneForcing::operator()(
 
     const int idir = m_axis;
     const amrex::Real* heights = m_vel_ht.data();
-    const amrex::Real* heights_end = m_vel_ht.data() + m_vel_ht.size();
+    const amrex::Real* heights_end = m_vel_ht.end();
     const amrex::Real* vals = m_vel_vals.data();
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -302,8 +302,7 @@ void ABLMesoForcingTemp::operator()(
     const amrex::Real* theights_begin =
         (m_tendency) ? m_meso_ht.data() : m_theta_ht.data();
     const amrex::Real* theights_end =
-        (m_tendency) ? m_meso_ht.data() + m_meso_ht.size()
-                     : m_theta_ht.data() + m_theta_ht.size();
+        (m_tendency) ? m_meso_ht.end() : m_theta_ht.end();
     const amrex::Real* theta_error_val = m_error_meso_avg_theta.data();
 
     const int idir = (int)m_axis;

--- a/amr-wind/equation_systems/temperature/source_terms/BodyForce.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/BodyForce.cpp
@@ -75,7 +75,7 @@ void BodyForce::operator()(
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
 
     const amrex::Real* force_ht = m_ht.data();
-    const amrex::Real* force_ht_end = m_ht.data() + m_ht.size();
+    const amrex::Real* force_ht_end = m_ht.end();
     const amrex::Real* force_theta = m_prof_theta.data();
 
     if (m_type == "height_varying" || m_type == "height-varying") {

--- a/amr-wind/equation_systems/temperature/source_terms/BodyForce.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/BodyForce.cpp
@@ -1,6 +1,7 @@
 #include "amr-wind/equation_systems/temperature/source_terms/BodyForce.H"
 #include "amr-wind/CFDSim.H"
 #include "amr-wind/utilities/trig_ops.H"
+#include "amr-wind/utilities/linear_interpolation.H"
 
 #include "AMReX_ParmParse.H"
 #include "AMReX_Gpu.H"
@@ -72,10 +73,9 @@ void BodyForce::operator()(
 
     const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
-    const int lp1 = lev + 1;
-    const int nh_max = (int)m_prof_theta.size() - 2;
 
     const amrex::Real* force_ht = m_ht.data();
+    const amrex::Real* force_ht_end = m_ht.data() + m_ht.size();
     const amrex::Real* force_theta = m_prof_theta.data();
 
     if (m_type == "height_varying" || m_type == "height-varying") {
@@ -84,14 +84,8 @@ void BodyForce::operator()(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::IntVect iv(i, j, k);
                 const amrex::Real ht = problo[2] + (iv[2] + 0.5) * dx[2];
-                const int il = amrex::min(k / lp1, nh_max);
-                const int ir = il + 1;
-                amrex::Real ftheta;
-
-                ftheta =
-                    force_theta[il] + ((force_theta[ir] - force_theta[il]) /
-                                       (force_ht[ir] - force_ht[il])) *
-                                          (ht - force_ht[il]);
+                const amrex::Real ftheta = amr_wind::interp::linear(
+                    force_ht, force_ht_end, force_theta, ht);
 
                 src_term(i, j, k, 0) += ftheta;
             });

--- a/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/HurricaneTempForcing.cpp
@@ -48,7 +48,7 @@ void HurricaneTempForcing::operator()(
 
     const int idir = m_axis;
     const amrex::Real* heights = m_vel_ht.data();
-    const amrex::Real* heights_end = m_vel_ht.data() + m_vel_ht.size();
+    const amrex::Real* heights_end = m_vel_ht.end();
     const amrex::Real* vals = m_vel_vals.data();
 
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {

--- a/amr-wind/turbulence/LES/AMD.cpp
+++ b/amr-wind/turbulence/LES/AMD.cpp
@@ -86,8 +86,7 @@ void AMD<Transport>::update_turbulent_viscosity(
         tpa_deriv_d.begin());
 
     const amrex::Real* p_tpa_coord_begin = tpa_coord_d.data();
-    const amrex::Real* p_tpa_coord_end =
-        tpa_coord_d.data() + tpa_coord_d.size();
+    const amrex::Real* p_tpa_coord_end = tpa_coord_d.end();
     const amrex::Real* p_tpa_deriv = tpa_deriv_d.data();
     const int nlevels = repo.num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
There are a few existing places where we have hand rolled interpolation code, this PR aims to identify and change those cases to use `interp::linear` and `interp::bilinear` where appropriate. 


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
