### PR TITLE
Check existence of mesh in ncf unit tests

### DIFF
--- a/unit_tests/wind_energy/test_abl_init_ncf.cpp
+++ b/unit_tests/wind_energy/test_abl_init_ncf.cpp
@@ -111,8 +111,10 @@ TEST_F(ABLMeshTest, abl_init_netcdf_multilevel)
             new amr_wind::CartBoxRefinement(sim()));
         box_refine->read_inputs(mesh(), ss);
 
-        mesh<RefineMesh>()->refine_criteria_vec().push_back(
-            std::move(box_refine));
+        if (mesh<RefineMesh>()) {
+            mesh<RefineMesh>()->refine_criteria_vec().push_back(
+                std::move(box_refine));
+        }
     }
 
     // Set up mock simulation init, starting with mesh and fields


### PR DESCRIPTION
## Summary

Check existence of mesh in ncf unit tests. This removes another null pointer dereference warning from the dashboard.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
