### PR TITLE
Fix the DTU spinner check

### DIFF
--- a/amr-wind/utilities/sampling/DTUSpinnerSampler.H
+++ b/amr-wind/utilities/sampling/DTUSpinnerSampler.H
@@ -77,6 +77,9 @@ public:
         return (m_beam_points * m_ntotal);
     }
 
+    //! Type of this sampling object
+    std::string sampletype() const override { return identifier(); }
+
     void
     define_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
     void

--- a/amr-wind/utilities/sampling/LidarSampler.H
+++ b/amr-wind/utilities/sampling/LidarSampler.H
@@ -37,6 +37,9 @@ public:
 
     void post_sample_actions() override {};
 
+    //! Type of this sampling object
+    std::string sampletype() const override { return identifier(); }
+
     void
     define_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
     void

--- a/amr-wind/utilities/sampling/SamplingContainer.cpp
+++ b/amr-wind/utilities/sampling/SamplingContainer.cpp
@@ -132,7 +132,13 @@ void SamplingContainer::initialize_particles(
             offset += npts;
         }
     }
-    AMREX_ALWAYS_ASSERT(m_total_particles == TotalNumberOfParticles(false));
+    // Skip this check if there is a DTUSpinnerSampler (may have out of domain
+    // particles)
+    if (std::all_of(samplers.cbegin(), samplers.cend(), [](const auto& probe) {
+            return probe->sampletype() != "DTUSpinnerSampler";
+        })) {
+        AMREX_ALWAYS_ASSERT(m_total_particles == TotalNumberOfParticles(false));
+    }
 }
 
 void SamplingContainer::interpolate_derived_fields(


### PR DESCRIPTION
## Summary

Fix the DTU spinner check. Basically the DTU spinner is special in that it may have probes outside the domain that are hard to catch (and set to a large negative number). Instead of breaking that workflow for users, we skip the check if there's a DTU spinner sampler.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
