### PR TITLE
Bounded terrain refinement

### DIFF
--- a/amr-wind/utilities/tagging/BoundFieldRefinement.H
+++ b/amr-wind/utilities/tagging/BoundFieldRefinement.H
@@ -1,0 +1,182 @@
+#ifndef BOUNDFIELDREFINEMENT_H
+#define BOUNDFIELDREFINEMENT_H
+
+#include "amr-wind/utilities/tagging/RefinementCriteria.H"
+
+namespace amr_wind {
+class Field;
+class IntField;
+
+/** AMR refinement using a given field (e.g., density)
+ *  \ingroup amr_utils
+ *
+ *  ```
+ *  tagging.labels = t1
+ *  tagging/t1.type = BoundFieldRefinement
+ *  tagging/t1.field_name = density
+ *  # Tagging based on field value
+ *  # tagging/t1.field_error = 10.0 10.0
+
+ *  # Tagging based on local gradient
+ *  tagging/t1.grad_error = 0.1 0.1 0.1
+ *  ```
+ * Adds an option to define bounds for different level of refinement
+ * from a user specified file
+ * A sample file looks like this
+ * xmin xmax ymin ymax level
+ * -500 500 -500 500 1
+ * -200 200 -200 200 2
+ * This helps to provide higher refinement levels near steep cliffs
+ * and keep refinement levels lower away from region of interest
+ */
+class BoundFieldRefinement
+    : public RefinementCriteria::Register<BoundFieldRefinement>
+{
+public:
+    static std::string identifier() { return "BoundFieldRefinement"; }
+
+    explicit BoundFieldRefinement(const CFDSim& sim);
+
+    ~BoundFieldRefinement() override = default;
+
+    //! Read input file and initialize boxarray used to refine each level
+    void initialize(const std::string& key) override;
+
+    void operator()(
+        const int level,
+        amrex::TagBoxArray& tags,
+        const amrex::Real time,
+        const int ngrow) override;
+
+    template <typename MF>
+    void tag(const int level, amrex::TagBoxArray& tags, const MF& mfab)
+    {
+        const bool tag_field = level <= m_max_lev_field;
+        const bool tag_grad = level <= m_max_lev_grad;
+        const auto& geom = m_mesh.Geom(level);
+        const auto& dx = geom.CellSizeArray();
+        const auto& prob_lo = geom.ProbLoArray();
+        const unsigned vsize = m_xmin_list.size();
+        amrex::Gpu::DeviceVector<amrex::Real> m_device_xmin_list;
+        amrex::Gpu::DeviceVector<amrex::Real> m_device_xmax_list;
+        amrex::Gpu::DeviceVector<amrex::Real> m_device_ymin_list;
+        amrex::Gpu::DeviceVector<amrex::Real> m_device_ymax_list;
+        amrex::Gpu::DeviceVector<amrex::Real> m_device_level_list;
+        m_device_xmin_list.resize(vsize);
+        m_device_xmax_list.resize(vsize);
+        m_device_ymin_list.resize(vsize);
+        m_device_ymax_list.resize(vsize);
+        m_device_level_list.resize(vsize);
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, m_xmin_list.begin(), m_xmin_list.end(),
+            m_device_xmin_list.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, m_xmax_list.begin(), m_xmax_list.end(),
+            m_device_xmax_list.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, m_ymin_list.begin(), m_ymin_list.end(),
+            m_device_ymin_list.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, m_ymax_list.begin(), m_ymax_list.end(),
+            m_device_ymax_list.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, m_level_list.begin(), m_level_list.end(),
+            m_device_level_list.begin());
+        const auto* device_xmin_list = m_device_xmin_list.data();
+        const auto* device_xmax_list = m_device_xmax_list.data();
+        const auto* device_ymin_list = m_device_ymin_list.data();
+        const auto* device_ymax_list = m_device_ymax_list.data();
+        const auto* device_level_list = m_device_level_list.data();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(mfab, amrex::TilingIfNotGPU()); mfi.isValid();
+             ++mfi) {
+            const auto& bx = mfi.tilebox();
+            const auto& tag = tags.array(mfi);
+            const auto& farr = mfab.const_array(mfi);
+
+            if (tag_field) {
+                const auto fld_err = m_field_error[level];
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                        const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                        const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+                        bool add_cell = false;
+                        for (unsigned ii = 0; ii < vsize; ++ii) {
+                            if (x >= device_xmin_list[i] &&
+                                x <= device_xmax_list[i] &&
+                                y >= device_ymin_list[i] &&
+                                y <= device_ymax_list[i] &&
+                                level <= device_level_list[i] && z > dx[2]) {
+                                add_cell = true;
+                                break;
+                            }
+                        }
+                        if (farr(i, j, k) > fld_err && add_cell) {
+                            tag(i, j, k) = amrex::TagBox::SET;
+                        }
+                    });
+            }
+            if (tag_grad) {
+                const auto gerr = m_grad_error[level];
+                amrex::ParallelFor(
+                    bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        const auto axp =
+                            std::abs(farr(i + 1, j, k) - farr(i, j, k));
+                        const auto ayp =
+                            std::abs(farr(i, j + 1, k) - farr(i, j, k));
+                        const auto azp =
+                            std::abs(farr(i, j, k + 1) - farr(i, j, k));
+                        const auto axm =
+                            std::abs(farr(i - 1, j, k) - farr(i, j, k));
+                        const auto aym =
+                            std::abs(farr(i, j - 1, k) - farr(i, j, k));
+                        const auto azm =
+                            std::abs(farr(i, j, k - 1) - farr(i, j, k));
+                        const auto ax = amrex::max(axp, axm);
+                        const auto ay = amrex::max(ayp, aym);
+                        const auto az = amrex::max(azp, azm);
+                        const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                        const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                        bool add_cell = false;
+                        for (unsigned ii = 0; ii < vsize; ++ii) {
+                            if (x >= device_xmin_list[ii] &&
+                                x <= device_xmax_list[ii] &&
+                                y >= device_ymin_list[ii] &&
+                                y <= device_ymax_list[ii] &&
+                                level <= device_level_list[ii]) {
+                                add_cell = true;
+                                break;
+                            }
+                        }
+                        if (amrex::max(ax, ay, az) >= gerr && add_cell) {
+                            tag(i, j, k) = amrex::TagBox::SET;
+                        }
+                    });
+            }
+        }
+    }
+
+private:
+    const CFDSim& m_sim;
+    const amrex::AmrCore& m_mesh;
+    Field* m_field{nullptr};
+    IntField* m_int_field{nullptr};
+
+    amrex::Vector<amrex::Real> m_field_error;
+    amrex::Vector<amrex::Real> m_grad_error;
+    std::string m_boundsfile;
+    amrex::Vector<amrex::Real> m_xmin_list;
+    amrex::Vector<amrex::Real> m_xmax_list;
+    amrex::Vector<amrex::Real> m_ymin_list;
+    amrex::Vector<amrex::Real> m_ymax_list;
+    amrex::Vector<amrex::Real> m_level_list;
+    int m_max_lev_field{-1};
+    int m_max_lev_grad{-1};
+};
+
+} // namespace amr_wind
+
+#endif /* BOUNDFIELDREFINEMENT_H */

