### PR TITLE
Include group information in `sampling_info` for `native` sampling

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -443,7 +443,7 @@ void Sampling::write_info_file(const std::string& fname)
 
     // YAML formatting
     fh << "time: " << m_sim.time().new_time() << std::endl;
-    fh << "groups:" << std::endl;
+    fh << "samplers:" << std::endl;
     for (int i = 0; i < m_samplers.size(); ++i) {
         fh << " - group_index: " << i << std::endl;
         fh << "   name: " << m_samplers[i]->label() << std::endl;

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -445,8 +445,8 @@ void Sampling::write_info_file(const std::string& fname)
     fh << "time: " << m_sim.time().new_time() << std::endl;
     fh << "samplers:" << std::endl;
     for (int i = 0; i < m_samplers.size(); ++i) {
-        fh << " - group_index: " << i << std::endl;
-        fh << "   name: " << m_samplers[i]->label() << std::endl;
+        fh << " - index: " << i << std::endl;
+        fh << "   label: " << m_samplers[i]->label() << std::endl;
         fh << "   sampling_type: " << m_samplers[i]->sampletype() << std::endl;
     }
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -2,6 +2,7 @@
 #include <utility>
 
 #include "amr-wind/utilities/sampling/Sampling.H"
+// #include "amr-wind/utilities/sampling/PlaneSampler.H"
 #include "amr-wind/utilities/io_utils.H"
 #include "amr-wind/utilities/ncutils/nc_interface.H"
 #include "amr-wind/utilities/IOManager.H"
@@ -443,19 +444,15 @@ void Sampling::write_info_file(const std::string& fname)
     }
 
     fh << "time " << m_sim.time().new_time() << std::endl;
-    //fh << "m_label " << m_label << std::endl;
     amrex::ParmParse pp(m_label);
     pp.getarr("labels", labels);
-    int i=0;
-    for (const auto& lbl : labels) {
-        i++;
-    }
-    fh << "ngroups " << i << std::endl;
-    i=0;
-    for (const auto& lbl : labels) {
-        fh << lbl << " " << i << std::endl;
-        i++;
-    }
+    fh << "ngroups " << labels.size() << std::endl;
+	for (int i = 0; i < labels.size(); ++i) {
+		fh << "group_index " << i << std::endl;
+		fh << "  name " << labels[i] << std::endl;
+		fh << "  sampling_type " << m_samplers[i]->sampletype() << std::endl;
+	}
+
     fh.close();
 }
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -425,7 +425,6 @@ void Sampling::write_ascii()
 void Sampling::write_info_file(const std::string& fname)
 {
     BL_PROFILE("amr-wind::Sampling::write_info_file");
-    amrex::Vector<std::string> labels;
 
     // Only I/O processor writes the info file
     if (!amrex::ParallelDescriptor::IOProcessor()) {
@@ -443,14 +442,12 @@ void Sampling::write_info_file(const std::string& fname)
     }
 
     fh << "time " << m_sim.time().new_time() << std::endl;
-    amrex::ParmParse pp(m_label);
-    pp.getarr("labels", labels);
-    fh << "ngroups " << labels.size() << std::endl;
-	for (int i = 0; i < labels.size(); ++i) {
-		fh << "group_index " << i << std::endl;
-		fh << "  name " << labels[i] << std::endl;
-		fh << "  sampling_type " << m_samplers[i]->sampletype() << std::endl;
-	}
+    fh << "ngroups " << m_samplers.size() << std::endl;
+    for (int i = 0; i < m_samplers.size(); ++i) {
+        fh << "group_index " << i << std::endl;
+        fh << "name " << m_samplers[i]->label() << std::endl;
+        fh << "sampling_type " << m_samplers[i]->sampletype() << std::endl;
+    }
 
     fh.close();
 }

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -397,7 +397,7 @@ void Sampling::impl_write_native()
             return p.id() > 0;
         });
 
-    const std::string info_name = name + "/sampling_info";
+    const std::string info_name = name + "/sampling_info.yaml";
     write_info_file(info_name);
 
     const std::string header_name = name + "/Header";
@@ -441,12 +441,13 @@ void Sampling::write_info_file(const std::string& fname)
         amrex::FileOpenFailed(fname);
     }
 
-    fh << "time " << m_sim.time().new_time() << std::endl;
-    fh << "ngroups " << m_samplers.size() << std::endl;
+    // YAML formatting
+    fh << "time: " << m_sim.time().new_time() << std::endl;
+    fh << "groups:" << std::endl;
     for (int i = 0; i < m_samplers.size(); ++i) {
-        fh << "group_index " << i << std::endl;
-        fh << "name " << m_samplers[i]->label() << std::endl;
-        fh << "sampling_type " << m_samplers[i]->sampletype() << std::endl;
+        fh << " - group_index: " << i << std::endl;
+        fh << "   name: " << m_samplers[i]->label() << std::endl;
+        fh << "   sampling_type: " << m_samplers[i]->sampletype() << std::endl;
     }
 
     fh.close();

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -2,7 +2,6 @@
 #include <utility>
 
 #include "amr-wind/utilities/sampling/Sampling.H"
