### PR TITLE
Fix hand rolled interpolation

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -139,13 +139,10 @@ void ABLMesoForcingMom::mean_velocity_heights(
     currtime = m_time.current_time();
     const auto& dt = m_time.delta_t();
 
-    const int num_meso_ht = ncfile->nheights();
-
-    const int numcomp = vavg.ncomp();
-
     amrex::Vector<amrex::Real> error_U(m_nht);
     amrex::Vector<amrex::Real> error_V(m_nht);
 
+    const int numcomp = vavg.ncomp();
     const auto& vavg_lc = vavg.line_centroids();
     for (int i = 0; i < m_nht; i++) {
         const amrex::Real interpolated_u = amr_wind::interp::bilinear(

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -108,9 +108,9 @@ void ABLMesoForcingMom::mean_velocity_heights(
     for (int i = 0; i < num_meso_ht; i++) {
 
         time_interpolated_u[i] = amr_wind::interp::linear(
-            ncfile->meso_times(), ncfile->meso_u(), currtime);
+            ncfile->meso_times(), ncfile->meso_u(), currtime, num_meso_ht, i);
         time_interpolated_v[i] = amr_wind::interp::linear(
-            ncfile->meso_times(), ncfile->meso_v(), currtime);
+            ncfile->meso_times(), ncfile->meso_v(), currtime, num_meso_ht, i);
     }
 
     for (int ih = 0; ih < num_meso_ht; ih++) {

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -144,16 +144,18 @@ void ABLMesoForcingMom::mean_velocity_heights(
 
     const int numcomp = vavg.ncomp();
     const auto& vavg_lc = vavg.line_centroids();
+    const auto& vavg_lavg = vavg.line_average();
+    const auto& meso_times = ncfile->meso_times();
+    const auto& meso_heights = ncfile->meso_heights();
+
     for (int i = 0; i < m_nht; i++) {
         const amrex::Real interpolated_u = amr_wind::interp::bilinear(
-            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_u(),
-            currtime, vavg_lc[i]);
+            meso_times, meso_heights, ncfile->meso_u(), currtime, vavg_lc[i]);
         const amrex::Real interpolated_v = amr_wind::interp::bilinear(
-            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_v(),
-            currtime, vavg_lc[i]);
-        error_U[i] =
-            interpolated_u - vavg.line_average()[static_cast<int>(numcomp * i)];
-        error_V[i] = interpolated_v - vavg.line_average()[(numcomp * i + 1)];
+            meso_times, meso_heights, ncfile->meso_v(), currtime, vavg_lc[i]);
+        error_U[i] = interpolated_u - vavg_lavg[static_cast<int>(numcomp * i)];
+        error_V[i] =
+            interpolated_v - vavg_lavg[static_cast<int>(numcomp * i + 1)];
     }
 
     if (amrex::toLower(m_forcing_scheme) == "indirect") {
@@ -161,8 +163,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
             // possible unexpected behaviors, as described in
             // ec5eb95c6ca853ce0fea8488e3f2515a2d6374e7
             m_transition_height = amr_wind::interp::linear(
-                ncfile->meso_times(), ncfile->meso_transition_height(),
-                currtime);
+                meso_times, ncfile->meso_transition_height(), currtime);
             amrex::Print() << "current transition height = "
                            << m_transition_height << std::endl;
 

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -154,8 +154,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
         const amrex::Real interpolated_v = amr_wind::interp::bilinear(
             meso_times, meso_heights, ncfile->meso_v(), currtime, vavg_lc[i]);
         error_U[i] = interpolated_u - vavg_lavg[static_cast<int>(numcomp * i)];
-        error_V[i] =
-            interpolated_v - vavg_lavg[static_cast<int>(numcomp * i + 1)];
+        error_V[i] = interpolated_v - vavg_lavg[numcomp * i + 1];
     }
 
     if (amrex::toLower(m_forcing_scheme) == "indirect") {

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -149,11 +149,11 @@ void ABLMesoForcingMom::mean_velocity_heights(
     const auto& vavg_lc = vavg.line_centroids();
     for (int i = 0; i < m_nht; i++) {
         const amrex::Real interpolated_u = amr_wind::interp::bilinear(
-            ncfile->meso_times(), m_meso_ht, ncfile->meso_u(), currtime,
-            vavg_lc[i]);
+            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_u(),
+            currtime, vavg_lc[i]);
         const amrex::Real interpolated_v = amr_wind::interp::bilinear(
-            ncfile->meso_times(), m_meso_ht, ncfile->meso_v(), currtime,
-            vavg_lc[i]);
+            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_v(),
+            currtime, vavg_lc[i]);
         error_U[i] =
             interpolated_u - vavg.line_average()[static_cast<int>(numcomp * i)];
         error_V[i] = interpolated_v - vavg.line_average()[(numcomp * i + 1)];

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -100,31 +100,17 @@ void ABLMesoForcingMom::mean_velocity_heights(
     amrex::Real currtime;
     currtime = m_time.current_time();
 
-    // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
-
-    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
-
-    amrex::Real denom =
-        ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
-
-    coeff_interp[0] = (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
-    coeff_interp[1] = 1.0 - coeff_interp[0];
-
-    int num_meso_ht = ncfile->nheights();
+    const int num_meso_ht = ncfile->nheights();
 
     amrex::Vector<amrex::Real> time_interpolated_u(num_meso_ht);
     amrex::Vector<amrex::Real> time_interpolated_v(num_meso_ht);
 
     for (int i = 0; i < num_meso_ht; i++) {
-        const int lt = m_idx_time * num_meso_ht + i;
-        const int rt = (m_idx_time + 1) * num_meso_ht + i;
 
-        time_interpolated_u[i] = coeff_interp[0] * ncfile->meso_u()[lt] +
-                                 coeff_interp[1] * ncfile->meso_u()[rt];
-
-        time_interpolated_v[i] = coeff_interp[0] * ncfile->meso_v()[lt] +
-                                 coeff_interp[1] * ncfile->meso_v()[rt];
+        time_interpolated_u[i] = amr_wind::interp::linear(
+            ncfile->meso_times(), ncfile->meso_u(), currtime);
+        time_interpolated_v[i] = amr_wind::interp::linear(
+            ncfile->meso_times(), ncfile->meso_v(), currtime);
     }
 
     for (int ih = 0; ih < num_meso_ht; ih++) {

--- a/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/ABLMesoForcingMom.cpp
@@ -139,40 +139,7 @@ void ABLMesoForcingMom::mean_velocity_heights(
     currtime = m_time.current_time();
     const auto& dt = m_time.delta_t();
 
-    // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
-
-    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
-
-    amrex::Real denom =
-        ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
-
-    coeff_interp[0] = (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
-    coeff_interp[1] = 1.0 - coeff_interp[0];
-
     const int num_meso_ht = ncfile->nheights();
-
-    amrex::Vector<amrex::Real> time_interpolated_u(num_meso_ht);
-    amrex::Vector<amrex::Real> time_interpolated_v(num_meso_ht);
-
-    for (int i = 0; i < num_meso_ht; i++) {
-        const int lt = m_idx_time * num_meso_ht + i;
-        const int rt = (m_idx_time + 1) * num_meso_ht + i;
-
-        time_interpolated_u[i] = coeff_interp[0] * ncfile->meso_u()[lt] +
-                                 coeff_interp[1] * ncfile->meso_u()[rt];
-
-        time_interpolated_v[i] = coeff_interp[0] * ncfile->meso_v()[lt] +
-                                 coeff_interp[1] * ncfile->meso_v()[rt];
-    }
-
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, time_interpolated_u.begin(),
-        time_interpolated_u.end(), m_meso_u_vals.begin());
-
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, time_interpolated_v.begin(),
-        time_interpolated_v.end(), m_meso_v_vals.begin());
 
     const int numcomp = vavg.ncomp();
 
@@ -180,29 +147,25 @@ void ABLMesoForcingMom::mean_velocity_heights(
     amrex::Vector<amrex::Real> error_V(m_nht);
 
     const auto& vavg_lc = vavg.line_centroids();
-    amrex::Vector<amrex::Real> meso_ht(num_meso_ht);
-    amrex::Gpu::copy(
-        amrex::Gpu::deviceToHost, m_meso_ht.begin(), m_meso_ht.end(),
-        meso_ht.begin());
     for (int i = 0; i < m_nht; i++) {
-        const amrex::Real height_interpolated_u =
-            amr_wind::interp::linear(meso_ht, time_interpolated_u, vavg_lc[i]);
-        const amrex::Real height_interpolated_v =
-            amr_wind::interp::linear(meso_ht, time_interpolated_v, vavg_lc[i]);
-        error_U[i] = height_interpolated_u -
-                     vavg.line_average()[static_cast<int>(numcomp * i)];
-        error_V[i] =
-            height_interpolated_v - vavg.line_average()[(numcomp * i + 1)];
+        const amrex::Real interpolated_u = amr_wind::interp::bilinear(
+            ncfile->meso_times(), m_meso_ht, ncfile->meso_u(), currtime,
+            vavg_lc[i]);
+        const amrex::Real interpolated_v = amr_wind::interp::bilinear(
+            ncfile->meso_times(), m_meso_ht, ncfile->meso_v(), currtime,
+            vavg_lc[i]);
+        error_U[i] =
+            interpolated_u - vavg.line_average()[static_cast<int>(numcomp * i)];
+        error_V[i] = interpolated_v - vavg.line_average()[(numcomp * i + 1)];
     }
 
     if (amrex::toLower(m_forcing_scheme) == "indirect") {
         if (m_update_transition_height) {
             // possible unexpected behaviors, as described in
             // ec5eb95c6ca853ce0fea8488e3f2515a2d6374e7
-            m_transition_height =
-                coeff_interp[0] * ncfile->meso_transition_height()[m_idx_time] +
-                coeff_interp[1] *
-                    ncfile->meso_transition_height()[m_idx_time + 1];
+            m_transition_height = amr_wind::interp::linear(
+                ncfile->meso_times(), ncfile->meso_transition_height(),
+                currtime);
             amrex::Print() << "current transition height = "
                            << m_transition_height << std::endl;
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -144,8 +144,8 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     currtime = m_time.current_time();
     const auto& dt = m_time.delta_t();
 
-
-    const amrex::Real interpTflux = amr_wind::interp::linear(ncfile->meso_times(), ncfile->meso_tflux(), currtime);
+    const amrex::Real interpTflux = amr_wind::interp::linear(
+        ncfile->meso_times(), ncfile->meso_tflux(), currtime);
 
     if (m_forcing_scheme.empty()) {
         // no temperature profile assimilation
@@ -156,7 +156,9 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
 
     for (int i = 0; i < m_nht; i++) {
         const amrex::Real interpolated_theta = amr_wind::interp::bilinear(
-            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_temp(), currtime, tavg.line_centroids()[i]);
+
+            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_temp(),
+            currtime, tavg.line_centroids()[i]);
         error_T[i] = interpolated_theta - tavg.line_average()[i];
     }
 
@@ -169,10 +171,11 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
 
             amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
 
-            const amrex::Real denom =
-                ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
+            const amrex::Real denom = ncfile->meso_times()[m_idx_time + 1] -
+                                      ncfile->meso_times()[m_idx_time];
 
-            coeff_interp[0] = (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
+            coeff_interp[0] =
+                (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
             coeff_interp[1] = 1.0 - coeff_interp[0];
             m_transition_height =
                 coeff_interp[0] * ncfile->meso_transition_height()[m_idx_time] +

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -151,20 +151,10 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
             // possible unexpected behaviors, as described in
             // ec5eb95c6ca853ce0fea8488e3f2515a2d6374e7
             // First the index in time
-            m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
-            amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
-
-            const amrex::Real denom = ncfile->meso_times()[m_idx_time + 1] -
-                                      ncfile->meso_times()[m_idx_time];
-
-            coeff_interp[0] =
-                (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
-            coeff_interp[1] = 1.0 - coeff_interp[0];
-            m_transition_height =
-                coeff_interp[0] * ncfile->meso_transition_height()[m_idx_time] +
-                coeff_interp[1] *
-                    ncfile->meso_transition_height()[m_idx_time + 1];
+            m_transition_height = amr_wind::interp::linear(
+                ncfile->meso_times(), ncfile->meso_transition_height(),
+                currtime);
             amrex::Print() << "current transition height = "
                            << m_transition_height << std::endl;
 

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -105,7 +105,8 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
 
     for (int i = 0; i < num_meso_ht; i++) {
         time_interpolated_theta[i] = amr_wind::interp::linear(
-            ncfile->meso_times(), ncfile->meso_temp(), currtime);
+            ncfile->meso_times(), ncfile->meso_temp(), currtime, num_meso_ht,
+            i);
     }
 
     amrex::Gpu::copy(

--- a/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/ABLMesoForcingTemp.cpp
@@ -144,59 +144,36 @@ amrex::Real ABLMesoForcingTemp::mean_temperature_heights(
     currtime = m_time.current_time();
     const auto& dt = m_time.delta_t();
 
-    // First the index in time
-    m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
 
-    amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
-
-    amrex::Real denom =
-        ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
-
-    coeff_interp[0] = (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
-    coeff_interp[1] = 1.0 - coeff_interp[0];
-
-    amrex::Real interpTflux;
-
-    interpTflux = coeff_interp[0] * ncfile->meso_tflux()[m_idx_time] +
-                  coeff_interp[1] * ncfile->meso_tflux()[m_idx_time + 1];
+    const amrex::Real interpTflux = amr_wind::interp::linear(ncfile->meso_times(), ncfile->meso_tflux(), currtime);
 
     if (m_forcing_scheme.empty()) {
         // no temperature profile assimilation
         return interpTflux;
     }
 
-    const int num_meso_ht = ncfile->nheights();
-
-    amrex::Vector<amrex::Real> time_interpolated_theta(num_meso_ht);
-
-    for (int i = 0; i < num_meso_ht; i++) {
-        const int lt = m_idx_time * num_meso_ht + i;
-        const int rt = (m_idx_time + 1) * num_meso_ht + i;
-
-        time_interpolated_theta[i] = coeff_interp[0] * ncfile->meso_temp()[lt] +
-                                     coeff_interp[1] * ncfile->meso_temp()[rt];
-    }
-
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, time_interpolated_theta.begin(),
-        time_interpolated_theta.end(), m_meso_theta_vals.begin());
-
     amrex::Vector<amrex::Real> error_T(m_nht);
 
-    amrex::Vector<amrex::Real> meso_ht(num_meso_ht);
-    amrex::Gpu::copy(
-        amrex::Gpu::deviceToHost, m_meso_ht.begin(), m_meso_ht.end(),
-        meso_ht.begin());
     for (int i = 0; i < m_nht; i++) {
-        const amrex::Real height_interpolated_theta = amr_wind::interp::linear(
-            meso_ht, time_interpolated_theta, tavg.line_centroids()[i]);
-        error_T[i] = height_interpolated_theta - tavg.line_average()[i];
+        const amrex::Real interpolated_theta = amr_wind::interp::bilinear(
+            ncfile->meso_times(), ncfile->meso_heights(), ncfile->meso_temp(), currtime, tavg.line_centroids()[i]);
+        error_T[i] = interpolated_theta - tavg.line_average()[i];
     }
 
     if (amrex::toLower(m_forcing_scheme) == "indirect") {
         if (m_update_transition_height) {
             // possible unexpected behaviors, as described in
             // ec5eb95c6ca853ce0fea8488e3f2515a2d6374e7
+            // First the index in time
+            m_idx_time = utils::closest_index(ncfile->meso_times(), currtime);
+
+            amrex::Array<amrex::Real, 2> coeff_interp{0.0, 0.0};
+
+            const amrex::Real denom =
+                ncfile->meso_times()[m_idx_time + 1] - ncfile->meso_times()[m_idx_time];
+
+            coeff_interp[0] = (ncfile->meso_times()[m_idx_time + 1] - currtime) / denom;
+            coeff_interp[1] = 1.0 - coeff_interp[0];
             m_transition_height =
                 coeff_interp[0] * ncfile->meso_transition_height()[m_idx_time] +
                 coeff_interp[1] *

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -196,6 +196,7 @@ void ABLFieldInit::operator()(
     const int ntvals = static_cast<int>(m_theta_heights.size());
     const int nwvals = static_cast<int>(m_wind_heights.size());
     const amrex::Real* th = m_thht_d.data();
+    const amrex::Real* th_end = m_thht_d.end();
     const amrex::Real* tv = m_thvv_d.data();
 
     if (m_init_uvtheta_profile) {
@@ -210,29 +211,10 @@ void ABLFieldInit::operator()(
                 const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
 
                 density(i, j, k) = rho_init;
-                amrex::Real theta = tv[0];
-                amrex::Real umean_prof = uu[0];
-                amrex::Real vmean_prof = vv[0];
-
-                for (int iz = 0; iz < ntvals - 1; ++iz) {
-                    if ((z > th[iz]) && (z <= th[iz + 1])) {
-                        const amrex::Real slope =
-                            (tv[iz + 1] - tv[iz]) / (th[iz + 1] - th[iz]);
-                        theta = tv[iz] + (z - th[iz]) * slope;
-
-                        const amrex::Real slopeu =
-                            (uu[iz + 1] - uu[iz]) / (th[iz + 1] - th[iz]);
-                        umean_prof = uu[iz] + (z - th[iz]) * slopeu;
-
-                        const amrex::Real slopev =
-                            (vv[iz + 1] - vv[iz]) / (th[iz + 1] - th[iz]);
-                        vmean_prof = vv[iz] + (z - th[iz]) * slopev;
-                    }
-                }
-
-                temperature(i, j, k, 0) += theta;
-                velocity(i, j, k, 0) += umean_prof;
-                velocity(i, j, k, 1) += vmean_prof;
+                const auto idx = interp::bisection_search(th, th_end, z);
+                temperature(i, j, k, 0) += interp::linear_impl(th, tv, z, idx);
+                velocity(i, j, k, 0) += interp::linear_impl(th, uu, z, idx);
+                velocity(i, j, k, 1) += interp::linear_impl(th, vv, z, idx);
             });
     } else if (m_initial_wind_profile) {
         //! RANS 1-D profile


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->
Replace hand rolled interpolation with `interp::linear` and `interp::bilinear` as appropriate.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: fixes #1364 