### PR TITLE
Ocean Waves (Waves2AMR): correct conditional in treatment of ow_velocity

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -90,7 +90,7 @@ void postprocess_velocity_mfab_liquid(
             // Set velocity to zero if no liquid present
             const amrex::Real cell_length_2D =
                 std::sqrt(dx[0] * dx[0] + dx[2] * dx[2]);
-            if (phi[nbx](i, j, k) + cell_length_2D >= 0) {
+            if (phi[nbx](i, j, k) + cell_length_2D < 0) {
                 vel[nbx](i, j, k, 0) = 0.0;
                 vel[nbx](i, j, k, 1) = 0.0;
                 vel[nbx](i, j, k, 2) = 0.0;


### PR DESCRIPTION
## Summary

This corrects a bug introduced in #1282. The conditional for this function within w2a is opposite of the other wave profiles because it zeros out the velocity where it doesn't apply, as opposed to only attributing the velocity where it does apply. Missed that the first time.

Should produce diffs in ow_w2a and abl_multiphase_w2a.

## Pull request type

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
