### PR TITLE
Check density bounds upon initialization - for constant density single-phase and two-phase

### DIFF
--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -136,6 +136,11 @@ public:
     //! -- intended for when boundaries rely on intermediate time states (nph)
     void prepare_boundaries();
 
+    //! Check that the bounds of density correspond to the expected values
+    //! -- only applies to two-phase and constant-density single-phase
+    //! -- performed once in post_init, will abort if density is unexpected
+    void density_check();
+
     //! Call fillpatch operator on state variables for all registered PDEs
     void fillpatch_state_fields(
         const amrex::Real time, const FieldState fstate = FieldState::New);

--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -146,6 +146,13 @@ void PDEMgr::prepare_boundaries()
 
 void PDEMgr::density_check()
 {
+    std::string advice(
+        "\nCheck the initial bulk density and the inflow BC density values in "
+        "the input file. When not specified, the default density is 1.0.");
+    std::string advice2(
+        "\nIf this simulation begins from a restart file, confirm that the "
+        "previous density is compatible with the parameters in the input "
+        "file.");
     if (m_sim.repo().field_exists("vof")) {
         amrex::Real rho_l_max{1.0}, rho_l_min{1.0};
         amrex::Real rho_g_max{1.0}, rho_g_min{1.0};
@@ -161,15 +168,15 @@ void PDEMgr::density_check()
                 "from liquid density minimum.\n"
                 "rho_l_max = " +
                 std::to_string(rho_l_max) +
-                ", rho_l_min = " + std::to_string(rho_l_min));
+                ", rho_l_min = " + std::to_string(rho_l_min) + advice2);
         }
         if (std::abs(rho_g_max - rho_g_min) > constants::LOOSE_TOL) {
             amrex::Abort(
                 "Density check failed. Gas density maximum is too different "
                 "from gas density minimum.\n"
                 "rho_g_max = " +
-                std::to_string(rho_g_max) +
-                ", rho_g_min = " + std::to_string(rho_g_min));
+                std::to_string(rho_g_max) + ", rho_g_min = " +
+                std::to_string(rho_g_min) + advice + advice2);
         }
     } else if (m_constant_density) {
         amrex::Real rho_max{1.0}, rho_min{1.0};
@@ -181,7 +188,7 @@ void PDEMgr::density_check()
                 "from minimum for a constant density simulation.\n"
                 "rho_max = " +
                 std::to_string(rho_max) +
-                ", rho_min = " + std::to_string(rho_min));
+                ", rho_min = " + std::to_string(rho_min) + advice + advice2);
         }
     }
 }

