### PR TITLE
Add a tagging box for restricting field refinement

### DIFF
--- a/amr-wind/utilities/tagging/FieldRefinement.H
+++ b/amr-wind/utilities/tagging/FieldRefinement.H
@@ -48,7 +48,6 @@ public:
         const bool tag_grad = level <= m_max_lev_grad;
         const auto& geom = m_sim.repo().mesh().Geom(level);
         const auto& prob_lo = geom.ProbLoArray();
-        const auto& prob_hi = geom.ProbHiArray();
         const auto& dx = geom.CellSizeArray();
 
 #ifdef AMREX_USE_OMP

--- a/amr-wind/utilities/tagging/FieldRefinement.H
+++ b/amr-wind/utilities/tagging/FieldRefinement.H
@@ -1,9 +1,11 @@
 #ifndef FIELDREFINEMENT_H
 #define FIELDREFINEMENT_H
 
+#include "amr-wind/CFDSim.H"
 #include "amr-wind/utilities/tagging/RefinementCriteria.H"
 
 namespace amr_wind {
+class CFDSim;
 class Field;
 class IntField;
 
@@ -44,6 +46,10 @@ public:
     {
         const bool tag_field = level <= m_max_lev_field;
         const bool tag_grad = level <= m_max_lev_grad;
+        const auto& geom = m_sim.repo().mesh().Geom(level);
+        const auto& prob_lo = geom.ProbLoArray();
+        const auto& prob_hi = geom.ProbHiArray();
+        const auto& dx = geom.CellSizeArray();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -58,7 +64,13 @@ public:
                 const auto fld_err = m_field_error[level];
                 amrex::ParallelFor(
                     bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        if (farr(i, j, k) > fld_err) {
+                        const amrex::RealVect coord = {AMREX_D_DECL(
+                            prob_lo[0] + (i + 0.5) * dx[0],
+                            prob_lo[1] + (j + 0.5) * dx[1],
+                            prob_lo[2] + (k + 0.5) * dx[2])};
+
+                        if ((farr(i, j, k) > fld_err) &&
+                            (m_tagging_box.contains(coord))) {
                             tag(i, j, k) = amrex::TagBox::SET;
                         }
                     });
@@ -68,6 +80,10 @@ public:
                 const auto gerr = m_grad_error[level];
                 amrex::ParallelFor(
                     bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        const amrex::RealVect coord = {AMREX_D_DECL(
+                            prob_lo[0] + (i + 0.5) * dx[0],
+                            prob_lo[1] + (j + 0.5) * dx[1],
+                            prob_lo[2] + (k + 0.5) * dx[2])};
                         const auto axp =
                             std::abs(farr(i + 1, j, k) - farr(i, j, k));
                         const auto ayp =
@@ -83,7 +99,8 @@ public:
                         const auto ax = amrex::max(axp, axm);
                         const auto ay = amrex::max(ayp, aym);
                         const auto az = amrex::max(azp, azm);
-                        if (amrex::max(ax, ay, az) >= gerr) {
+                        if ((amrex::max(ax, ay, az) >= gerr) &&
+                            (m_tagging_box.contains(coord))) {
                             tag(i, j, k) = amrex::TagBox::SET;
                         }
                     });
@@ -102,6 +119,7 @@ private:
 
     int m_max_lev_field{-1};
     int m_max_lev_grad{-1};
+    amrex::RealBox m_tagging_box;
 };
 
 } // namespace amr_wind

--- a/amr-wind/utilities/tagging/FieldRefinement.H
+++ b/amr-wind/utilities/tagging/FieldRefinement.H
@@ -49,6 +49,7 @@ public:
         const auto& geom = m_sim.repo().mesh().Geom(level);
         const auto& prob_lo = geom.ProbLoArray();
         const auto& dx = geom.CellSizeArray();
+        const auto tagging_box = m_tagging_box;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -69,7 +70,7 @@ public:
                             prob_lo[2] + (k + 0.5) * dx[2])};
 
                         if ((farr(i, j, k) > fld_err) &&
-                            (m_tagging_box.contains(coord))) {
+                            (tagging_box.contains(coord))) {
                             tag(i, j, k) = amrex::TagBox::SET;
                         }
                     });
@@ -99,7 +100,7 @@ public:
                         const auto ay = amrex::max(ayp, aym);
                         const auto az = amrex::max(azp, azm);
                         if ((amrex::max(ax, ay, az) >= gerr) &&
-                            (m_tagging_box.contains(coord))) {
+                            (tagging_box.contains(coord))) {
                             tag(i, j, k) = amrex::TagBox::SET;
                         }
                     });