-// #include "amr-wind/utilities/sampling/PlaneSampler.H"
 #include "amr-wind/utilities/io_utils.H"
 #include "amr-wind/utilities/ncutils/nc_interface.H"
 #include "amr-wind/utilities/IOManager.H"

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -425,6 +425,7 @@ void Sampling::write_ascii()
 void Sampling::write_info_file(const std::string& fname)
 {
     BL_PROFILE("amr-wind::Sampling::write_info_file");
+    amrex::Vector<std::string> labels;
 
     // Only I/O processor writes the info file
     if (!amrex::ParallelDescriptor::IOProcessor()) {
@@ -442,6 +443,19 @@ void Sampling::write_info_file(const std::string& fname)
     }
 
     fh << "time " << m_sim.time().new_time() << std::endl;
+    //fh << "m_label " << m_label << std::endl;
+    amrex::ParmParse pp(m_label);
+    pp.getarr("labels", labels);
+    int i=0;
+    for (const auto& lbl : labels) {
+        i++;
+    }
+    fh << "ngroups " << i << std::endl;
+    i=0;
+    for (const auto& lbl : labels) {
+        fh << lbl << " " << i << std::endl;
+        i++;
+    }
     fh.close();
 }
 

--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -447,7 +447,7 @@ void Sampling::write_info_file(const std::string& fname)
     for (int i = 0; i < m_samplers.size(); ++i) {
         fh << " - index: " << i << std::endl;
         fh << "   label: " << m_samplers[i]->label() << std::endl;
-        fh << "   sampling_type: " << m_samplers[i]->sampletype() << std::endl;
+        fh << "   type: " << m_samplers[i]->sampletype() << std::endl;
     }
 
     fh.close();

--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -101,7 +101,7 @@ input order), ``probe_id`` is the local probe id to this label,
 ``*co`` are the coordinates of the probe, and the other columns are
 the user requested sampled fields. The same labels are seeing by other
 visualization tools such as ParaView. The directory also contains a
-``sampling_info`` file where additional information (e.g., time) is
+``sampling_info.yaml`` YAML file where additional information (e.g., time) is
 stored. This file is automatically parse by the provided particle
 reader tool and the information is stored in a dictionary that is a
 member variable of the class.

--- a/tools/amrex_particle.py
+++ b/tools/amrex_particle.py
@@ -12,6 +12,7 @@ the sampling data written out by AMR-Wind using the native AMReX binary format.
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import yaml
 
 class AmrexParticleFile:
     """AmrexParticleFile reader
@@ -83,25 +84,11 @@ class AmrexParticleFile:
 
     def parse_info(self):
         """Parse the sampling info file"""
-        self.info = {}
-        with open(self.pdir.parent / "sampling_info", 'r') as fh:
-            # Read time and number of groups
-            (key_t, val_t) = fh.readline().split()
-            (key_g, val_g) = fh.readline().split()
-            self.info[key_t] = float(val_t)
-            self.info[key_g] = int(val_g)
-            # Read each group options
-            for i in range(self.info[key_g]):
-                (_, g_index) = fh.readline().split()
-                (_, g_name)  = fh.readline().split()
-                (_, g_stype) = fh.readline().split()
-                self.info[g_name] = {}
-                self.info[g_name]['group_index'] = g_index
-                self.info[g_name]['sampling_type'] = g_stype
-            # Read remaining items if any
-            for line in fh:
-                (key, val) = line.split()
-                self.info[key] = float(val)
+        with open(self.pdir.parent / "sampling_info.yaml", 'r') as fh:
+            try:
+                self.info = yaml.safe_load(fh)
+            except yaml.YAMLError as exc:
+                print(exc)
 
     def load_binary_data(self):
         """Read binary data into memory"""

--- a/tools/amrex_particle.py
+++ b/tools/amrex_particle.py
@@ -36,7 +36,8 @@ class AmrexParticleFile:
             pdir (path): Directory path
         """
         self.pdir = Path(pdir)
-        assert self.pdir.exists()
+        if not self.pdir.exists():
+            raise ValueError(f'Path {self.pdir} does not exist.')
 
     def __call__(self):
         """Parse the header and load all binary files
@@ -84,6 +85,20 @@ class AmrexParticleFile:
         """Parse the sampling info file"""
         self.info = {}
         with open(self.pdir.parent / "sampling_info", 'r') as fh:
+            # Read time and number of groups
+            (key_t, val_t) = fh.readline().split()
+            (key_g, val_g) = fh.readline().split()
+            self.info[key_t] = float(val_t)
+            self.info[key_g] = int(val_g)
+            # Read each group options
+            for i in range(self.info[key_g]):
+                (_, g_index) = fh.readline().split()
+                (_, g_name)  = fh.readline().split()
+                (_, g_stype) = fh.readline().split()
+                self.info[g_name] = {}
+                self.info[g_name]['group_index'] = g_index
+                self.info[g_name]['sampling_type'] = g_stype
+            # Read remaining items if any
             for line in fh:
                 (key, val) = line.split()
                 self.info[key] = float(val)


### PR DESCRIPTION
## Summary

Adds additional information for `native` sampling, written to `sampling_info`. And switches the file to a yaml format.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:
- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

No unit-test or regression tests performed. I couldn't find any specific manual entry regarding this. Maybe we should create one?

## Additional background

Now the `sampling_info` file will look like this
```
time 100.3
ngroups 2
group_index 0
  name HighT1_inflow0deg
  sampling_type PlaneSampler
group_index 1
  name HighT2_inflow0deg
  sampling_type PlaneSampler
 ```
The reader has been updated accordingly, and outputs the info as follows:
```
{'time': 100.3,
 'ngroups': 2,
 'HighT1_inflow0deg': {'group_index': '0', 'sampling_type': 'PlaneSampler'},
 'HighT2_inflow0deg': {'group_index': '1', 'sampling_type': 'PlaneSampler'}}
 ```
 
 This format works well for me, but happy to hear any comments and feedback regarding the format.
  
