### PR TITLE
Update checkpoint refinement to have a max level

### DIFF
--- a/tools/utilities/refine-chkpt/RefineCheckpt.cpp
+++ b/tools/utilities/refine-chkpt/RefineCheckpt.cpp
@@ -66,9 +66,14 @@ void RefineCheckpt::run_utility()
     } else {
         refine_chkpt_file();
         const int start_level = 1;
+        int end_level = finestLevel();
+        {
+            amrex::ParmParse pp("amr");
+            pp.query("max_refined_level", end_level);
+        }
         amrex::Print() << "Writing refined levels: " << start_level << " - "
-                       << finestLevel() << std::endl;
-        sim().io_manager().write_checkpoint_file(start_level);
+                       << end_level << std::endl;
+        sim().io_manager().write_checkpoint_file(start_level, end_level);
     }
 }
 


### PR DESCRIPTION
## Summary

This lets the user do `amr.max_refined_level=1`:
```
Input grid summary:
  Level 0   216 grids  110592 cells  100 % of domain
            smallest grid: 8 x 8 x 8  biggest grid: 8 x 8 x 8
  Level 1   27 grids  13824 cells  1.5625 % of domain
            smallest grid: 8 x 8 x 8  biggest grid: 8 x 8 x 8

Uniformly refining mesh
Refinement time elapsed: 1.657051958
Refined grid summary:
  Level 0   216 grids  110592 cells  100 % of domain
            smallest grid: 8 x 8 x 8  biggest grid: 8 x 8 x 8
  Level 1   1728 grids  884736 cells  100 % of domain
            smallest grid: 8 x 8 x 8  biggest grid: 8 x 8 x 8
  Level 2   512 grids  262144 cells  3.703703704 % of domain
            smallest grid: 8 x 8 x 8  biggest grid: 8 x 8 x 8

Writing refined levels: 1 - 1
```

So that only (in this example) level 1 is written out. By default it would write level 1 and 2. 
