### PR TITLE
Phase offset for linear and Stokes waves

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/LinearWaves.H
+++ b/amr-wind/ocean_waves/relaxation_zones/LinearWaves.H
@@ -9,7 +9,7 @@ struct LinearWavesData : public RelaxZonesBaseData
 {
     amrex::Real wave_height{0.1};
     amrex::Real wave_length{1.0};
-    amrex::Real wave_offset_time{0.0};
+    amrex::Real wave_phase_offset{0.0};
 };
 
 struct LinearWaves : public RelaxZonesType

--- a/amr-wind/ocean_waves/relaxation_zones/LinearWaves.H
+++ b/amr-wind/ocean_waves/relaxation_zones/LinearWaves.H
@@ -9,6 +9,7 @@ struct LinearWavesData : public RelaxZonesBaseData
 {
     amrex::Real wave_height{0.1};
     amrex::Real wave_length{1.0};
+    amrex::Real wave_offset_time{0.0};
 };
 
 struct LinearWaves : public RelaxZonesType

--- a/amr-wind/ocean_waves/relaxation_zones/StokesWaves.H
+++ b/amr-wind/ocean_waves/relaxation_zones/StokesWaves.H
@@ -9,6 +9,7 @@ struct StokesWavesData : public RelaxZonesBaseData
 {
     amrex::Real wave_height{0.1};
     amrex::Real wave_length{1.0};
+    amrex::Real wave_phase_offset{0.0};
     int order{2};
 };
 

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -24,7 +24,15 @@ struct ReadInputsOp<LinearWaves>
 
         pp.get("wave_length", wdata.wave_length);
         pp.get("wave_height", wdata.wave_height);
-        pp.query("wave_phase_offset_time", wdata.wave_offset_time);
+        pp.query("wave_phase_offset_radians", wdata.wave_phase_offset);
+        if (!pp.contains("wave_phase_offset_radians")) {
+            pp.query("wave_phase_offset_degrees", wdata.wave_phase_offset);
+            wdata.wave_phase_offset *= M_PI / 180.;
+        } else if (pp.contains("wave_phase_offset_degrees")) {
+            amrex::Abort(
+                "ReadInputsOp<LinearWaves> : wave phase offset is specified in "
+                "both radians and degrees. Please use only one.");
+        }
     }
 };
 
@@ -59,7 +67,7 @@ struct InitDataOp<LinearWaves>
 
         const amrex::Real wave_height = wdata.wave_height;
         const amrex::Real wave_length = wdata.wave_length;
-        const amrex::Real offset_time = wdata.wave_offset_time;
+        const amrex::Real phase_offset = wdata.wave_phase_offset;
         const amrex::Real water_depth = wdata.water_depth;
 
         amrex::ParallelFor(
@@ -72,7 +80,7 @@ struct InitDataOp<LinearWaves>
                 const amrex::Real omega = std::pow(
                     wave_number * g * std::tanh(wave_number * water_depth),
                     0.5);
-                const amrex::Real phase = wave_number * x - omega * offset_time;
+                const amrex::Real phase = wave_number * x - phase_offset;
 
                 // Wave profile
                 const amrex::Real eta_w =
@@ -140,7 +148,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
 
             const amrex::Real wave_height = wdata.wave_height;
             const amrex::Real wave_length = wdata.wave_length;
-            const amrex::Real offset_time = wdata.wave_offset_time;
+            const amrex::Real phase_offset = wdata.wave_phase_offset;
             const amrex::Real water_depth = wdata.water_depth;
             const amrex::Real zero_sea_level = wdata.zsl;
             const amrex::Real g = wdata.g;
@@ -156,7 +164,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
                         wave_number * g * std::tanh(wave_number * water_depth),
                         0.5);
                     const amrex::Real phase =
-                        wave_number * x - omega * (time + offset_time);
+                        wave_number * x - omega * time - phase_offset;
 
                     const amrex::Real eta =
                         wave_height / 2.0 * std::cos(phase) + zero_sea_level;

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -24,6 +24,7 @@ struct ReadInputsOp<LinearWaves>
 
         pp.get("wave_length", wdata.wave_length);
         pp.get("wave_height", wdata.wave_height);
+        pp.get("wave_phase_offset_time", wdata.wave_offset_time);
     }
 };
 
@@ -58,7 +59,9 @@ struct InitDataOp<LinearWaves>
 
         const amrex::Real wave_height = wdata.wave_height;
         const amrex::Real wave_length = wdata.wave_length;
+        const amrex::Real offset_time = wdata.wave_offset_time;
         const amrex::Real water_depth = wdata.water_depth;
