### PR TITLE
Update terrain blanking

### DIFF
--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -110,7 +110,7 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
                 xterrain_ptr, xterrain_ptr + xterrain_size, yterrain_ptr,
                 yterrain_ptr + yterrain_size, zterrain_ptr, x, y);
             levelBlanking[nbx](i, j, k, 0) =
-                static_cast<int>((z <= terrainHt) && (z > 0));
+                static_cast<int>((z <= terrainHt) && (z > prob_lo[2]));
             levelheight[nbx](i, j, k, 0) =
                 std::max(std::abs(z - terrainHt), 0.5 * dx[2]);
 

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -109,7 +109,8 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
             const amrex::Real terrainHt = interp::bilinear(
                 xterrain_ptr, xterrain_ptr + xterrain_size, yterrain_ptr,
                 yterrain_ptr + yterrain_size, zterrain_ptr, x, y);
-            levelBlanking[nbx](i, j, k, 0) = static_cast<int>(z <= terrainHt);
+            levelBlanking[nbx](i, j, k, 0) =
+                static_cast<int>((z <= terrainHt) && (z > 0));
             levelheight[nbx](i, j, k, 0) =
                 std::max(std::abs(z - terrainHt), 0.5 * dx[2]);
 


### PR DESCRIPTION
## Summary

Update terrain blanking so that the ghost cells are not tagged as blanked. This ensures only the actual part of the blanking gets tagged for refinement and not the whole bottom domain.

Tagging now looks like:
![Screenshot 2024-11-18 at 4 06 30 PM](https://github.com/user-attachments/assets/06e70a03-d6d0-444c-8a68-8c9eb88054ba)



## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
