### PR TITLE
Use ubuntu-22.04 github image for CI that runs MPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   Formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Clone
       uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-22.04, macos-latest]
         build_type: [Release, Debug]
         openmp_flag: [OpenMP, NoOpenMP]
         include:
@@ -37,7 +37,7 @@ jobs:
             comp: llvm
             procs: $(sysctl -n hw.ncpu)
             ccache_cache: /Users/runner/Library/Caches/ccache
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             install_deps: sudo apt-get install -y mpich libmpich-dev
             comp: gnu
             procs: $(nproc)


### PR DESCRIPTION
There are problems when running with MPI in the `ubuntu-24.04` image which is now also `ubuntu-latest`. So we will revert to 22.04 until we can resolve the runtime issue.