### PR TITLE
Use reference potential temperature for anelastic

### DIFF
--- a/amr-wind/utilities/constants.H
+++ b/amr-wind/utilities/constants.H
@@ -46,5 +46,8 @@ static constexpr amrex::Real AVOGADRO_CONSTANT = 6.02214076 * 1e23;
 static constexpr amrex::Real UNIVERSAL_GAS_CONSTANT =
     AVOGADRO_CONSTANT * BOLTZMANN_CONSTANT;
 
+//! Heat capacity ratio
+static constexpr amrex::Real HEAT_CAPACITY_RATIO = 1.4;
+
 } // namespace amr_wind::constants
 #endif

--- a/amr-wind/wind_energy/ABLAnelastic.cpp
+++ b/amr-wind/wind_energy/ABLAnelastic.cpp
@@ -88,7 +88,7 @@ void ABLAnelastic::initialize_data()
 
     auto& temp0 = m_sim.repo().get_field("reference_temperature");
     const amrex::Real air_molar_mass = 0.02896492; // kg/mol
-    const amrex::Real pressure_00 = 1.0e5; // Pa
+    const amrex::Real pressure_00 = 1.0e5;         // Pa
     const amrex::Real Rair = constants::UNIVERSAL_GAS_CONSTANT / air_molar_mass;
     for (int lev = 0; lev < m_sim.repo().num_active_levels(); ++lev) {
         const auto& rho0_arrs = rho0(lev).const_arrays();

--- a/amr-wind/wind_energy/ABLAnelastic.cpp
+++ b/amr-wind/wind_energy/ABLAnelastic.cpp
@@ -88,7 +88,7 @@ void ABLAnelastic::initialize_data()
 
     auto& temp0 = m_sim.repo().get_field("reference_temperature");
     const amrex::Real air_molar_mass = 0.02896492; // kg/mol
-    const amrex::Real pressure_00 = 1.0e5;         // Pa
+    const amrex::Real pressure_00 = m_bottom_reference_pressure;
     const amrex::Real Rair = constants::UNIVERSAL_GAS_CONSTANT / air_molar_mass;
     for (int lev = 0; lev < m_sim.repo().num_active_levels(); ++lev) {
         const auto& rho0_arrs = rho0(lev).const_arrays();


### PR DESCRIPTION
## Summary

Use reference potential temperature for anelastic. The expression comes from https://erf.readthedocs.io/en/latest/theory/DryEquations.html

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