--- a/amr-wind/utilities/tagging/BoundFieldRefinement.H
+++ b/amr-wind/utilities/tagging/BoundFieldRefinement.H
@@ -105,11 +105,11 @@ public:
                         const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
                         bool add_cell = false;
                         for (unsigned ii = 0; ii < vsize; ++ii) {
-                            if (x >= device_xmin_list[i] &&
-                                x <= device_xmax_list[i] &&
-                                y >= device_ymin_list[i] &&
-                                y <= device_ymax_list[i] &&
-                                level <= device_level_list[i] && z > dx[2]) {
+                            if (x >= device_xmin_list[ii] &&
+                                x <= device_xmax_list[ii] &&
+                                y >= device_ymin_list[ii] &&
+                                y <= device_ymax_list[ii] &&
+                                level <= device_level_list[ii] && z > dx[2]) {
                                 add_cell = true;
                                 break;
                             }
@@ -143,11 +143,11 @@ public:
                         const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
                         bool add_cell = false;
                         for (unsigned ii = 0; ii < vsize; ++ii) {
-                            if (x >= device_xmin_list[i] &&
-                                x <= device_xmax_list[i] &&
-                                y >= device_ymin_list[i] &&
-                                y <= device_ymax_list[i] &&
-                                level <= device_level_list[i] && z > dx[2]) {
+                            if (x >= device_xmin_list[ii] &&
+                                x <= device_xmax_list[ii] &&
+                                y >= device_ymin_list[ii] &&
+                                y <= device_ymax_list[ii] &&
+                                level <= device_level_list[ii] && z > dx[2]) {
                                 add_cell = true;
                                 break;
                             }

--- a/amr-wind/utilities/tagging/BoundFieldRefinement.H
+++ b/amr-wind/utilities/tagging/BoundFieldRefinement.H
@@ -140,13 +140,14 @@ public:
                         const auto az = amrex::max(azp, azm);
                         const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
                         const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                        const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
                         bool add_cell = false;
                         for (unsigned ii = 0; ii < vsize; ++ii) {
-                            if (x >= device_xmin_list[ii] &&
-                                x <= device_xmax_list[ii] &&
-                                y >= device_ymin_list[ii] &&
-                                y <= device_ymax_list[ii] &&
-                                level <= device_level_list[ii]) {
+                            if (x >= device_xmin_list[i] &&
+                                x <= device_xmax_list[i] &&
+                                y >= device_ymin_list[i] &&
+                                y <= device_ymax_list[i] &&
+                                level <= device_level_list[i] && z > dx[2]) {
                                 add_cell = true;
                                 break;
                             }

--- a/amr-wind/utilities/tagging/BoundFieldRefinement.cpp
+++ b/amr-wind/utilities/tagging/BoundFieldRefinement.cpp
@@ -1,0 +1,105 @@
+#include "amr-wind/utilities/tagging/BoundFieldRefinement.H"
+#include "amr-wind/CFDSim.H"
+
+#include "AMReX.H"
+#include "AMReX_ParmParse.H"
+
+namespace amr_wind {
+
+BoundFieldRefinement::BoundFieldRefinement(const CFDSim& sim)
+    : m_sim(sim)
+    , m_mesh(sim.mesh())
+    , m_field_error(
+          m_sim.mesh().maxLevel() + 1, std::numeric_limits<amrex::Real>::max())
+    , m_grad_error(
+          m_sim.mesh().maxLevel() + 1, std::numeric_limits<amrex::Real>::max())
+{}
+
+void BoundFieldRefinement::initialize(const std::string& key)
+{
+    amrex::ParmParse pp(key);
+    std::string fname;
+    pp.query("field_name", fname);
+    const auto& repo = m_sim.repo();
+    if (repo.field_exists(fname)) {
+        m_field = &(m_sim.repo().get_field(fname));
+        AMREX_ALWAYS_ASSERT(m_field->num_grow() > amrex::IntVect{0});
+    } else if (repo.int_field_exists(fname)) {
+        m_int_field = &(m_sim.repo().get_int_field(fname));
+        AMREX_ALWAYS_ASSERT(m_int_field->num_grow() > amrex::IntVect{0});
+    } else {
+        amrex::Abort("BoundFieldRefinement: Cannot find field = " + fname);
+    }
+
+    amrex::Vector<amrex::Real> field_err;
+    amrex::Vector<amrex::Real> grad_err;
+    pp.queryarr("field_error", field_err);
+    pp.queryarr("grad_error", grad_err);
+
+    if ((field_err.empty()) && (grad_err.empty())) {
+        amrex::Abort(
+            "BoundFieldRefinement: Must specify at least one of field_error or "
+            "grad_error");
+    }
+
+    {
+        const int fcount = std::min(
+            static_cast<int>(field_err.size()),
+            static_cast<int>(m_field_error.size()));
+        for (int i = 0; i < fcount; ++i) {
+            m_field_error[i] = field_err[i];
+        }
+        m_max_lev_field = fcount - 1;
+    }
+    {
+        const int fcount = std::min(
+            static_cast<int>(grad_err.size()),
+            static_cast<int>(m_grad_error.size()));
+        for (int i = 0; i < fcount; ++i) {
+            m_grad_error[i] = grad_err[i];
+        }
+        m_max_lev_grad = fcount - 1;
+    }
+    pp.query("bounds_file", m_boundsfile);
+    if (!m_boundsfile.empty()) {
+        std::ifstream boundsfile(m_boundsfile, std::ios::in);
+        if (!boundsfile.good()) {
+            amrex::Abort("Cannot find the bounds file " + m_boundsfile);
+        }
+        amrex::Real value1, value2, value3, value4, value5;
+        while (boundsfile >> value1 >> value2 >> value3 >> value4 >> value5) {
+            m_xmin_list.push_back(value1);
+            m_xmax_list.push_back(value2);
+            m_ymin_list.push_back(value3);
+            m_ymax_list.push_back(value4);
+            m_level_list.push_back(value5);
+        }
+    }
+}
+
+void BoundFieldRefinement::operator()(
+    const int level,
+    amrex::TagBoxArray& tags,
+    const amrex::Real time,
+    const int /*ngrow*/)
+{
+    const bool tag_grad = level <= m_max_lev_grad;
+    if (tag_grad) {
+        if (m_field != nullptr) {
+            m_field->fillpatch(level, time, (*m_field)(level), 1);
+        } else if (m_int_field != nullptr) {
+            (*m_int_field)(level).FillBoundary(
+                m_sim.repo().mesh().Geom(level).periodicity());
+        }
+    }
+
+    if (m_field != nullptr) {
+        const auto& mfab = (*m_field)(level);
+        tag(level, tags, mfab);
+    } else if (m_int_field != nullptr) {
+        const auto& mfab = (*m_int_field)(level);
+        tag(level, tags, mfab);
+    }
+}
+
+} // namespace amr_wind

--- a/amr-wind/utilities/tagging/CMakeLists.txt
+++ b/amr-wind/utilities/tagging/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${amr_wind_lib_name} PRIVATE
   RefinementCriteria.cpp
   CartBoxRefinement.cpp
   FieldRefinement.cpp
+  BoundFieldRefinement.cpp
   GradientMagRefinement.cpp
   CurvatureRefinement.cpp
   QCriterionRefinement.cpp


### PR DESCRIPTION
The field refinement with terrain_blank is unbounded and provides refinements in regions which are not of interest. This modification limits the bounds and levels of field refinement based on the user-specified  input file. 


Please check the type of change introduced:

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [X ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ X] on CPU <!-- note the OS and compiler -->

To do: 

1. Create a regression test 
2. Create a unit test 
![BoxRefinement](https://github.com/user-attachments/assets/d37a43fd-f298-46f3-8e9c-a67f61de55f8)

