### PR TITLE
w2a fields - replace fillpatch with FillBoundary

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -679,18 +679,17 @@ struct UpdateTargetFieldsOp<W2AWaves>
             }
 
             // Average down to get fine information on coarse grid where
-            // possible (may be unnecessary)
+            // possible and update ghost cells (may be unnecessary)
             for (int lev = nlevels - 1; lev > 0; --lev) {
                 amrex::average_down(
                     w2a_velocity(lev), w2a_velocity(lev - 1), 0, AMREX_SPACEDIM,
                     sim.mesh().refRatio(lev - 1));
+                w2a_velocity(lev - 1).FillBoundary(geom[lev - 1].periodicity());
                 amrex::average_down(
                     w2a_levelset(lev), w2a_levelset(lev - 1), 0, 1,
                     sim.mesh().refRatio(lev - 1));
+                w2a_levelset(lev - 1).FillBoundary(geom[lev - 1].periodicity());
             }
-            // Fill patch to get correct ghost cells after average down
-            w2a_velocity.fillpatch(sim.time().new_time());
-            w2a_levelset.fillpatch(sim.time().new_time());
         }
 
         // Temporally interpolate at every timestep to get target solution


### PR DESCRIPTION
## Summary

It's better to rely on the directly populated ghost boundary cells than use fillpatch to fill them. 

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU  - just the w2a cases

## Additional background

Creates tiny diffs in the w2a cases. The one exception is the ow_w2a_nonperiodic case, but I am willing to trust my understanding of the boundary conditions that things are better without the fillpatch.

Putting an epsilon with the norm also fixes the issue, but when I dug deeper I found that the issue was taking place in ghost cells and that the zero norm wouldn't have been prior to this fillpatch operation.

Issue Number: closes #1469 
