### PR TITLE
Create transport model before the physics

### DIFF
--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -424,13 +424,13 @@ void incflo::init_physics_and_pde()
         pde_mgr.register_transport_pde("Density");
     }
 
+    m_sim.create_transport_model();
     m_sim.init_physics();
     {
         // Check for if velocity is prescribed
         amrex::ParmParse pp("incflo");
         pp.query("prescribe_velocity", m_prescribe_vel);
     }
-    m_sim.create_transport_model();
     m_sim.create_turbulence_model();
 
     // Initialize the refinement criteria

--- a/amr-wind/transport_models/ConstTransport.H
+++ b/amr-wind/transport_models/ConstTransport.H
@@ -16,8 +16,7 @@ public:
 
     static std::string identifier() { return "ConstTransport"; }
 
-    explicit ConstTransport(const CFDSim& sim)
-        : m_repo(sim.repo())
+    explicit ConstTransport(const CFDSim& sim) : m_repo(sim.repo())
     {
         amrex::ParmParse pp("transport");
         pp.query("viscosity", m_mu);

--- a/amr-wind/transport_models/ConstTransport.H
+++ b/amr-wind/transport_models/ConstTransport.H
@@ -17,7 +17,7 @@ public:
     static std::string identifier() { return "ConstTransport"; }
 
     explicit ConstTransport(const CFDSim& sim)
-        : m_repo(sim.repo()), m_phy_mgr(sim.physics_manager())
+        : m_repo(sim.repo())
     {
         amrex::ParmParse pp("transport");
         pp.query("viscosity", m_mu);
@@ -264,9 +264,6 @@ public:
 private:
     //! Reference to the field repository (for creating scratch fields)
     FieldRepo& m_repo;
-
-    //! Reference to the physics manager
-    const PhysicsMgr& m_phy_mgr;
 
     //! (Laminar) dynamic viscosity
     amrex::Real m_mu{1.0e-5};

--- a/amr-wind/transport_models/TwoPhaseTransport.H
+++ b/amr-wind/transport_models/TwoPhaseTransport.H
@@ -18,15 +18,8 @@ public:
     static std::string identifier() { return "TwoPhaseTransport"; }
 
     explicit TwoPhaseTransport(const CFDSim& sim)
-        : m_sim(sim), m_repo(sim.repo())
+        : m_repo(sim.repo()), m_physics_mgr(sim.physics_manager())
     {
-        const auto& physics_mgr = m_sim.physics_manager();
-        if (!physics_mgr.contains("MultiPhase")) {
-            amrex::Abort("TwoPhaseTransport requires MultiPhase physics");
-        }
-        const auto& multiphase = physics_mgr.get<MultiPhase>();
-        m_ifacetype = multiphase.interface_capturing_method();
-
         amrex::ParmParse pp("transport");
         pp.query("viscosity_fluid1", m_mu1);
         pp.query("viscosity_fluid2", m_mu2);
@@ -140,7 +133,8 @@ public:
         // Select the interface capturing method
         auto mu = m_repo.create_scratch_field(1, m_ngrow);
 
-        if (m_ifacetype == InterfaceCapturingMethod::VOF) {
+        auto ifacetype = get_iface_method();
+        if (ifacetype == InterfaceCapturingMethod::VOF) {
 
             const auto& vof = m_repo.get_field("vof");
 
@@ -160,7 +154,7 @@ public:
                 }
             }
 
-        } else if (m_ifacetype == InterfaceCapturingMethod::LS) {
+        } else if (ifacetype == InterfaceCapturingMethod::LS) {
 
             const auto& levelset = m_repo.get_field("levelset");
             const auto& geom = m_repo.mesh().Geom();
@@ -205,7 +199,8 @@ public:
         // Select the interface capturing method
         auto alpha = m_repo.create_scratch_field(1, m_ngrow);
 
-        if (m_ifacetype == InterfaceCapturingMethod::VOF) {
+        auto ifacetype = get_iface_method();
+        if (ifacetype == InterfaceCapturingMethod::VOF) {
 
             const auto& vof = m_repo.get_field("vof");
 
@@ -228,7 +223,7 @@ public:
                 }
             }
 
-        } else if (m_ifacetype == InterfaceCapturingMethod::LS) {
+        } else if (ifacetype == InterfaceCapturingMethod::LS) {
 
             const auto& levelset = m_repo.get_field("levelset");
             const auto& geom = m_repo.mesh().Geom();
@@ -330,7 +325,8 @@ public:
                 });
         }
 