--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -158,10 +158,10 @@ void PDEMgr::density_check()
         amrex::Real rho_g_max{1.0}, rho_g_min{1.0};
         diagnostics::get_field_extrema(
             rho_l_max, rho_l_min, m_sim.repo().get_field("density"),
-            m_sim.repo().get_field("vof"), 1.0);
+            m_sim.repo().get_field("vof"), 1.0, 0, 1);
         diagnostics::get_field_extrema(
             rho_g_max, rho_g_min, m_sim.repo().get_field("density"),
-            m_sim.repo().get_field("vof"), 0.0);
+            m_sim.repo().get_field("vof"), 0.0, 0, 1);
         if (std::abs(rho_l_max - rho_l_min) > constants::LOOSE_TOL) {
             amrex::Abort(
                 "Density check failed. Liquid density maximum is too different "
@@ -181,7 +181,7 @@ void PDEMgr::density_check()
     } else if (m_constant_density) {
         amrex::Real rho_max{1.0}, rho_min{1.0};
         diagnostics::get_field_extrema(
-            rho_max, rho_min, m_sim.repo().get_field("density"));
+            rho_max, rho_min, m_sim.repo().get_field("density"), 0, 1);
         if (std::abs(rho_max - rho_min) > constants::LOOSE_TOL) {
             amrex::Abort(
                 "Density check failed. Density maximum is too different "

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -124,6 +124,7 @@ void incflo::init_amr_wind_modules()
     }
 
     m_sim.pde_manager().fillpatch_state_fields(m_time.current_time());
+    m_sim.pde_manager().density_check();
     m_sim.post_manager().post_init_actions();
 }
 

--- a/amr-wind/utilities/diagnostics.H
+++ b/amr-wind/utilities/diagnostics.H
@@ -5,6 +5,34 @@
 
 namespace amr_wind::diagnostics {
 
+void get_mfab_extrema(
+    amrex::Real& mfab_max_val,
+    amrex::Real& mfab_min_val,
+    const amrex::MultiFab& mfab,
+    const int nghost);
+
+void get_mfab_extrema(
+    amrex::Real& mfab_max_val,
+    amrex::Real& mfab_min_val,
+    const amrex::MultiFab& mfab,
+    const amrex::MultiFab& mfab_mask,
+    const amrex::Real mask_val,
+    const int nghost);
+
+void get_field_extrema(
+    amrex::Real& field_max_val,
+    amrex::Real& field_min_val,
+    const amr_wind::Field& field,
+    const bool include_ghosts = true);
+
+void get_field_extrema(
+    amrex::Real& field_max_val,
+    amrex::Real& field_min_val,
+    const amr_wind::Field& field,
+    const amr_wind::Field& field_mask,
+    const amrex::Real mask_val,
+    const bool include_ghosts = true);
+
 amrex::Real get_vel_max(
     const amrex::MultiFab& vel,
     const amrex::iMultiFab& level_mask,

--- a/amr-wind/utilities/diagnostics.H
+++ b/amr-wind/utilities/diagnostics.H
@@ -19,10 +19,17 @@ void get_mfab_extrema(
     const amrex::Real mask_val,
     const int nghost);
 
+void make_mask_multiplier(
+    amrex::MultiFab& mfab,
+    const amrex::MultiFab& mfab_mask,
+    const amrex::Real mask_val,
+    const amrex::Real set_val);
+
 void get_field_extrema(
     amrex::Real& field_max_val,
     amrex::Real& field_min_val,
     const amr_wind::Field& field,
+    const int icomp = -1,
     const bool include_ghosts = true);
 
 void get_field_extrema(
@@ -31,6 +38,7 @@ void get_field_extrema(
     const amr_wind::Field& field,
     const amr_wind::Field& field_mask,
     const amrex::Real mask_val,
+    const int icomp = -1,
     const bool include_ghosts = true);
 
 amrex::Real get_vel_max(

--- a/amr-wind/utilities/diagnostics.H
+++ b/amr-wind/utilities/diagnostics.H
@@ -5,20 +5,6 @@
 
 namespace amr_wind::diagnostics {
 
-void get_mfab_extrema(
-    amrex::Real& mfab_max_val,
-    amrex::Real& mfab_min_val,
-    const amrex::MultiFab& mfab,
-    const int nghost);
-
-void get_mfab_extrema(
-    amrex::Real& mfab_max_val,
-    amrex::Real& mfab_min_val,
-    const amrex::MultiFab& mfab,
-    const amrex::MultiFab& mfab_mask,
-    const amrex::Real mask_val,
-    const int nghost);
-
 void make_mask_multiplier(
     amrex::MultiFab& mfab,
     const amrex::MultiFab& mfab_mask,
@@ -29,7 +15,8 @@ void get_field_extrema(
     amrex::Real& field_max_val,
     amrex::Real& field_min_val,
     const amr_wind::Field& field,
-    const int icomp = -1,
+    const int comp,
+    const int ncomp,
     const bool include_ghosts = true);
 
 void get_field_extrema(
@@ -38,7 +25,8 @@ void get_field_extrema(
     const amr_wind::Field& field,
     const amr_wind::Field& field_mask,
     const amrex::Real mask_val,
-    const int icomp = -1,
+    const int comp,
+    const int ncomp,
     const bool include_ghosts = true);
 
 amrex::Real get_vel_max(

--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -65,7 +65,6 @@ void amr_wind::diagnostics::get_field_extrema(
 {
     const int finest_level = field.repo().num_active_levels() - 1;
 
-    // Initial values
     amrex::Real max_val_lev{constants::LOW_NUM};
     amrex::Real min_val_lev{constants::LARGE_NUM};
     field_max_val = max_val_lev;

--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -99,7 +99,6 @@ void amr_wind::diagnostics::get_field_extrema(
         }
     }
 
-    // Do additional parallelism stuff
     amrex::ParallelDescriptor::ReduceRealMax(field_max_val);
     amrex::ParallelDescriptor::ReduceRealMin(field_min_val);
 }

--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -47,7 +47,6 @@ void amr_wind::diagnostics::get_field_extrema(
         }
     }
 
-    // Do additional parallelism stuff
     amrex::ParallelDescriptor::ReduceRealMax(field_max_val);
     amrex::ParallelDescriptor::ReduceRealMin(field_min_val);
 }

--- a/amr-wind/utilities/diagnostics.cpp
+++ b/amr-wind/utilities/diagnostics.cpp
@@ -32,7 +32,6 @@ void amr_wind::diagnostics::get_field_extrema(
 {
     const int finest_level = field.repo().num_active_levels() - 1;
 
-    // Initial values
     amrex::Real max_val_lev{constants::LOW_NUM};
     amrex::Real min_val_lev{constants::LARGE_NUM};
     field_max_val = max_val_lev;

--- a/test/test_files/abl_multiphase_laminar_input/abl_multiphase_laminar_input.inp
+++ b/test/test_files/abl_multiphase_laminar_input/abl_multiphase_laminar_input.inp
@@ -88,7 +88,7 @@ geometry.prob_hi        =   400.   400.   400.  # Hi corner coordinates
 geometry.is_periodic    =   0   1   0   # Periodicity x y z (0/1)
 # Boundary conditions
 xlo.type = "mass_inflow"
-xlo.density = 1.0
+xlo.density = 1.3223
 xlo.vof = 0.0
 xlo.temperature = 0.0
 xhi.type = "pressure_outflow"

--- a/test/test_files/abl_w2a_terrain/abl_w2a_terrain.inp
+++ b/test/test_files/abl_w2a_terrain/abl_w2a_terrain.inp
@@ -21,7 +21,7 @@ io.outputs = density velocity p ow_levelset ow_velocity
 #               PHYSICS                 #
 #.......................................#
 incflo.gravity        =  0.0  0.0 -9.81  # Gravitational force (3D)
-incflo.density                   = 1.225
+incflo.density                   = 1.0
 transport.model                          = ConstTransport
 transport.viscosity                      = 1e-5
 transport.laminar_prandtl                        = 0.7

--- a/test/test_files/ow_current_bathymetry/ow_current_bathymetry.inp
+++ b/test/test_files/ow_current_bathymetry/ow_current_bathymetry.inp
@@ -60,3 +60,6 @@ ylo.type =     "slip_wall"
 yhi.type =     "slip_wall"
 zlo.type =     "slip_wall"
 zhi.type =     "slip_wall"
+
+# density at inflow condition must match the gas density specified above
+xlo.density = 1.25

--- a/test/test_files/ow_current_bathymetry/ow_current_bathymetry.inp
+++ b/test/test_files/ow_current_bathymetry/ow_current_bathymetry.inp
@@ -62,4 +62,4 @@ zlo.type =     "slip_wall"
 zhi.type =     "slip_wall"
 
 # density at inflow condition must match the gas density specified above
-xlo.density = 1.25
+xlo.density = 1.225

--- a/test/test_files/ow_w2a_nonperiodic/ow_w2a_nonperiodic.inp
+++ b/test/test_files/ow_w2a_nonperiodic/ow_w2a_nonperiodic.inp
@@ -61,3 +61,6 @@ ylo.type =   slip_wall
 yhi.type =   slip_wall
 zlo.type =   slip_wall
 zhi.type =   slip_wall
+
+# density at inflow condition must match the gas density specified above
+xlo.density = 1.25


### PR DESCRIPTION
## Summary

After a fillpatch has been applied in post_init, this density check evaluates the maximum and minimum density in the domain, including the ghost cells. If the simulation is supposed to be constant density, but the minimum and the maximum densities do not match, then the code aborts. This works in the case that the BC density does not match the density from the input file, or the simulation restarts from a checkpoint file with a different density. For two-phase cases, this checks the max and min of the density in cells that are fully liquid or fully gas.

This PR also changes some reg tests because of this issue.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
