### PR TITLE
Fix netcdf sampling when more than 2 labels

### DIFF
--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -80,8 +80,10 @@ void SamplingContainer::initialize_particles(
                 continue;
             }
 
-            const auto uid_offset =
-                (iprobe == 0) ? 0 : samplers[iprobe - 1]->num_points();
+            int uid_offset = 0;
+            for(int iprobe2=0; iprobe2 < iprobe; iprobe2++){
+              uid_offset += samplers[iprobe2]->num_points();
+            }
             const auto probe_id = probe->id();
             amrex::Gpu::DeviceVector<amrex::RealVect> dlocs(npts);
             amrex::Gpu::copy(

--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -80,10 +80,9 @@ void SamplingContainer::initialize_particles(
                 continue;
             }
 
-            int uid_offset = 0;
-            for(int iprobe2=0; iprobe2 < iprobe; iprobe2++){
-              uid_offset += samplers[iprobe2]->num_points();
-            }
+            const int uid_offset = std::accumulate(
+                samplers.begin(), samplers.begin() + iprobe, 0,
+                [&](int sum, const auto& s) { return sum + s->num_points(); });
             const auto probe_id = probe->id();
             amrex::Gpu::DeviceVector<amrex::RealVect> dlocs(npts);
             amrex::Gpu::copy(

--- a/test/test_files/abl_sampling/abl_sampling.inp
+++ b/test/test_files/abl_sampling/abl_sampling.inp
@@ -128,7 +128,7 @@ probe_sampling.probe1.offsets   = 0.0 200.0 400.0 600.0
 plane_sampling.output_frequency     = 1
 plane_sampling.output_format        = native
 plane_sampling.fields               = velocity
-plane_sampling.labels               = plane1 plane2
+plane_sampling.labels               = plane1 plane2 plane3
 plane_sampling.plane1.type          = PlaneSampler
 plane_sampling.plane1.axis1         = 400.0 0.0 0.0
 plane_sampling.plane1.axis2         = 0.0 0.0 400.0
@@ -144,6 +144,14 @@ plane_sampling.plane2.origin        = 0.0 0.0 500.0
 plane_sampling.plane2.num_points    = 10 10
 plane_sampling.plane2.offset_vector = 0.0 0.0 1.0
 plane_sampling.plane2.offsets       = 0.0 499.0
+
+plane_sampling.plane3.type          = PlaneSampler
+plane_sampling.plane3.axis1         = 400.0 0.0 0.0
+plane_sampling.plane3.axis2         = 0.0 0.0 400.0
+plane_sampling.plane3.origin        = 400.0 200.0 200.0
+plane_sampling.plane3.num_points    = 10 10
+plane_sampling.plane3.offset_vector = 0.0 1.0 1.0
+plane_sampling.plane3.offsets       = 0.0 20.0 30.0 200.0
 
 line_sampling.output_frequency     = 1
 line_sampling.output_format        = native

--- a/test/test_files/abl_sampling_netcdf/abl_sampling_netcdf.inp
+++ b/test/test_files/abl_sampling_netcdf/abl_sampling_netcdf.inp
@@ -128,7 +128,7 @@ probe_sampling.probe1.offsets   = 0.0 200.0 400.0 600.0
 plane_sampling.output_frequency     = 1
 plane_sampling.output_format        = netcdf
 plane_sampling.fields               = velocity
-plane_sampling.labels               = plane1
+plane_sampling.labels               = plane1 plane2 plane3
 plane_sampling.plane1.type          = PlaneSampler
 plane_sampling.plane1.axis1         = 400.0 0.0 0.0
 plane_sampling.plane1.axis2         = 0.0 0.0 400.0
@@ -136,6 +136,22 @@ plane_sampling.plane1.origin        = 200.0 200.0 200.0
 plane_sampling.plane1.num_points    = 10 10
 plane_sampling.plane1.offset_vector = 0.0 1.0 1.0
 plane_sampling.plane1.offsets       = 0.0 20.0 30.0 200.0
+
+plane_sampling.plane2.type          = PlaneSampler
+plane_sampling.plane2.axis1         = 1000.0 0.0 0.0
+plane_sampling.plane2.axis2         = 0.0 1000.0 0.0
+plane_sampling.plane2.origin        = 0.0 0.0 500.0
+plane_sampling.plane2.num_points    = 10 10
+plane_sampling.plane2.offset_vector = 0.0 0.0 1.0
+plane_sampling.plane2.offsets       = 0.0 499.0
+
+plane_sampling.plane3.type          = PlaneSampler
+plane_sampling.plane3.axis1         = 400.0 0.0 0.0
+plane_sampling.plane3.axis2         = 0.0 0.0 400.0
+plane_sampling.plane3.origin        = 400.0 200.0 200.0
+plane_sampling.plane3.num_points    = 10 10
+plane_sampling.plane3.offset_vector = 0.0 1.0 1.0
+plane_sampling.plane3.offsets       = 0.0 20.0 30.0 200.0
 
 line_sampling.output_frequency     = 1
 line_sampling.output_format        = netcdf


### PR DESCRIPTION
## Summary

Fix netcdf sampling when more than 2 labels. The unique id of the particles had a bug that made it work with at most 2 sampling labels. Basically it forgot to increment the uid offset. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [x] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Closes #1443 