### PR TITLE
Add a sampling info file

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -109,6 +109,9 @@ protected:
      */
     virtual void write_ascii();
 
+    //! Output extra information for certain formats
+    void write_info_file(const std::string fname);
+
     SamplingContainer& sampling_container() { return *m_scontainer; }
 
 private:

--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -110,7 +110,7 @@ protected:
     virtual void write_ascii();
 
     //! Output extra information for certain formats
-    void write_info_file(const std::string fname);
+    void write_info_file(const std::string& fname);
 
     SamplingContainer& sampling_container() { return *m_scontainer; }
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -421,7 +421,7 @@ void Sampling::write_ascii()
     write_info_file(info_name);
 }
 
-void Sampling::write_info_file(const std::string fname)
+void Sampling::write_info_file(const std::string& fname)
 {
     BL_PROFILE("amr-wind::Sampling::write_info_file");
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -398,6 +398,9 @@ void Sampling::impl_write_native()
             const SamplingContainer::SuperParticleType& p) {
             return p.id() > 0;
         });
+
+    const std::string info_name = name + "/sampling_info";
+    write_info_file(info_name);
 }
 
 void Sampling::write_ascii()
@@ -413,6 +416,32 @@ void Sampling::write_ascii()
 
     const std::string fname = post_dir + "/" + sname + ".txt";
     m_scontainer->WriteAsciiFile(fname);
+
+    const std::string info_name = post_dir + "/" + sname + "_info.txt";
+    write_info_file(info_name);
+}
+
+void Sampling::write_info_file(const std::string fname)
+{
+    BL_PROFILE("amr-wind::Sampling::write_info_file");
+
+    // Only I/O processor writes the info file
+    if (!amrex::ParallelDescriptor::IOProcessor()) {
+        return;
+    }
+
+    if ((m_out_fmt != "native") && (m_out_fmt != "ascii")) {
+        amrex::Abort(
+            "write_info_file is implemented only for native and ascii formats");
+    }
+
+    std::ofstream fh(fname.c_str(), std::ios::out);
+    if (!fh.good()) {
+        amrex::FileOpenFailed(fname);
+    }
+
+    fh << "time " << m_sim.time().new_time() << std::endl;
+    fh.close();
 }
 
 void Sampling::prepare_netcdf_file()

--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -100,7 +100,9 @@ where ``uid`` is the global probe id, ``set_id`` is the label id
 input order), ``probe_id`` is the local probe id to this label,
 ``*co`` are the coordinates of the probe, and the other columns are
 the user requested sampled fields. The same labels are seeing by other
-visualization tools such as ParaView.
+visualization tools such as ParaView. The directory also contains a
+``sampling_info`` file where additional information (e.g., time) is
+stored.
 
 Sampling along a line
 ``````````````````````

--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -102,7 +102,9 @@ input order), ``probe_id`` is the local probe id to this label,
 the user requested sampled fields. The same labels are seeing by other
 visualization tools such as ParaView. The directory also contains a
 ``sampling_info`` file where additional information (e.g., time) is
-stored.
+stored. This file is automatically parse by the provided particle
+reader tool and the information is stored in a dictionary that is a
+member variable of the class.
 
 Sampling along a line
 ``````````````````````

--- a/tools/amrex_particle.py
+++ b/tools/amrex_particle.py
@@ -46,6 +46,7 @@ class AmrexParticleFile:
         """
         if not hasattr(self, "df"):
             self.parse_header()
+            self.parse_info()
             self.load_binary_data()
         return self.df
 
@@ -78,6 +79,14 @@ class AmrexParticleFile:
                     ginfo.append(
                         [int(ix) for ix in fh.readline().strip().split()])
                 self.grid_info.append(ginfo)
+
+    def parse_info(self):
+        """Parse the sampling info file"""
+        self.info = {}
+        with open(self.pdir.parent / "sampling_info", 'r') as fh:
+            for line in fh:
+                (key, val) = line.split()
+                self.info[key] = float(val)
 
     def load_binary_data(self):
         """Read binary data into memory"""

--- a/tools/fcompare_particles.py
+++ b/tools/fcompare_particles.py
@@ -29,8 +29,11 @@ def main():
     assert Path(args.f0).is_dir()
     assert Path(args.f1).is_dir()
 
-    p0df = AmrexParticleFile(Path(args.f0) / "particles")()
-    p1df = AmrexParticleFile(Path(args.f1) / "particles")()
+    p0f = AmrexParticleFile(Path(args.f0) / "particles")
+    p1f = AmrexParticleFile(Path(args.f1) / "particles")
+    p0df = p0f()
+    p1df = p1f()
+    assert np.abs(p0f.info["time"] - p1f.info["time"]) <= args.abs_tol
     assert p0df.shape == p1df.shape
     p0df.sort_values(by=["uid"], inplace=True, kind="stable", ignore_index=True)
     p1df.sort_values(by=["uid"], inplace=True, kind="stable", ignore_index=True)


### PR DESCRIPTION
## Summary

The particle binary and ascii formats for the samplers do not contain time information in the Header file. This is a limitation of amrex. Therefore, this PR adds a `sampling_info` file that can contain extra information not contained in the header file. Right now, only the simulation time is written out but it could be expanded. It should be noted that ParaView and VisIt are not going to be using this file and so will not know the physical time. But our scripts can.

E.g.:
```
❯ cat post_processing/line_sampling00000/sampling_info
time 0
❯ cat post_processing/line_sampling00001/sampling_info
time 0.5
❯ cat post_processing/line_sampling00002/sampling_info
time 1
```

Thanks @rthedin for bringing this to my attention!

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [X] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