--- a/amr-wind/utilities/tagging/FieldRefinement.cpp
+++ b/amr-wind/utilities/tagging/FieldRefinement.cpp
@@ -39,10 +39,12 @@ void FieldRefinement::initialize(const std::string& key)
 
     amrex::Vector<amrex::Real> box_lo(AMREX_SPACEDIM, 0);
     amrex::Vector<amrex::Real> box_hi(AMREX_SPACEDIM, 0);
-    if (pp.queryarr("box_lo", box_lo, 0, static_cast<int>(box_lo.size()))) {
+    if (pp.queryarr("box_lo", box_lo, 0, static_cast<int>(box_lo.size())) ==
+        1) {
         m_tagging_box.setLo(box_lo);
     }
-    if (pp.queryarr("box_hi", box_hi, 0, static_cast<int>(box_hi.size()))) {
+    if (pp.queryarr("box_hi", box_hi, 0, static_cast<int>(box_hi.size())) ==
+        1) {
         m_tagging_box.setHi(box_hi);
     }
 

--- a/amr-wind/utilities/tagging/FieldRefinement.cpp
+++ b/amr-wind/utilities/tagging/FieldRefinement.cpp
@@ -36,6 +36,15 @@ void FieldRefinement::initialize(const std::string& key)
     pp.queryarr("field_error", field_err);
     pp.queryarr("grad_error", grad_err);
 
+    amrex::Vector<amrex::Real> box_lo(AMREX_SPACEDIM);
+    amrex::Vector<amrex::Real> box_hi(AMREX_SPACEDIM);
+    pp.queryarr("box_lo", box_lo, 0, static_cast<int>(box_lo.size()));
+    pp.queryarr("box_hi", box_hi, 0, static_cast<int>(box_hi.size()));
+    m_tagging_box = amrex::RealBox(box_lo.data(), box_hi.data());
+    if (!m_tagging_box.ok()) {
+        m_tagging_box = m_sim.repo().mesh().Geom(0).ProbDomain();
+    }
+
     if ((field_err.empty()) && (grad_err.empty())) {
         amrex::Abort(
             "FieldRefinement: Must specify at least one of field_error or "

--- a/amr-wind/utilities/tagging/FieldRefinement.cpp
+++ b/amr-wind/utilities/tagging/FieldRefinement.cpp
@@ -12,6 +12,7 @@ FieldRefinement::FieldRefinement(const CFDSim& sim)
           m_sim.mesh().maxLevel() + 1, std::numeric_limits<amrex::Real>::max())
     , m_grad_error(
           m_sim.mesh().maxLevel() + 1, std::numeric_limits<amrex::Real>::max())
+    , m_tagging_box(m_sim.repo().mesh().Geom(0).ProbDomain())
 {}
 
 void FieldRefinement::initialize(const std::string& key)
@@ -36,13 +37,13 @@ void FieldRefinement::initialize(const std::string& key)
     pp.queryarr("field_error", field_err);
     pp.queryarr("grad_error", grad_err);
 
-    amrex::Vector<amrex::Real> box_lo(AMREX_SPACEDIM);
-    amrex::Vector<amrex::Real> box_hi(AMREX_SPACEDIM);
-    pp.queryarr("box_lo", box_lo, 0, static_cast<int>(box_lo.size()));
-    pp.queryarr("box_hi", box_hi, 0, static_cast<int>(box_hi.size()));
-    m_tagging_box = amrex::RealBox(box_lo.data(), box_hi.data());
-    if (!m_tagging_box.ok()) {
-        m_tagging_box = m_sim.repo().mesh().Geom(0).ProbDomain();
+    amrex::Vector<amrex::Real> box_lo(AMREX_SPACEDIM, 0);
+    amrex::Vector<amrex::Real> box_hi(AMREX_SPACEDIM, 0);
+    if (pp.queryarr("box_lo", box_lo, 0, static_cast<int>(box_lo.size()))) {
+        m_tagging_box.setLo(box_lo);
+    }
+    if (pp.queryarr("box_hi", box_hi, 0, static_cast<int>(box_hi.size()))) {
+        m_tagging_box.setHi(box_hi);
     }
 
     if ((field_err.empty()) && (grad_err.empty())) {

--- a/docs/sphinx/user/inputs_tagging.rst
+++ b/docs/sphinx/user/inputs_tagging.rst
@@ -80,6 +80,8 @@ Example::
   tagging.f1.type = FieldRefinement
   tagging.f1.field_name = density
   tagging.f1.grad_error = 0.1. 0.1 0.1
+  tagging.f1.box_lo = 10.0 10.0 10.0
+  tagging.f1.box_hi = 20.0 20.0 20.0
 
 .. input_param:: tagging.FieldRefinement.field_name
 
@@ -100,6 +102,20 @@ Example::
 
    List of gradient error values at each level. The user must specify a value for
    each level desired.
+
+.. input_param:: tagging.FieldRefinement.box_lo
+
+   **type:** Vector<Real>, optional
+
+   List of the low corner values for a bounding box where the tagging
+   will be active. By default the bounding box will span the entire domain.
+
+.. input_param:: tagging.FieldRefinement.box_hi
+
+   **type:** Vector<Real>, optional
+
+   List of the high corner values for a bounding box where the tagging
+   will be active. By default the bounding box will span the entire domain.
 
 Refinement using geometry
 `````````````````````````

--- a/unit_tests/utilities/test_field_norms.cpp
+++ b/unit_tests/utilities/test_field_norms.cpp
@@ -174,7 +174,7 @@ protected:
         ppt1.add("field_name", m_ifname);
         ppt1.addarr("field_error", amrex::Vector<int>{m_ifref_val});
     }
-    void setup_tagging_box()
+    static void setup_tagging_box()
     {
         amrex::ParmParse ppt1("tagging.t1");
         amrex::Vector<amrex::Real> blo = {3.0, 3.0, 3.0};

--- a/unit_tests/utilities/test_field_norms.cpp
+++ b/unit_tests/utilities/test_field_norms.cpp
@@ -174,6 +174,14 @@ protected:
         ppt1.add("field_name", m_ifname);
         ppt1.addarr("field_error", amrex::Vector<int>{m_ifref_val});
     }
+    void setup_tagging_box()
+    {
+        amrex::ParmParse ppt1("tagging.t1");
+        amrex::Vector<amrex::Real> blo = {3.0, 3.0, 3.0};
+        amrex::Vector<amrex::Real> bhi = {30.0, 30.0, 30.0};
+        ppt1.addarr("box_lo", blo);
+        ppt1.addarr("box_hi", bhi);
+    }
     // Parameters to reuse
     const amrex::Vector<amrex::Real> m_problo{{0.0, 0.0, -4.0}};
     const amrex::Vector<amrex::Real> m_probhi{{128.0, 128.0, 124.0}};
@@ -264,6 +272,63 @@ TEST_F(FieldNormsTest, levelmask_on)
     wnorm =
         std::sqrt(m_ncell0 * m_cv0 * lev0_fac * lev0_fac * m_w * m_w / m_dv);
     tool.check_output(unorm, vnorm, wnorm);
+}
+
+TEST_F(FieldNormsTest, levelmask_on_with_box)
+{
+    bool levelmask = true;
+    // Set up parameters for domain
+    populate_parameters();
+    // Set up parameters for refinement
+    setup_fieldrefinement();
+    setup_tagging_box();
+    // Set up parameters for sampler
+    setup_fnorm(levelmask);
+    // Create mesh and initialize
+    reset_prob_domain();
+    auto rmesh = FNRefinemesh();
+    rmesh.initialize_mesh(0.0);
+
+    // Repo and fields
+    auto& repo = rmesh.field_repo();
+    auto& velocity = repo.declare_field("velocity", 3, 2);
+    auto& flag = repo.declare_field(m_fname, 1, 2);
+
+    // Set up scalar for determining refinement - all fine level
+    flag.setVal(2.0 * m_fref_val);
+
+    // Initialize mesh refiner and remesh
+    rmesh.init_refiner();
+    rmesh.remesh();
+
+    // Initialize velocity distribution and access sim
+    const amrex::Real lev0_fac = 1.5;
+    init_velocity(velocity, m_u, m_v, m_w, lev0_fac);
+    auto& rsim = rmesh.sim();
+
+    // Initialize IOManager because FieldNorms relies on it
+    auto& io_mgr = rsim.io_manager();
+    // Set up velocity as an output (plot) variable
+    io_mgr.register_output_var("velocity");
+    io_mgr.initialize_io();
+
+    // Initialize sampler and check result on initial mesh
+    FieldNormsImpl tool(rsim, "fieldnorm");
+    tool.initialize();
+    tool.post_advance_work();
+    tool.check_output(
+        1.342655804506534, 1.9393917176204616, 4.0279674135195087);
+
+    // Change scalar for determining refinement - no fine level
+    flag.setVal(0.0);
+
+    // Regrid
+    rmesh.remesh();
+
+    // Check result on new mesh
+    tool.post_advance_work();
+    tool.check_output(
+        1.3500000000000343, 1.9499999999999589, 4.0500000000000043);
 }
 
 // Not sure why this option would be used, but it is available


### PR DESCRIPTION
## Summary

User can add 
```
tagging.g1.box_lo = 3.0 3.0 3.0
tagging.g1.box_hi = 40.0 40.0 40.0
```
to refine in a box with those lo/hi corners. Defaults to the entire domain.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->