### PR TITLE
Ocean Waves: harmonize initial profile

### DIFF
--- a/amr-wind/ocean_waves/CMakeLists.txt
+++ b/amr-wind/ocean_waves/CMakeLists.txt
@@ -3,4 +3,3 @@ target_sources(${amr_wind_lib_name}
   OceanWaves.cpp
   )
 add_subdirectory(relaxation_zones)
-add_subdirectory(utils)

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -43,69 +43,72 @@ struct InitDataOp<LinearWaves>
         auto& m_velocity = sim.repo().get_field("velocity");
 
         const auto& problo = geom.ProbLoArray();
+        const auto& probhi = geom.ProbHiArray();
         const auto& dx = geom.CellSizeArray();
         for (amrex::MFIter mfi(m_levelset(level)); mfi.isValid(); ++mfi) {
 
             const auto& phi = m_levelset(level).array(mfi);
             const auto& vel = m_velocity(level).array(mfi);
 
-            const amrex::Real zsl = wdata.zsl;
+            const amrex::Real zero_sea_level = wdata.zsl;
+            const amrex::Real gen_length = wdata.gen_length;
+            const amrex::Real beach_length = wdata.beach_length;
             const amrex::Real g = wdata.g;
+            const bool has_beach = wdata.has_beach;
+            const bool init_wave_field = wdata.init_wave_field;
             const auto& gbx3 = mfi.growntilebox(3);
 
-            if (wdata.init_wave_field) {
-                const amrex::Real wave_height = wdata.wave_height;
-                const amrex::Real wave_length = wdata.wave_length;
-                const amrex::Real water_depth = wdata.water_depth;
-                amrex::ParallelFor(
-                    gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real xc = problo[0] + (i + 0.5) * dx[0];
-                        const amrex::Real zc = problo[2] + (k + 0.5) * dx[2];
+            const amrex::Real wave_height = wdata.wave_height;
+            const amrex::Real wave_length = wdata.wave_length;
+            const amrex::Real water_depth = wdata.water_depth;
+            amrex::ParallelFor(
+                gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                    const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
-                        const amrex::Real wave_number = 2. * M_PI / wave_length;
-                        const amrex::Real omega = std::pow(
-                            wave_number * g *
-                                std::tanh(wave_number * water_depth),
-                            0.5);
-                        const amrex::Real phase = wave_number * xc;
-                        const amrex::Real eta =
-                            wave_height / 2.0 * std::cos(phase) + zsl;
+                    const amrex::Real wave_number = 2. * M_PI / wave_length;
+                    const amrex::Real omega = std::pow(
+                        wave_number * g * std::tanh(wave_number * water_depth),
+                        0.5);
+                    const amrex::Real phase = wave_number * x;
 
-                        phi(i, j, k) = eta - zc;
+                    // Wave profile
+                    const amrex::Real eta_w =
+                        wave_height / 2.0 * std::cos(phase) + zero_sea_level;
+                    const amrex::Real u_w =
+                        omega * wave_height / 2.0 *
+                        std::cosh(
+                            wave_number * (z - zero_sea_level + water_depth)) /
+                        std::sinh(wave_number * water_depth) * std::cos(phase);
+                    const amrex::Real v_w = 0.0;
+                    const amrex::Real w_w =
+                        omega * wave_height / 2.0 *
+                        std::sinh(
+                            wave_number * (z - zero_sea_level + water_depth)) /
+                        std::sinh(wave_number * water_depth) * std::sin(phase);
+                    const utils::WaveVec wave_sol{u_w, v_w, w_w, eta_w};
 
-                        const amrex::Real cell_length_2D =
-                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
-                        if (phi(i, j, k) + cell_length_2D >= 0) {
-                            vel(i, j, k, 0) =
-                                omega * wave_height / 2.0 *
-                                std::cosh(
-                                    wave_number * (zc - zsl + water_depth)) /
-                                std::sinh(wave_number * water_depth) *
-                                std::cos(phase);
-                            vel(i, j, k, 1) = 0.0;
-                            vel(i, j, k, 2) =
-                                omega * wave_height / 2.0 *
-                                std::sinh(
-                                    wave_number * (zc - zsl + water_depth)) /
-                                std::sinh(wave_number * water_depth) *
-                                std::sin(phase);
-                        }
-                    });
+                    // Quiescent profile
+                    const utils::WaveVec quiescent{
+                        0.0, 0.0, 0.0, zero_sea_level};
 
-            } else {
-                amrex::ParallelFor(
-                    gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
-                        phi(i, j, k) = zsl - z;
-                        const amrex::Real cell_length_2D =
-                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
-                        if (phi(i, j, k) + cell_length_2D >= 0) {
-                            vel(i, j, k, 0) = 0.0;
-                            vel(i, j, k, 1) = 0.0;
-                            vel(i, j, k, 2) = 0.0;
-                        }
-                    });
-            }
+                    // Specify initial state for each region of domain
+                    const auto bulk = init_wave_field ? wave_sol : quiescent;
+                    const auto outlet = has_beach ? quiescent : wave_sol;
+
+                    auto local_profile = utils::harmonize_profiles_1D(
+                        x, z, problo[0], gen_length, probhi[0], beach_length,
+                        wave_sol, bulk, outlet);
+
+                    phi(i, j, k) = local_profile[3] - z;
+                    const amrex::Real cell_length_2D =
+                        std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
+                    if (phi(i, j, k) + cell_length_2D >= 0) {
+                        vel(i, j, k, 0) = local_profile[0];
+                        vel(i, j, k, 1) = local_profile[1];
+                        vel(i, j, k, 2) = local_profile[2];
+                    }
+                });
         }
     }
 };