+
         amrex::ParallelFor(
             m_velocity(level), amrex::IntVect(3),
             [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
@@ -69,7 +72,7 @@ struct InitDataOp<LinearWaves>
                 const amrex::Real omega = std::pow(
                     wave_number * g * std::tanh(wave_number * water_depth),
                     0.5);
-                const amrex::Real phase = wave_number * x;
+                const amrex::Real phase = wave_number * x - omega * offset_time;
 
                 // Wave profile
                 const amrex::Real eta_w =
@@ -137,6 +140,7 @@ struct UpdateRelaxZonesOp<LinearWaves>
 
             const amrex::Real wave_height = wdata.wave_height;
             const amrex::Real wave_length = wdata.wave_length;
+            const amrex::Real offset_time = wdata.wave_offset_time;
             const amrex::Real water_depth = wdata.water_depth;
             const amrex::Real zero_sea_level = wdata.zsl;
             const amrex::Real g = wdata.g;
@@ -151,7 +155,8 @@ struct UpdateRelaxZonesOp<LinearWaves>
                     const amrex::Real omega = std::pow(
                         wave_number * g * std::tanh(wave_number * water_depth),
                         0.5);
-                    const amrex::Real phase = wave_number * x - omega * time;
+                    const amrex::Real phase =
+                        wave_number * x - omega * (time + offset_time);
 
                     const amrex::Real eta =
                         wave_height / 2.0 * std::cos(phase) + zero_sea_level;

--- a/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/linear_waves_ops.H
@@ -24,7 +24,7 @@ struct ReadInputsOp<LinearWaves>
 
         pp.get("wave_length", wdata.wave_length);
         pp.get("wave_height", wdata.wave_height);
-        pp.get("wave_phase_offset_time", wdata.wave_offset_time);
+        pp.query("wave_phase_offset_time", wdata.wave_offset_time);
     }
 };
 

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -364,6 +364,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     amrex::Real x,
     amrex::Real z,
     amrex::Real time,
+    amrex::Real phase_offset,
     amrex::Real& eta,
     amrex::Real& u_w,
     amrex::Real& v_w,
@@ -391,7 +392,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     //    d4 * std::pow(eps, 4) * std::sqrt(g / std::pow(k, 3));
 
     const amrex::Real omega = c * wavenumber;
-    const amrex::Real phase = wavenumber * x - omega * time;
+    const amrex::Real phase = wavenumber * x - omega * time - phase_offset;
 
     eta = (eps * std::cos(phase)                           // first order term
            + std::pow(eps, 2) * b22 * std::cos(2. * phase) // second order term

--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -65,6 +65,15 @@ struct ReadInputsOp<StokesWaves>
                                << wdata.wave_length << " m.\n";
             }
         }
+        pp.query("wave_phase_offset_radians", wdata.wave_phase_offset);
+        if (!pp.contains("wave_phase_offset_radians")) {
+            pp.query("wave_phase_offset_degrees", wdata.wave_phase_offset);
+            wdata.wave_phase_offset *= M_PI / 180.;
+        } else if (pp.contains("wave_phase_offset_degrees")) {
+            amrex::Abort(
+                "ReadInputsOp<StokesWaves> : wave phase offset is specified in "
+                "both radians and degrees. Please use only one.");
+        }
     }
 };
 
@@ -90,6 +99,7 @@ struct InitDataOp<StokesWaves>
 
         const amrex::Real wave_height = wdata.wave_height;
         const amrex::Real wave_length = wdata.wave_length;
+        const amrex::Real phase_offset = wdata.wave_phase_offset;
         const amrex::Real water_depth = wdata.water_depth;
         const amrex::Real zero_sea_level = wdata.zsl;
         const amrex::Real gen_length = wdata.gen_length;
@@ -109,7 +119,8 @@ struct InitDataOp<StokesWaves>
                 amrex::Real eta_w{0.0}, u_w{0.0}, v_w{0.0}, w_w{0.0};
                 relaxation_zones::stokes_waves(
                     order, wave_length, water_depth, wave_height,
-                    zero_sea_level, g, x, z, 0.0, eta_w, u_w, v_w, w_w);
+                    zero_sea_level, g, x, z, 0.0, phase_offset, eta_w, u_w, v_w,
+                    w_w);
                 const utils::WaveVec wave_sol{u_w, v_w, w_w, eta_w};
 
                 // Quiescent profile
@@ -162,6 +173,7 @@ struct UpdateRelaxZonesOp<StokesWaves>
 
             const amrex::Real wave_height = wdata.wave_height;
             const amrex::Real wave_length = wdata.wave_length;
+            const amrex::Real phase_offset = wdata.wave_phase_offset;
             const amrex::Real water_depth = wdata.water_depth;
             const amrex::Real zero_sea_level = wdata.zsl;
             const amrex::Real g = wdata.g;
@@ -177,7 +189,8 @@ struct UpdateRelaxZonesOp<StokesWaves>
 
                     relaxation_zones::stokes_waves(
                         order, wave_length, water_depth, wave_height,
-                        zero_sea_level, g, x, z, time, eta, u_w, v_w, w_w);
+                        zero_sea_level, g, x, z, time, phase_offset, eta, u_w,
+                        v_w, w_w);
 
                     phi[nbx](i, j, k) = eta - z;
                     const amrex::Real cell_length_2D =

--- a/docs/sphinx/user/inputs_ocean_waves.rst
+++ b/docs/sphinx/user/inputs_ocean_waves.rst
@@ -104,6 +104,25 @@ The following input arguments are only valid for the LinearWaves and StokesWave 
 
    The amplitude of the wave profile
 
+.. input_param:: OceanWaves.label.wave_phase_offset_radians
+
+   **type** Real, optional, default = 0.
+
+   This specifies a phase offset to the target wave profile.
+   It is in terms of phase (radians) relative to the wave, not
+   in terms of time. Note that this argument should be retained
+   when restarting a simulation so that the phase of the wave forcing
+   is consistent with the preceding simulation.
+
+.. input_param:: OceanWaves.label.wave_phase_offset_degrees
+
+   **type** Real, optional, default = 0.
+
+   This specifies a phase offset to the target wave profile
+   in terms of degrees. If the offset is specified in both radians
+   and degrees, the code will abort; only one of these arguments
+   can be used at a time.
+
 The following input arguments are only valid for the StokesWave wave type:
 
 .. input_param:: OceanWaves.label.order


### PR DESCRIPTION
## Summary

Allow user to specify an offset to the phase of wave profiles (stokes and linear).

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
