### PR TITLE
ALM replace abort with if condition check

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H
@@ -183,11 +183,12 @@ determine_influenced_procs<TurbineFast>(typename TurbineFast::DataType& data)
     info.procs =
         utils::determine_influenced_procs(data.sim().mesh(), info.bound_box);
 
-    AMREX_ALWAYS_ASSERT(info.root_proc > -1);
-    // During regrid, the influenced processes might have changed and might
-    // no longer include the root proc. We insert it back to ensure that it
-    // is always present on the list.
-    info.procs.insert(info.root_proc);
+    if (info.root_proc > -1) {
+        // During regrid, the influenced processes might have changed and might
+        // no longer include the root proc. We insert it back to ensure that it
+        // is always present on the list.
+        info.procs.insert(info.root_proc);
+    }
 
     const int iproc = amrex::ParallelDescriptor::MyProc();
     auto in_proc = info.procs.find(iproc);


### PR DESCRIPTION
## Summary

In [turbine_fast_ops](https://github.com/Exawind/amr-wind/blob/main/amr-wind/wind_energy/actuator/turbine/fast/turbine_fast_ops.H#L186), we `AMREX_ALWAYS_ASSERT(info.root_proc > -1);`. We do not do that in https://github.com/Exawind/amr-wind/blob/main/amr-wind/wind_energy/actuator/actuator_opsI.H#L18. In that scenario, we have an `if` condition check and then the fix. I have no idea why one has an abort and the other a simple if check. The git blames do not over any information for that difference. 

This PR makes the `turbine_fast_ops.H` operate the same as the others. Before this is merged, I would like help doing due diligence that this doesn't break something even more.

@lawrenceccheung, @ndevelder , @gyalla can I ask you to run this branch on an ALM case (like one of the calibration tests) and tell me if it looks ok? 


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

Closes #1385
