### PR TITLE
fix parenthesis error in eta for stokes waves

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/amr-wind/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -397,8 +397,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     eta = (eps * std::cos(phase)                           // first order term
            + std::pow(eps, 2) * b22 * std::cos(2. * phase) // second order term
            + std::pow(eps, 3) * b31 * (std::cos(phase) - std::cos(3. * phase)) +
-           std::pow(eps, 4) * b42 *
-               (std::cos(2. * phase) + b44 * std::cos(4. * phase)) +
+           std::pow(eps, 4) *
+               (b42 * std::cos(2. * phase) + b44 * std::cos(4. * phase)) +
            std::pow(eps, 5) *
                (-(b53 + b55) * std::cos(phase) + b53 * std::cos(3 * phase) +
                 b55 * std::cos(5 * phase))) +


### PR DESCRIPTION
## Summary

4th-order term was calculated incorrectly due to a typo. Following these notes https://www.caee.utexas.edu/prof/kinnas/ce358/oenotes/kinnas_stokes11.pdf based on this paper https://johndfenton.com/Papers/Fenton85d-A-fifth-order-Stokes-theory-for-steady-waves.pdf

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
