### PR TITLE
Fixed Monin-Obukhov length driver for non-neutral stratification with RANS model 

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.H
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.H
@@ -48,6 +48,9 @@ private:
     int m_sponge_south{0};
     int m_sponge_north{1};
     bool m_is_laminar{false};
+    amrex::Real m_mol_length{10000};
+    amrex::Real m_gamma_m{5.0};
+    amrex::Real m_beta_m{16.0};
 };
 
 } // namespace amr_wind::pde::icns

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -27,6 +27,10 @@ DragForcing::DragForcing(const CFDSim& sim)
     pp.query("sponge_south", m_sponge_south);
     pp.query("sponge_north", m_sponge_north);
     pp.query("is_laminar", m_is_laminar);
+    amrex::ParmParse pp_abl("ABL");    
+    pp_abl.query("mol_length", m_mol_length);
+    pp_abl.query("mo_gamma_m", m_gamma_m);
+    pp_abl.query("mo_beta_m", m_beta_m);    
     const auto& phy_mgr = m_sim.physics_manager();
     if (phy_mgr.contains("ABL")) {
         const auto& abl = m_sim.physics_manager().get<amr_wind::ABL>();

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -27,10 +27,10 @@ DragForcing::DragForcing(const CFDSim& sim)
     pp.query("sponge_south", m_sponge_south);
     pp.query("sponge_north", m_sponge_north);
     pp.query("is_laminar", m_is_laminar);
-    amrex::ParmParse pp_abl("ABL");    
+    amrex::ParmParse pp_abl("ABL");
     pp_abl.query("mol_length", m_mol_length);
     pp_abl.query("mo_gamma_m", m_gamma_m);
-    pp_abl.query("mo_beta_m", m_beta_m);    
+    pp_abl.query("mo_beta_m", m_beta_m);
     const auto& phy_mgr = m_sim.physics_manager();
     if (phy_mgr.contains("ABL")) {
         const auto& abl = m_sim.physics_manager().get<amr_wind::ABL>();
@@ -91,7 +91,7 @@ void DragForcing::operator()(
     } else {
         const amrex::Real x = std::sqrt(std::sqrt(1 - m_beta_m * zeta));
         psi_m_cell = 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
-                      2.0 * std::atan(x) + utils::half_pi();
+                     2.0 * std::atan(x) + utils::half_pi();
     }
     //! Cell Value
     const auto& prob_lo = geom.ProbLoArray();

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.H
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.H
@@ -40,7 +40,7 @@ private:
     amrex::Real m_kappa{0.41};
     amrex::Real m_mol_length{10000};
     amrex::Real m_gamma_m{5.0};
-    amrex::Real m_beta_m{16.0};    
+    amrex::Real m_beta_m{16.0};
     amrex::Real m_sponge_start{600};
     amrex::Real m_ref_tke{1e-10};
     amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.H
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.H
@@ -38,6 +38,9 @@ private:
     amrex::Real m_ref_temp{300.0};
     amrex::Real m_z0{0.1};
     amrex::Real m_kappa{0.41};
+    amrex::Real m_mol_length{10000};
+    amrex::Real m_gamma_m{5.0};
+    amrex::Real m_beta_m{16.0};    
     amrex::Real m_sponge_start{600};
     amrex::Real m_ref_tke{1e-10};
     amrex::Vector<amrex::Real> m_gravity{0.0, 0.0, -9.81};

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -51,6 +51,7 @@ void KransAxell::operator()(
     const auto& dissip_arr = (this->m_dissip)(lev).array(mfi);
     const auto& tke_arr = m_tke(lev).array(mfi);
     const auto& geom = m_mesh.Geom(lev);
+    const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& probhi = m_mesh.Geom(lev).ProbHiArray();
     const auto& dx = geom.CellSizeArray();
     const auto& dt = m_time.delta_t();
@@ -76,7 +77,7 @@ void KransAxell::operator()(
         amrex::Real bcforcing = 0;
         const amrex::Real ux = vel(i, j, k, 0);
         const amrex::Real uy = vel(i, j, k, 1);
-        const amrex::Real z = (k + 0.5) * dx[2];
+        const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
         if (k == 0) {
             const amrex::Real m = std::sqrt(ux * ux + uy * uy);
             const amrex::Real ustar = m * kappa / ( std::log(z / z0) + psi_m);

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -26,7 +26,7 @@ KransAxell::KransAxell(const CFDSim& sim)
     pp.query("surface_temp_flux", m_heat_flux);
     pp.query("mol_length", m_mol_length);
     pp.query("mo_gamma_m", m_gamma_m);
-    pp.query("mo_beta_m", m_beta_m);      
+    pp.query("mo_beta_m", m_beta_m);
     pp.query("meso_sponge_start", m_sponge_start);
     {
         amrex::ParmParse pp_incflow("incflo");
@@ -71,7 +71,7 @@ void KransAxell::operator()(
     } else {
         const amrex::Real x = std::sqrt(std::sqrt(1 - m_beta_m * zeta));
         psi_m = 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
-                      2.0 * std::atan(x) + 2 * std::atan(1.0);
+                2.0 * std::atan(x) + 2 * std::atan(1.0);
     }
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         amrex::Real bcforcing = 0;
@@ -80,7 +80,7 @@ void KransAxell::operator()(
         const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
         if (k == 0) {
             const amrex::Real m = std::sqrt(ux * ux + uy * uy);
-            const amrex::Real ustar = m * kappa / ( std::log(z / z0) + psi_m);
+            const amrex::Real ustar = m * kappa / (std::log(z / z0) + psi_m);
             const amrex::Real rans_b = std::pow(
                 std::max(heat_flux, 0.0) * kappa * z / std::pow(Cmu, 3),
                 (2.0 / 3.0));
@@ -115,7 +115,8 @@ void KransAxell::operator()(
                 const amrex::Real uy = vel(i, j, k, 1);
                 const amrex::Real z = 0.5 * dx[2];
                 amrex::Real m = std::sqrt(ux * ux + uy * uy);
-                const amrex::Real ustar = m * kappa / ( std::log(z / z0) + psi_m);
+                const amrex::Real ustar =
+                    m * kappa / (std::log(z / z0) + psi_m);
                 const amrex::Real rans_b = std::pow(
                     std::max(heat_flux, 0.0) * kappa * z / std::pow(Cmu, 3),
                     (2.0 / 3.0));

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -82,6 +82,11 @@ public:
 private:
     const ABLWallFunction& m_wall_func;
     std::string m_wall_shear_stress_type{"moeng"};
+    std::string m_surface_flux_method{"uniform"};
+    amrex::Real m_mol_length{10000};
+    amrex::Real m_surface_roughness{0.1};
+    amrex::Real m_gamma_m{5.0};
+    amrex::Real m_beta_m{16.0};
 };
 
 class ABLTempWallFunc : public FieldBCIface
@@ -98,6 +103,9 @@ public:
 private:
     const ABLWallFunction& m_wall_func;
     std::string m_wall_shear_stress_type{"moeng"};
+    std::string m_surface_flux_method{"uniform"};
+    amrex::Real m_mol_length{10000};
+    amrex::Real m_surface_roughness{0.1};    
 };
 
 } // namespace amr_wind

--- a/amr-wind/wind_energy/ABLWallFunction.H
+++ b/amr-wind/wind_energy/ABLWallFunction.H
@@ -105,7 +105,7 @@ private:
     std::string m_wall_shear_stress_type{"moeng"};
     std::string m_surface_flux_method{"uniform"};
     amrex::Real m_mol_length{10000};
-    amrex::Real m_surface_roughness{0.1};    
+    amrex::Real m_surface_roughness{0.1};
 };
 
 } // namespace amr_wind


### PR DESCRIPTION
## Summary

There are three methods available in air-wind for specifying the stratification effects: (i)uniform heat flux (ii) surface temperature and (iii) heating or cooling rate. However, quasi-steady RANS simulations for wind turbine siting, runs faster if the monin-obukhov length is fixed to a constant value for the surface. This PR provides a capability to do this within the air-wind RANS (or LES) framework with terrain. This is still in the draft stage as I am checking to make sure that I do not break anything. 


Please check the type of change introduced:

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

1. Need regression test 
2. Need unit test 
3. Need documentation 