-        if (m_ifacetype == InterfaceCapturingMethod::VOF) {
+        auto ifacetype = get_iface_method();
+        if (ifacetype == InterfaceCapturingMethod::VOF) {
             const auto& vof = m_repo.get_field("vof");
             const auto& vof_arr = vof(lev).const_array(mfi);
             amrex::ParallelFor(
@@ -339,7 +335,7 @@ public:
                         beta(i, j, k) = 0.0;
                     }
                 });
-        } else if (m_ifacetype == InterfaceCapturingMethod::LS) {
+        } else if (ifacetype == InterfaceCapturingMethod::LS) {
             const auto& levelset = m_repo.get_field("levelset");
             const auto& dx = m_repo.mesh().Geom(lev).CellSizeArray();
             const auto& phi_arr = levelset(lev).const_array(mfi);
@@ -416,14 +412,11 @@ public:
     }
 
 private:
-    //! Reference to the CFD sim
-    const CFDSim& m_sim;
-
     //! Reference to the field repository (for creating scratch fields)
     FieldRepo& m_repo;
 
-    //! Interface capturing method variable
-    InterfaceCapturingMethod m_ifacetype;
+    //! Reference to the physics manager
+    const PhysicsMgr& m_physics_mgr;
 
     //! Phase 1 (liquid) dynamic molecular viscosity
     amrex::Real m_mu1{1.0e-3};
@@ -445,6 +438,15 @@ private:
 
     //! Reference temperature
     amrex::Real m_reference_temperature{-1.0};
+
+    InterfaceCapturingMethod get_iface_method() const
+    {
+        if (!m_physics_mgr.contains("MultiPhase")) {
+            amrex::Abort("TwoPhaseTransport requires MultiPhase physics");
+        }
+        const auto& multiphase = m_physics_mgr.get<MultiPhase>();
+        return multiphase.interface_capturing_method();
+    }
 };
 
 } // namespace amr_wind::transport

--- a/test/test_files/abl_meso_tendency/abl_meso_tendency.inp
+++ b/test/test_files/abl_meso_tendency/abl_meso_tendency.inp
@@ -43,6 +43,7 @@ incflo.velocity = 0 0 0 # dummy values
 
 ABL.kappa = .41
 ABL.surface_roughness_z0 = 0.0002
+ABL.surface_temp_rate = -0.25
 
 ABL.stats_output_frequency = 1
 

--- a/unit_tests/offshore_wind/test_abloffshore_src.cpp
+++ b/unit_tests/offshore_wind/test_abloffshore_src.cpp
@@ -304,8 +304,8 @@ TEST_F(ABLOffshoreMeshTest, boussinesq)
     auto& pde_mgr = sim().pde_manager();
     pde_mgr.register_icns();
     pde_mgr.register_transport_pde("Temperature");
-    sim().init_physics();
     sim().create_transport_model();
+    sim().init_physics();
     auto& mphase = sim().physics_manager().get<amr_wind::MultiPhase>();
     // Make sure to read water level
     mphase.post_init_actions();

--- a/unit_tests/wind_energy/test_abl_src.cpp
+++ b/unit_tests/wind_energy/test_abl_src.cpp
@@ -535,8 +535,8 @@ TEST_F(ABLMeshTest, boussinesq)
     auto& pde_mgr = sim().pde_manager();
     pde_mgr.register_icns();
     pde_mgr.register_transport_pde("Temperature");
-    sim().init_physics();
     sim().create_transport_model();
+    sim().init_physics();
 
     amr_wind::pde::icns::BoussinesqBuoyancy bb(sim());
 
@@ -582,8 +582,8 @@ TEST_F(ABLMeshTest, boussinesq_nph)
     auto& pde_mgr = sim().pde_manager();
     pde_mgr.register_icns();
     pde_mgr.register_transport_pde("Temperature");
-    sim().init_physics();
     sim().create_transport_model();
+    sim().init_physics();
 
     amr_wind::pde::icns::BoussinesqBuoyancy bb(sim());
 


### PR DESCRIPTION
## Summary

Some physics classes, in rare instances, which is why we hadn't caught it yet, need some transport model information. This PR makes it so the transport models are created before the physics. 

Basically it is the combination of `ABL.surface_temp_rate` specified and a missing `ABL.surface_temp_init`. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

Closes #1457 