### PR TITLE
Remove unused surface tension part of projection

### DIFF
--- a/amr-wind/projection/incflo_apply_nodal_projection.cpp
+++ b/amr-wind/projection/incflo_apply_nodal_projection.cpp
@@ -237,40 +237,6 @@ void incflo::ApplyProjection(
         }
     }
 
-    bool add_surface_tension = m_sim.physics_manager().contains("MultiPhase");
-    if (add_surface_tension && !incremental) {
-        // Create the Surface tension forcing term (Cell-centered)
-        for (int lev = 0; lev <= finest_level; ++lev) {
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            {
-                amrex::MultiFab surf_tens_force;
-                surf_tens_force.define(
-                    grids[lev], dmap[lev], AMREX_SPACEDIM, 1, MFInfo(),
-                    Factory(lev));
-                // At the moment set it to zero
-                surf_tens_force.setVal(0.0);
-                for (MFIter mfi(velocity(lev), TilingIfNotGPU()); mfi.isValid();
-                     ++mfi) {
-                    Box const& bx = mfi.tilebox();
-                    Array4<Real> const& force_st = surf_tens_force.array(mfi);
-                    Array4<Real const> const& rho =
-                        density[lev]->const_array(mfi);
-                    Array4<Real> const& u = velocity(lev).array(mfi);
-
-                    amrex::ParallelFor(
-                        bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                            Real soverrho = scaling_factor / rho(i, j, k);
-                            u(i, j, k, 0) += force_st(i, j, k, 0) * soverrho;
-                            u(i, j, k, 1) += force_st(i, j, k, 1) * soverrho;
-                            u(i, j, k, 2) += force_st(i, j, k, 2) * soverrho;
-                        });
-                }
-            }
-        }
-    }
-
     // ensure velocity is in stretched mesh space
     if (velocity_old.in_uniform_space() && mesh_mapping) {
         velocity_old.to_stretched_space();


### PR DESCRIPTION
## Summary

Just cleaning up some stuff. As you can see, this was set up but never used (always set to 0). Now that it's clear we do not intend to model surface tension, let's remove this clutter.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
