### PR TITLE
Allow string periodic for periodic BCs

### DIFF
--- a/amr-wind/boundary_conditions/BCInterface.cpp
+++ b/amr-wind/boundary_conditions/BCInterface.cpp
@@ -47,7 +47,8 @@ void BCIface::read_bctype()
 
         // Protect against copy/paste errors where user intended to add a BC but
         // forgot to turn off periodic in that direction, or vice versa.
-        if (geom.isPeriodic(ori.coordDir()) && bcstr != "null") {
+        if (geom.isPeriodic(ori.coordDir()) &&
+            ((bcstr != "null") && (bcstr != "periodic"))) {
             amrex::Abort(
                 "Setting " + bcstr + " BC on a periodic face " + bcid +
                 " is not allowed");


### PR DESCRIPTION
## Summary

Allow string periodic for periodic BCs.

Basically it's weird to get an error message that says:
```
std::runtime_error: Setting periodic BC on a periodic face xlo is not allowed
```

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
