### PR TITLE
Floating point math is hard

### DIFF
--- a/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
+++ b/amr-wind/utilities/sampling/FreeSurfaceSampler.cpp
@@ -344,21 +344,21 @@ void FreeSurfaceSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] <= prob_lo[d]) {
+        if (m_start[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_lo[d] + bounds_tol;
+            m_start[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_start[d] >= prob_hi[d]) {
+        if (m_start[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_hi[d] - bounds_tol;
+            m_start[d] = prob_hi[d] - 10 * bounds_tol;
         }
-        if (m_end[d] <= prob_lo[d]) {
+        if (m_end[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_lo[d] + bounds_tol;
+            m_end[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_end[d] >= prob_hi[d]) {
+        if (m_end[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_hi[d] - bounds_tol;
+            m_end[d] = prob_hi[d] - 10 * bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/LineSampler.cpp
+++ b/amr-wind/utilities/sampling/LineSampler.cpp
@@ -30,21 +30,21 @@ void LineSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] <= prob_lo[d]) {
+        if (m_start[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_lo[d] + bounds_tol;
+            m_start[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_start[d] >= prob_hi[d]) {
+        if (m_start[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_hi[d] - bounds_tol;
+            m_start[d] = prob_hi[d] - 10 * bounds_tol;
         }
-        if (m_end[d] <= prob_lo[d]) {
+        if (m_end[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_lo[d] + bounds_tol;
+            m_end[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_end[d] >= prob_hi[d]) {
+        if (m_end[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_hi[d] - bounds_tol;
+            m_end[d] = prob_hi[d] - 10 * bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/ProbeSampler.cpp
+++ b/amr-wind/utilities/sampling/ProbeSampler.cpp
@@ -73,7 +73,8 @@ void ProbeSampler::check_bounds()
             if (probe_locs[i][d] < (prob_lo[d] + bounds_tol)) {
                 all_ok = false;
                 probe_locs[i][d] = prob_lo[d] + 10 * bounds_tol;
-            } else if (probe_locs[i][d] > (prob_hi[d] - bounds_tol)) {
+            }
+            if (probe_locs[i][d] > (prob_hi[d] - bounds_tol)) {
                 all_ok = false;
                 probe_locs[i][d] = prob_hi[d] - 10 * bounds_tol;
             }

--- a/amr-wind/utilities/sampling/ProbeSampler.cpp
+++ b/amr-wind/utilities/sampling/ProbeSampler.cpp
@@ -70,13 +70,12 @@ void ProbeSampler::check_bounds()
     bool all_ok = true;
     for (int i = 0; i < m_npts; ++i) {
         for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            if (probe_locs[i][d] <= prob_lo[d]) {
+            if (probe_locs[i][d] < (prob_lo[d] + bounds_tol)) {
                 all_ok = false;
-                probe_locs[i][d] = prob_lo[d] + bounds_tol;
-            }
-            if (probe_locs[i][d] >= prob_hi[d]) {
+                probe_locs[i][d] = prob_lo[d] + 10 * bounds_tol;
+            } else if (probe_locs[i][d] > (prob_hi[d] - bounds_tol)) {
                 all_ok = false;
-                probe_locs[i][d] = prob_hi[d] - bounds_tol;
+                probe_locs[i][d] = prob_hi[d] - 10 * bounds_tol;
             }
         }
     }

--- a/amr-wind/utilities/sampling/RadarSampler.cpp
+++ b/amr-wind/utilities/sampling/RadarSampler.cpp
@@ -104,21 +104,21 @@ void RadarSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_start[d] <= prob_lo[d]) {
+        if (m_start[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_lo[d] + bounds_tol;
+            m_start[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_start[d] >= prob_hi[d]) {
+        if (m_start[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_start[d] = prob_hi[d] - bounds_tol;
+            m_start[d] = prob_hi[d] - 10 * bounds_tol;
         }
-        if (m_end[d] <= prob_lo[d]) {
+        if (m_end[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_lo[d] + bounds_tol;
+            m_end[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_end[d] >= prob_hi[d]) {
+        if (m_end[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_end[d] = prob_hi[d] - bounds_tol;
+            m_end[d] = prob_hi[d] - 10 * bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/SamplerBase.H
+++ b/amr-wind/utilities/sampling/SamplerBase.H
@@ -4,6 +4,7 @@
 #include <AMReX_RealVect.H>
 #include "amr-wind/core/Factory.H"
 #include "amr-wind/utilities/ncutils/nc_interface.H"
+#include "amr-wind/utilities/constants.H"
 
 namespace amr_wind {
 
@@ -56,8 +57,7 @@ class SamplerBase : public Factory<SamplerBase, CFDSim&>
 public:
     static std::string base_identifier() { return "SamplerBase"; }
 
-    static constexpr amrex::Real bounds_tol =
-        std::numeric_limits<amrex::Real>::epsilon();
+    static constexpr amrex::Real bounds_tol = constants::TIGHT_TOL;
 
     ~SamplerBase() override = default;
 

--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -132,6 +132,7 @@ void SamplingContainer::initialize_particles(
             offset += npts;
         }
     }
+    AMREX_ALWAYS_ASSERT(m_total_particles == TotalNumberOfParticles(false));
 }
 
 void SamplingContainer::interpolate_derived_fields(

--- a/amr-wind/utilities/sampling/VolumeSampler.cpp
+++ b/amr-wind/utilities/sampling/VolumeSampler.cpp
@@ -42,21 +42,21 @@ void VolumeSampler::check_bounds()
 
     bool all_ok = true;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        if (m_lo[d] <= prob_lo[d]) {
+        if (m_lo[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_lo[d] = prob_lo[d] + bounds_tol;
+            m_lo[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_lo[d] >= prob_hi[d]) {
+        if (m_lo[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_lo[d] = prob_hi[d] - bounds_tol;
+            m_lo[d] = prob_hi[d] - 10 * bounds_tol;
         }
-        if (m_hi[d] <= prob_lo[d]) {
+        if (m_hi[d] < (prob_lo[d] + bounds_tol)) {
             all_ok = false;
-            m_hi[d] = prob_lo[d] + bounds_tol;
+            m_hi[d] = prob_lo[d] + 10 * bounds_tol;
         }
-        if (m_hi[d] >= prob_hi[d]) {
+        if (m_hi[d] > (prob_hi[d] - bounds_tol)) {
             all_ok = false;
-            m_hi[d] = prob_hi[d] - bounds_tol;
+            m_hi[d] = prob_hi[d] - 10 * bounds_tol;
         }
     }
     if (!all_ok) {

--- a/amr-wind/utilities/sampling/VolumeSampler.cpp
+++ b/amr-wind/utilities/sampling/VolumeSampler.cpp
@@ -60,7 +60,7 @@ void VolumeSampler::check_bounds()
         }
     }
     if (!all_ok) {
-        amrex::Print() << "WARNING: VolumeSampler: Out of domain line was "
+        amrex::Print() << "WARNING: VolumeSampler: Out of domain corner was "
                           "truncated to match domain"
                        << std::endl;
     }


### PR DESCRIPTION
## Summary

Slightly looser tolerances on checking whether a particle is in the domain and then adjusting its position so that it is fully in the domain.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

If a sampling particle is too close to the boundary, floating point arithmetic could make it look like it is outside the domain. And that leads to a mismatch between the number of particles it thinks exists and those that are actually created. 

Closes #1520 
