### PR TITLE
Add a plot header file for sampling particles

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -118,7 +118,7 @@ protected:
 
     SamplingContainer& sampling_container() { return *m_scontainer; }
 
-    amrex::Vector<std::string> int_var_names()
+    static amrex::Vector<std::string> int_var_names()
     {
         return {"uid", "set_id", "probe_id"};
     };

--- a/amr-wind/utilities/sampling/Sampling.H
+++ b/amr-wind/utilities/sampling/Sampling.H
@@ -8,6 +8,7 @@
 #include "amr-wind/utilities/PostProcessing.H"
 #include "amr-wind/utilities/sampling/SamplerBase.H"
 #include "amr-wind/utilities/sampling/SamplingContainer.H"
+#include <AMReX_PlotFileUtil.H>
 
 /**
  *  \defgroup sampling Data-sampling utilities
@@ -110,9 +111,17 @@ protected:
     virtual void write_ascii();
 
     //! Output extra information for certain formats
+    void write_header_file(const std::string& fname);
+
+    //! Output extra information for certain formats
     void write_info_file(const std::string& fname);
 
     SamplingContainer& sampling_container() { return *m_scontainer; }
+
+    amrex::Vector<std::string> int_var_names()
+    {
+        return {"uid", "set_id", "probe_id"};
+    };
 
 private:
     CFDSim& m_sim;

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -454,10 +454,6 @@ void Sampling::write_header_file(const std::string& fname)
         return;
     }
 
-    if (amrex::FileSystem::Exists(fname)) {
-        return;
-    }
-
     if ((m_out_fmt != "native")) {
         amrex::Abort(
             "write_header_file is implemented only for native formats");

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -390,16 +390,18 @@ void Sampling::impl_write_native()
     const std::string sampling_name =
         amrex::Concatenate(m_label, m_sim.time().time_index());
     const std::string name(post_dir + "/" + sampling_name);
-    amrex::Vector<std::string> int_var_names{"uid", "set_id", "probe_id"};
 
     m_scontainer->WritePlotFile(
-        name, "particles", m_var_names, int_var_names,
+        name, "particles", m_var_names, int_var_names(),
         [=] AMREX_GPU_DEVICE(const SamplingContainer::SuperParticleType& p) {
             return p.id() > 0;
         });
 
     const std::string info_name = name + "/sampling_info";
     write_info_file(info_name);
+
+    const std::string header_name = name + "/Header";
+    write_header_file(header_name);
 }
 
 void Sampling::write_ascii()
@@ -441,6 +443,47 @@ void Sampling::write_info_file(const std::string& fname)
 
     fh << "time " << m_sim.time().new_time() << std::endl;
     fh.close();
+}
+
+void Sampling::write_header_file(const std::string& fname)
+{
+    BL_PROFILE("amr-wind::Sampling::write_header_file");
+
+    // Only I/O processor writes the info file
+    if (!amrex::ParallelDescriptor::IOProcessor()) {
+        return;
+    }
+
+    if (amrex::FileSystem::Exists(fname)) {
+        return;
+    }
+
+    if ((m_out_fmt != "native")) {
+        amrex::Abort(
+            "write_header_file is implemented only for native formats");
+    }
+
+    amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::IO_Buffer_Size);
+    std::ofstream hdr;
+    hdr.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
+    hdr.open(
+        fname.c_str(),
+        std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+    if (!hdr.good()) {
+        amrex::FileOpenFailed(fname);
+    }
+
+    const int nlevels = m_sim.repo().num_active_levels();
+    const auto& bas = m_sim.mesh().boxArray();
+    const auto& geoms = m_sim.mesh().Geom();
+    const auto& ref_ratio = m_sim.mesh().refRatio();
+    const amrex::Vector<int> level_steps(nlevels, m_sim.time().time_index());
+    auto vnames = m_var_names;
+    const auto inames = int_var_names();
+    vnames.insert(vnames.end(), inames.begin(), inames.end());
+    amrex::WriteGenericPlotfileHeader(
+        hdr, nlevels, bas, vnames, geoms, m_sim.time().new_time(), level_steps,
+        ref_ratio, "HyperCLaw-V1.1", "Level_", "Cell");
 }
 
 void Sampling::prepare_netcdf_file()


### PR DESCRIPTION
## Summary

Add a `Header` file for sampling particles. Long story of why is below.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

Issue #1417 brought to our attention that Paraview >= 5.12 could not read our sampling particles any more. 

This was reported to ParaView here: https://gitlab.kitware.com/paraview/paraview/-/issues/22835. 

It turns out that Paraview in this [PR](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9698) started requiring a Header file that was written by the WritePlotFile routine (independently of the particles). In the majority of amrex applications, particles are written out in conjunction with a plot file (and in the same directory) so this is typically not an issue because the plot file header is available. However, the AMR-Wind sampling particles are independent (can be written at a different frequency, etc) so our particle directories did not have a Header file. 

This PR adds a Header file to the sampling particle directories. I can now use ParaView 5.13 to viz our particles. The added bonus is that it now recognizes the time stamp associated to those particles. 

![Screenshot 2025-01-08 at 9 47 48 AM](https://github.com/user-attachments/assets/2eefb28f-9704-4973-a6ad-a89d240adf54)

Tagging @rthedin as interested.