### PR TITLE
Initialize density to reference density for anelastic

### DIFF
--- a/amr-wind/wind_energy/ABLAnelastic.cpp
+++ b/amr-wind/wind_energy/ABLAnelastic.cpp
@@ -78,6 +78,10 @@ void ABLAnelastic::initialize_data()
     m_theta.copy_to_field(temp0);
     density0_field.fillpatch(m_sim.time().current_time());
     temp0.fillpatch(m_sim.time().current_time());
+    auto& density_field = m_sim.repo().get_field("density");
+    field_ops::copy(
+        density_field, density0_field, 0, 0, density0_field.num_comp(),
+        density0_field.num_grow());
 }
 
 void ABLAnelastic::initialize_isentropic_hse()


### PR DESCRIPTION
## Summary

Initialize density to reference density for anelastic. Tagging @mukul1992 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