@@ -139,14 +142,14 @@ struct UpdateRelaxZonesOp<LinearWaves>
                 const amrex::Real wave_height = wdata.wave_height;
                 const amrex::Real wave_length = wdata.wave_length;
                 const amrex::Real water_depth = wdata.water_depth;
-                const amrex::Real zsl = wdata.zsl;
+                const amrex::Real zero_sea_level = wdata.zsl;
                 const amrex::Real g = wdata.g;
 
                 const auto& gbx = mfi.growntilebox(3);
                 amrex::ParallelFor(
                     gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real xc = problo[0] + (i + 0.5) * dx[0];
-                        const amrex::Real zc = problo[2] + (k + 0.5) * dx[2];
+                        const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
                         const amrex::Real wave_number = 2. * M_PI / wave_length;
                         const amrex::Real omega = std::pow(
@@ -154,12 +157,13 @@ struct UpdateRelaxZonesOp<LinearWaves>
                                 std::tanh(wave_number * water_depth),
                             0.5);
                         const amrex::Real phase =
-                            wave_number * xc - omega * time;
+                            wave_number * x - omega * time;
 
                         const amrex::Real eta =
-                            wave_height / 2.0 * std::cos(phase) + zsl;
+                            wave_height / 2.0 * std::cos(phase) +
+                            zero_sea_level;
 
-                        phi(i, j, k) = eta - zc;
+                        phi(i, j, k) = eta - z;
 
                         const amrex::Real cell_length_2D =
                             std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
@@ -167,14 +171,16 @@ struct UpdateRelaxZonesOp<LinearWaves>
                             vel(i, j, k, 0) =
                                 omega * wave_height / 2.0 *
                                 std::cosh(
-                                    wave_number * (zc - zsl + water_depth)) /
+                                    wave_number *
+                                    (z - zero_sea_level + water_depth)) /
                                 std::sinh(wave_number * water_depth) *
                                 std::cos(phase);
                             vel(i, j, k, 1) = 0.0;
                             vel(i, j, k, 2) =
                                 omega * wave_height / 2.0 *
                                 std::sinh(
-                                    wave_number * (zc - zsl + water_depth)) /
+                                    wave_number *
+                                    (z - zero_sea_level + water_depth)) /
                                 std::sinh(wave_number * water_depth) *
                                 std::sin(phase);
                         } else {

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -96,7 +96,7 @@ struct InitDataOp<LinearWaves>
                     const auto bulk = init_wave_field ? wave_sol : quiescent;
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
-                    auto local_profile = utils::harmonize_profiles_1D(
+                    auto local_profile = utils::harmonize_profiles_1d(
                         x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -97,7 +97,7 @@ struct InitDataOp<LinearWaves>
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
                     auto local_profile = utils::harmonize_profiles_1D(
-                        x, z, problo[0], gen_length, probhi[0], beach_length,
+                        x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 
                     phi(i, j, k) = local_profile[3] - z;

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -96,7 +96,7 @@ struct InitDataOp<LinearWaves>
                     const auto bulk = init_wave_field ? wave_sol : quiescent;
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
-                    auto local_profile = utils::harmonize_profiles_1d(
+                    const auto local_profile = utils::harmonize_profiles_1d(
                         x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.H
@@ -4,6 +4,7 @@
 #include "amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H"
 #include "amr-wind/ocean_waves/OceanWavesTypes.H"
 #include "amr-wind/ocean_waves/OceanWavesOps.H"
+#include "amr-wind/ocean_waves/utils/wave_utils_K.H"
 #include "amr-wind/core/MultiParser.H"
 #include "amr-wind/fvm/gradient.H"
 

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -119,9 +119,8 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                         const amrex::Real Gamma =
                             utils::gamma_generate(x - problo[0], gen_length);
                         // Get bounded new vof, incorporate with increment
-                        amrex::Real new_vof =
-                            (1. - Gamma) * target_volfrac(i, j, k) +
-                            Gamma * volfrac(i, j, k);
+                        amrex::Real new_vof = utils::combine_linear(
+                            Gamma, target_volfrac(i, j, k), volfrac(i, j, k));
                         new_vof = (new_vof > 1. - vof_tiny)
                                       ? 1.0
                                       : (new_vof < vof_tiny ? 0.0 : new_vof);
@@ -136,8 +135,8 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                             // Get updated liquid velocity
                             amrex::Real vel_liq = vel(i, j, k, n);
                             const amrex::Real dvel_liq =
-                                ((1. - Gamma) * target_vel(i, j, k, n) +
-                                 Gamma * vel_liq) -
+                                utils::combine_linear(
+                                    Gamma, target_vel(i, j, k, n), vel_liq) -
                                 vel_liq;
                             vel_liq += rampf * fvel_liq * dvel_liq;
                             // If liquid was added, that liquid has target_vel
@@ -161,10 +160,10 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                         // Numerical beach (sponge layer)
                         if (has_beach) {
                             // Get bounded new vof, save increment
-                            amrex::Real new_vof =
-                                (1. - Gamma) *
-                                    utils::free_surface_to_vof(zsl, z, dx[2]) +
-                                Gamma * volfrac(i, j, k);
+                            amrex::Real new_vof = utils::combine_linear(
+                                Gamma,
+                                utils::free_surface_to_vof(zsl, z, dx[2]),
+                                volfrac(i, j, k));
                             new_vof =
                                 (new_vof > 1. - vof_tiny)
                                     ? 1.0
@@ -187,9 +186,9 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                         // Forcing to wave profile instead
                         if (has_outprofile) {
                             // Same steps as in wave generation region
-                            amrex::Real new_vof =
-                                (1. - Gamma) * target_volfrac(i, j, k) +
-                                Gamma * volfrac(i, j, k);
+                            amrex::Real new_vof = utils::combine_linear(
+                                Gamma, target_volfrac(i, j, k),
+                                volfrac(i, j, k));
                             new_vof =
                                 (new_vof > 1. - vof_tiny)
                                     ? 1.0
@@ -204,8 +203,9 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                             for (int n = 0; n < vel.ncomp; ++n) {
                                 amrex::Real vel_liq = vel(i, j, k, n);
                                 const amrex::Real dvel_liq =
-                                    ((1. - Gamma) * target_vel(i, j, k, n) +
-                                     Gamma * vel_liq) -
+                                    utils::combine_linear(
+                                        Gamma, target_vel(i, j, k, n),
+                                        vel_liq) -
                                     vel_liq;
                                 vel_liq += rampf * fvel_liq * dvel_liq;
                                 amrex::Real integrated_vel_liq =

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -8,8 +8,6 @@
 #include "amr-wind/fvm/gradient.H"
 #include "amr-wind/core/field_ops.H"
 
-#include "amr-wind/ocean_waves/utils/wave_utils_K.H"
-
 #include "AMReX_ParmParse.H"
 
 namespace amr_wind::ocean_waves::relaxation_zones {

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -122,7 +122,7 @@ struct InitDataOp<StokesWaves>
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
                     auto local_profile = utils::harmonize_profiles_1D(
-                        x, z, problo[0], gen_length, probhi[0], beach_length,
+                        x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 
                     phi(i, j, k) = local_profile[3] - z;

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -121,7 +121,7 @@ struct InitDataOp<StokesWaves>
                     const auto bulk = init_wave_field ? wave_sol : quiescent;
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
-                    auto local_profile = utils::harmonize_profiles_1d(
+                    const auto local_profile = utils::harmonize_profiles_1d(
                         x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -82,6 +82,7 @@ struct InitDataOp<StokesWaves>
         // cppcheck-suppress constVariableReference
         auto& velocity = sim.repo().get_field("velocity");
         const auto& problo = geom.ProbLoArray();
+        const auto& probhi = geom.ProbHiArray();
         const auto& dx = geom.CellSizeArray();
         for (amrex::MFIter mfi(m_levelset(level)); mfi.isValid(); ++mfi) {
 
@@ -92,46 +93,47 @@ struct InitDataOp<StokesWaves>
             const amrex::Real wave_length = wdata.wave_length;
             const amrex::Real water_depth = wdata.water_depth;
             const amrex::Real zero_sea_level = wdata.zsl;
+            const amrex::Real gen_length = wdata.gen_length;
+            const amrex::Real beach_length = wdata.beach_length;
             const amrex::Real g = wdata.g;
             const int order = wdata.order;
+            const bool has_beach = wdata.has_beach;
+            const bool init_wave_field = wdata.init_wave_field;
             const auto& gbx3 = mfi.growntilebox(3);
 
-            if (wdata.init_wave_field) {
-                amrex::ParallelFor(
-                    gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
-                        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+            amrex::ParallelFor(
+                gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    const amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                    const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
-                        amrex::Real eta{0.0}, u_w{0.0}, v_w{0.0}, w_w{0.0};
+                    // Wave profile
+                    amrex::Real eta_w{0.0}, u_w{0.0}, v_w{0.0}, w_w{0.0};
+                    relaxation_zones::stokes_waves(
+                        order, wave_length, water_depth, wave_height,
+                        zero_sea_level, g, x, z, 0.0, eta_w, u_w, v_w, w_w);
+                    const WaveVec wave_sol{u_w, v_w, w_w, eta_w};
 
-                        relaxation_zones::stokes_waves(
-                            order, wave_length, water_depth, wave_height,
-                            zero_sea_level, g, x, z, 0.0, eta, u_w, v_w, w_w);
+                    // Quiescent profile
+                    const WaveVec quiescent{0.0, 0.0, 0.0, zero_sea_level};
 
-                        phi(i, j, k) = eta - z;
-                        const amrex::Real cell_length_2D =
-                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
-                        if (phi(i, j, k) + cell_length_2D >= 0) {
-                            vel(i, j, k, 0) = u_w;
-                            vel(i, j, k, 1) = v_w;
-                            vel(i, j, k, 2) = w_w;
-                        }
-                    });
+                    // Specify initial state for each region of domain
+                    const auto bulk = init_wave_field ? wave_sol : quiescent;
+                    const auto outlet = has_beach ? quiescent : wave_sol;
 
-            } else {
-                amrex::ParallelFor(
-                    gbx3, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
-                        phi(i, j, k) = zero_sea_level - z;
-                        const amrex::Real cell_length_2D =
-                            std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
-                        if (phi(i, j, k) + cell_length_2D >= 0) {
-                            vel(i, j, k, 0) = 0.0;
-                            vel(i, j, k, 1) = 0.0;
-                            vel(i, j, k, 2) = 0.0;
-                        }
-                    });
-            }
+                    auto local_profile =
+                        ocean_waves::utils::harmonize_profiles_1D(
+                            x, z, problo[0], gen_length, probhi[0],
+                            beach_length, wave_sol, bulk, outlet);
+
+                    phi(i, j, k) = local_profile[3] - z;
+                    const amrex::Real cell_length_2D =
+                        std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
+                    if (phi(i, j, k) + cell_length_2D >= 0) {
+                        vel(i, j, k, 0) = local_profile[0];
+                        vel(i, j, k, 1) = local_profile[1];
+                        vel(i, j, k, 2) = local_profile[2];
+                    }
+                });
         }
     }
 };

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -121,7 +121,7 @@ struct InitDataOp<StokesWaves>
                     const auto bulk = init_wave_field ? wave_sol : quiescent;
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
-                    auto local_profile = utils::harmonize_profiles_1D(
+                    auto local_profile = utils::harmonize_profiles_1d(
                         x, problo[0], gen_length, probhi[0], beach_length,
                         wave_sol, bulk, outlet);
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -111,19 +111,19 @@ struct InitDataOp<StokesWaves>
                     relaxation_zones::stokes_waves(
                         order, wave_length, water_depth, wave_height,
                         zero_sea_level, g, x, z, 0.0, eta_w, u_w, v_w, w_w);
-                    const WaveVec wave_sol{u_w, v_w, w_w, eta_w};
+                    const utils::WaveVec wave_sol{u_w, v_w, w_w, eta_w};
 
                     // Quiescent profile
-                    const WaveVec quiescent{0.0, 0.0, 0.0, zero_sea_level};
+                    const utils::WaveVec quiescent{
+                        0.0, 0.0, 0.0, zero_sea_level};
 
                     // Specify initial state for each region of domain
                     const auto bulk = init_wave_field ? wave_sol : quiescent;
                     const auto outlet = has_beach ? quiescent : wave_sol;
 
-                    auto local_profile =
-                        ocean_waves::utils::harmonize_profiles_1D(
-                            x, z, problo[0], gen_length, probhi[0],
-                            beach_length, wave_sol, bulk, outlet);
+                    auto local_profile = utils::harmonize_profiles_1D(
+                        x, z, problo[0], gen_length, probhi[0], beach_length,
+                        wave_sol, bulk, outlet);
 
                     phi(i, j, k) = local_profile[3] - z;
                     const amrex::Real cell_length_2D =

--- a/amr-wind/ocean_waves/utils/CMakeLists.txt
+++ b/amr-wind/ocean_waves/utils/CMakeLists.txt
@@ -1,3 +1,0 @@
-target_sources(${amr_wind_lib_name}
-  PRIVATE
-  )

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -66,7 +66,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real combine_linear(
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1D(
     const amrex::Real x,
-    const amrex::Real z,
     const amrex::Real left_bdy,
     const amrex::Real left_length,
     const amrex::Real right_bdy,

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -64,7 +64,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real combine_linear(
     return (1. - factor) * target + factor * current;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1D(
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1d(
     const amrex::Real x,
     const amrex::Real left_bdy,
     const amrex::Real left_length,
@@ -79,21 +79,20 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1D(
         return left;
     } else if (x + right_length >= right_bdy) {
         return right;
-    } else {
-        // Combine solutions in central region using relax zone length scales
-        const amrex::Real Gamma_left =
-            gamma_generate(x - (left_bdy + left_length), 0.5 * left_length);
-        const amrex::Real Gamma_right = gamma_absorb(
-            x - (right_bdy - 1.5 * right_length), 0.5 * right_length, 1.0);
-        const bool right_inactive = Gamma_right > 1.0 - 1e-12;
-        WaveVec combo;
-        for (int n = 0; n < 4; ++n) {
-            combo[n] = right_inactive
-                           ? combine_linear(Gamma_left, left[n], bulk[n])
-                           : combine_linear(Gamma_right, right[n], bulk[n]);
-        }
-        return combo;
     }
+    // Combine solutions in central region using relax zone length scales
+    const amrex::Real Gamma_left =
+        gamma_generate(x - (left_bdy + left_length), 0.5 * left_length);
+    const amrex::Real Gamma_right = gamma_absorb(
+        x - (right_bdy - 1.5 * right_length), 0.5 * right_length, 1.0);
+    const bool right_inactive = Gamma_right > 1.0 - 1e-12;
+    WaveVec combo;
+    for (int n = 0; n < 4; ++n) {
+        combo[n] = right_inactive
+                       ? combine_linear(Gamma_left, left[n], bulk[n])
+                       : combine_linear(Gamma_right, right[n], bulk[n]);
+    }
+    return combo;
 }
 
 } // namespace amr_wind::ocean_waves::utils

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -82,9 +82,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1D(
     } else {
         // Combine solutions in central region using relax zone length scales
         const amrex::Real Gamma_left =
-            gamma_generate(x - (left_bdy + left_length), left_length);
+            gamma_generate(x - (left_bdy + left_length), 0.5 * left_length);
         const amrex::Real Gamma_right = gamma_absorb(
-            x - (right_bdy - 2.0 * right_length), right_length, 1.0);
+            x - (right_bdy - 1.5 * right_length), 0.5 * right_length, 1.0);
         const bool right_inactive = Gamma_right > 1.0 - 1e-12;
         WaveVec combo;
         for (int n = 0; n < 4; ++n) {

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -77,7 +77,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1d(
     // Initialize boundary regions entirely with boundary solutions
     if (x <= left_bdy + left_length) {
         return left;
-    } else if (x + right_length >= right_bdy) {
+    }
+    if (x + right_length >= right_bdy) {
         return right;
     }
     // Combine solutions in central region using relax zone length scales

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -4,9 +4,9 @@
 #include <AMReX_FArrayBox.H>
 #include <cmath>
 
-using WaveVec = amrex::GpuArray<amrex::Real, 4>;
-
 namespace amr_wind::ocean_waves::utils {
+
+using WaveVec = amrex::GpuArray<amrex::Real, 4>;
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real free_surface_to_vof(
     const amrex::Real eta, const amrex::Real z, const amrex::Real dz)

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -4,6 +4,8 @@
 #include <AMReX_FArrayBox.H>
 #include <cmath>
 
+using WaveVec = amrex::GpuArray<amrex::Real, 4>;
+
 namespace amr_wind::ocean_waves::utils {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real free_surface_to_vof(
@@ -52,6 +54,14 @@ ramp(const amrex::Real time, const amrex::Real ramp_period)
             (1.0 / M_PI) * std::sin(M_PI * (time / ramp_period));
     }
     return f;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real combine_linear(
+    const amrex::Real factor,
+    const amrex::Real target,
+    const amrex::Real current)
+{
+    return (1. - factor) * target + factor * current;
 }
 
 } // namespace amr_wind::ocean_waves::utils

--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -64,6 +64,39 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real combine_linear(
     return (1. - factor) * target + factor * current;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE WaveVec harmonize_profiles_1D(
+    const amrex::Real x,
+    const amrex::Real z,
+    const amrex::Real left_bdy,
+    const amrex::Real left_length,
+    const amrex::Real right_bdy,
+    const amrex::Real right_length,
+    const WaveVec left,
+    const WaveVec bulk,
+    const WaveVec right)
+{
+    // Initialize boundary regions entirely with boundary solutions
+    if (x <= left_bdy + left_length) {
+        return left;
+    } else if (x + right_length >= right_bdy) {
+        return right;
+    } else {
+        // Combine solutions in central region using relax zone length scales
+        const amrex::Real Gamma_left =
+            gamma_generate(x - (left_bdy + left_length), left_length);
+        const amrex::Real Gamma_right = gamma_absorb(
+            x - (right_bdy - 2.0 * right_length), right_length, 1.0);
+        const bool right_inactive = Gamma_right > 1.0 - 1e-12;
+        WaveVec combo;
+        for (int n = 0; n < 4; ++n) {
+            combo[n] = right_inactive
+                           ? combine_linear(Gamma_left, left[n], bulk[n])
+                           : combine_linear(Gamma_right, right[n], bulk[n]);
+        }
+        return combo;
+    }
+}
+
 } // namespace amr_wind::ocean_waves::utils
 
 #endif

--- a/unit_tests/ocean_waves/test_wave_utils.cpp
+++ b/unit_tests/ocean_waves/test_wave_utils.cpp
@@ -154,14 +154,14 @@ TEST_F(WaveUtilsTest, harmonize_profiles)
     const amr_wind::ocean_waves::utils::WaveVec right{-1.0, 1.0, 0.5, -0.1};
 
     amrex::Real x = -0.9;
-    auto result = amr_wind::ocean_waves::utils::harmonize_profiles_1D(
+    auto result = amr_wind::ocean_waves::utils::harmonize_profiles_1d(
         x, problo_x, gen_length, probhi_x, beach_length, left, bulk, right);
     for (int n = 0; n < 4; ++n) {
         EXPECT_NEAR(left[n], result[n], tol);
     }
 
     x = -0.75;
-    result = amr_wind::ocean_waves::utils::harmonize_profiles_1D(
+    result = amr_wind::ocean_waves::utils::harmonize_profiles_1d(
         x, problo_x, gen_length, probhi_x, beach_length, left, bulk, right);
     const amrex::Real Gamma_l = amr_wind::ocean_waves::utils::gamma_generate(
         x - (problo_x + gen_length), 0.5 * gen_length);
@@ -171,14 +171,14 @@ TEST_F(WaveUtilsTest, harmonize_profiles)
     }
 
     x = 0.;
-    result = amr_wind::ocean_waves::utils::harmonize_profiles_1D(
+    result = amr_wind::ocean_waves::utils::harmonize_profiles_1d(
         x, problo_x, gen_length, probhi_x, beach_length, left, bulk, right);
     for (int n = 0; n < 4; ++n) {
         EXPECT_NEAR(bulk[n], result[n], tol);
     }
 
     x = 0.5;
-    result = amr_wind::ocean_waves::utils::harmonize_profiles_1D(
+    result = amr_wind::ocean_waves::utils::harmonize_profiles_1d(
         x, problo_x, gen_length, probhi_x, beach_length, left, bulk, right);
     const amrex::Real Gamma_r = amr_wind::ocean_waves::utils::gamma_absorb(
         x - (probhi_x - beach_length) + 0.5 * beach_length, 0.5 * beach_length,
@@ -189,7 +189,7 @@ TEST_F(WaveUtilsTest, harmonize_profiles)
     }
 
     x = 0.8;
-    result = amr_wind::ocean_waves::utils::harmonize_profiles_1D(
+    result = amr_wind::ocean_waves::utils::harmonize_profiles_1d(
         x, problo_x, gen_length, probhi_x, beach_length, left, bulk, right);
     for (int n = 0; n < 4; ++n) {
         EXPECT_NEAR(right[n], result[n], tol);

--- a/unit_tests/ocean_waves/test_wave_utils.cpp
+++ b/unit_tests/ocean_waves/test_wave_utils.cpp
@@ -128,4 +128,17 @@ TEST_F(WaveUtilsTest, ramp)
     EXPECT_NEAR(f_ramp_past, 1.0, tol);
 }
 
+TEST_F(WaveUtilsTest, combine_linear)
+{
+    constexpr amrex::Real tol = 1e-12;
+    constexpr amrex::Real Gamma = 0.7;
+    constexpr amrex::Real target = 2.0;
+    constexpr amrex::Real current = 1.5;
+
+    const amrex::Real result =
+        amr_wind::ocean_waves::utils::combine_linear(Gamma, target, current);
+
+    EXPECT_NEAR(result, (1.0 - Gamma) * target + Gamma * current, tol);
+}
+
 } // namespace amr_wind_tests


### PR DESCRIPTION
## Summary

This sets up the boundary regions better at initialization and smooths the profile to whatever is specified within the bulk of the domain. Did some refactoring along the way. This PR helps with some stability issues we've been seeing by avoiding initial transients that were difficult for the pressure solver.

## Pull request type

not exactly sure:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

needs new unit tests
