### PR TITLE
more advice for initial density check failures

### DIFF
--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -153,6 +153,10 @@ void PDEMgr::density_check()
         "\nIf this simulation begins from a restart file, confirm that the "
         "previous density is compatible with the parameters in the input "
         "file.");
+    std::string advice3(
+        "\nIf specific scalar boundary conditions are specified, make sure "
+        "that vof and density BCs are the same (if Neumann type) or compatible "
+        "(if Dirichlet type).");
     if (m_sim.repo().field_exists("vof")) {
         amrex::Real rho_l_max{1.0}, rho_l_min{1.0};
         amrex::Real rho_g_max{1.0}, rho_g_min{1.0};
@@ -167,8 +171,8 @@ void PDEMgr::density_check()
                 "Density check failed. Liquid density maximum is too different "
                 "from liquid density minimum.\n"
                 "rho_l_max = " +
-                std::to_string(rho_l_max) +
-                ", rho_l_min = " + std::to_string(rho_l_min) + advice2);
+                std::to_string(rho_l_max) + ", rho_l_min = " +
+                std::to_string(rho_l_min) + advice2 + advice3);
         }
         if (std::abs(rho_g_max - rho_g_min) > constants::LOOSE_TOL) {
             amrex::Abort(
@@ -176,7 +180,7 @@ void PDEMgr::density_check()
                 "from gas density minimum.\n"
                 "rho_g_max = " +
                 std::to_string(rho_g_max) + ", rho_g_min = " +
-                std::to_string(rho_g_min) + advice + advice2);
+                std::to_string(rho_g_min) + advice + advice2 + advice3);
         }
     } else if (m_constant_density) {
         amrex::Real rho_max{1.0}, rho_min{1.0};


### PR DESCRIPTION
## Summary

After exawind-driver reg tests failed due to the density_check(), I realized there are other ways things can be set up wrong. This points the user in the right direction if that happens.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): improved error message

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
