### PR TITLE
F/superellipsebody

### DIFF
--- a/amr-wind/physics/CMakeLists.txt
+++ b/amr-wind/physics/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${amr_wind_lib_name}
   ActuatorSourceTagging.cpp
   Intermittency.cpp
   ForestDrag.cpp
+  SuperEllipseBody.cpp
   )
 
 add_subdirectory(multiphase)

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -1,7 +1,7 @@
 #ifndef AMREX_SUPER_ELLIPSE_BODY_H
 #define AMREX_SUPER_ELLIPSE_BODY_H
 
-#include "amr-wind/physics/PhysicsBase.H"
+#include "amr-wind/physics/Physics.H"
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/core/vs/vector_space.H"
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -13,11 +13,20 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
     SuperEllipseBody(CFDSim& sim);
     ~SuperEllipseBody() override = default;
 
-    std::string identifier() const override { return "SuperEllipseBody"; }
+    std::string identifier() { return "SuperEllipseBody"; }
+
+    explicit SuperEllipseBody(CFDSim& sim);
+
+    ~SuperEllipseBody() override = default;
 
     void initialize_fields(int level, const amrex::Geometry& geom) override;
-    void post_init_actions() override;
-    void pre_advance_work() override;
+
+    void pre_init_actions() override {}
+    
+    void post_init_actions() override {};
+
+    void pre_advance_work() override {};
+
     void post_regrid_actions() override;
 
   private:

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -2,7 +2,8 @@
 #define AMREX_SUPER_ELLIPSE_BODY_H
 
 #include "amr-wind/core/Physics.H"
-#include "amr-wind/core/FieldRepo.H"
+#include "amr-wind/core/Field.H"
+#include "amr-wind/CFDSim.H"
 #include "amr-wind/core/vs/vector_space.H"
 
 namespace amr_wind::superellipsebody {
@@ -23,9 +24,12 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
     
     void post_init_actions() override {};
 
+    void post_regrid_actions() override;
+
     void pre_advance_work() override {};
 
-    void post_regrid_actions() override;
+    void post_advance_work() override {}
+
 
   private:
     CFDSim& m_sim;

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -7,7 +7,7 @@
 
 namespace amr_wind::superellipsebody {
 
-class SuperEllipseBody : public PhysicsBase
+class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
 {
   public:
     SuperEllipseBody(CFDSim& sim);
@@ -21,8 +21,6 @@ class SuperEllipseBody : public PhysicsBase
     void post_regrid_actions() override;
 
   private:
-    void convert_waves_to_body_fields();
-
     CFDSim& m_sim;
     FieldRepo& m_repo;
     Mesh& m_mesh;

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -3,6 +3,7 @@
 
 #include "amr-wind/physics/PhysicsBase.H"
 #include "amr-wind/core/FieldRepo.H"
+#include "amr-wind/core/vs/vector_space.H"
 
 namespace amr_wind::superellipsebody {
 
@@ -27,7 +28,12 @@ class SuperEllipseBody : public PhysicsBase
     Mesh& m_mesh;
 
     amrex::IntMultiFab m_body_blank;
-    amrex::IntMultiFab m_body_drag;
+
+    vs::Vector m_loc{0.0, 0.0, 0.0};
+
+    vs::Vector m_dim{1.0, 1.0, 1.0};
+    
+    vs::Tensor m_orient = vs::Tensor::identity();
 
     std::string m_body_file;
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -10,8 +10,6 @@ namespace amr_wind::superellipsebody {
 class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
 {
   public:
-    SuperEllipseBody(CFDSim& sim);
-    ~SuperEllipseBody() override = default;
 
     std::string identifier() { return "SuperEllipseBody"; }
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -29,10 +29,11 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
 
   private:
     CFDSim& m_sim;
-    FieldRepo& m_repo;
-    Mesh& m_mesh;
+    const FieldRepo& m_repo;
+    const amrex::AmrCore& m_mesh;
 
-    amrex::IntMultiFab m_body_blank;
+    //! Blanking field for SuperEllipseBody
+    IntField&  m_body_blank;
 
     vs::Vector m_loc{0.0, 0.0, 0.0};
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -36,6 +36,7 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
 
     //! Blanking field for SuperEllipseBody
     IntField&  m_body_blank;
+    IntField&  m_terrain_drag;
 
     vs::Vector m_loc{0.0, 0.0, 0.0};
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -37,6 +37,7 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
     //! Blanking field for SuperEllipseBody
     IntField&  m_body_blank;
     IntField&  m_terrain_drag;
+    Field& m_terrainz0;    
 
     vs::Vector m_loc{0.0, 0.0, 0.0};
 

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -1,5 +1,5 @@
-#ifndef AMREX_SUPER_ELLIPSE_BODY_H
-#define AMREX_SUPER_ELLIPSE_BODY_H
+#ifndef SuperEllipseBody_H
+#define SuperEllipseBody_H
 
 #include "amr-wind/core/Physics.H"
 #include "amr-wind/core/Field.H"
@@ -11,8 +11,7 @@ namespace amr_wind::superellipsebody {
 class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
 {
   public:
-
-    std::string identifier() { return "SuperEllipseBody"; }
+    static std::string identifier() { return "SuperEllipseBody"; }
 
     explicit SuperEllipseBody(CFDSim& sim);
 
@@ -29,7 +28,6 @@ class SuperEllipseBody : public Physics::Register<SuperEllipseBody>
     void pre_advance_work() override {};
 
     void post_advance_work() override {}
-
 
   private:
     CFDSim& m_sim;

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -28,17 +28,9 @@ class SuperEllipseBody : public PhysicsBase
 
     amrex::IntMultiFab m_body_blank;
     amrex::IntMultiFab m_body_drag;
-    Field m_bodyz0;
-    Field m_body_height;
 
     std::string m_body_file;
-    std::string m_roughness_file;
 
-    bool m_body_is_waves{false};
-    Field const* m_wave_volume_fraction{nullptr};
-    Field const* m_wave_negative_elevation{nullptr};
-    std::string m_wave_volume_fraction_name{"vof"};
-    std::string m_wave_negative_elevation_name{"wave_neg_elev"};
 };
 
 } // namespace amr_wind::superellipsebody

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -1,0 +1,46 @@
+#ifndef AMREX_SUPER_ELLIPSE_BODY_H
+#define AMREX_SUPER_ELLIPSE_BODY_H
+
+#include "amr-wind/physics/PhysicsBase.H"
+#include "amr-wind/core/FieldRepo.H"
+
+namespace amr_wind::superellipsebody {
+
+class SuperEllipseBody : public PhysicsBase
+{
+  public:
+    SuperEllipseBody(CFDSim& sim);
+    ~SuperEllipseBody() override = default;
+
+    std::string identifier() const override { return "SuperEllipseBody"; }
+
+    void initialize_fields(int level, const amrex::Geometry& geom) override;
+    void post_init_actions() override;
+    void pre_advance_work() override;
+    void post_regrid_actions() override;
+
+  private:
+    void convert_waves_to_body_fields();
+
+    CFDSim& m_sim;
+    FieldRepo& m_repo;
+    Mesh& m_mesh;
+
+    amrex::IntMultiFab m_body_blank;
+    amrex::IntMultiFab m_body_drag;
+    Field m_bodyz0;
+    Field m_body_height;
+
+    std::string m_body_file;
+    std::string m_roughness_file;
+
+    bool m_body_is_waves{false};
+    Field const* m_wave_volume_fraction{nullptr};
+    Field const* m_wave_negative_elevation{nullptr};
+    std::string m_wave_volume_fraction_name{"vof"};
+    std::string m_wave_negative_elevation_name{"wave_neg_elev"};
+};
+
+} // namespace amr_wind::superellipsebody
+
+#endif

--- a/amr-wind/physics/SuperEllipseBody.H
+++ b/amr-wind/physics/SuperEllipseBody.H
@@ -1,7 +1,7 @@
 #ifndef AMREX_SUPER_ELLIPSE_BODY_H
 #define AMREX_SUPER_ELLIPSE_BODY_H
 
-#include "amr-wind/physics/Physics.H"
+#include "amr-wind/core/Physics.H"
 #include "amr-wind/core/FieldRepo.H"
 #include "amr-wind/core/vs/vector_space.H"
 

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -31,6 +31,7 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     , m_repo(sim.repo())
     , m_mesh(sim.mesh())
     , m_body_blank(sim.repo().declare_int_field("terrain_blank", 1, 1, 1))
+    , m_terrain_drag(sim.repo().declare_int_field("terrain_drag", 1, 1, 1))
 {
 
     amrex::ParmParse pp(identifier());
@@ -38,7 +39,10 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     m_dim = parse_vector(pp, "dimensions");
 
     m_sim.io_manager().register_output_int_var("terrain_blank");
+    m_sim.io_manager().register_output_int_var("terrain_drag");
     m_body_blank.setVal(0.0);
+    m_terrain_drag.setVal(0.0);
+
 }
 
 void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -1,0 +1,230 @@
+#include "amr-wind/physics/SuperEllipseBody.H"
+#include "amr-wind/CFDSim.H"
+#include "AMReX_iMultiFab.H"
+#include "AMReX_MultiFabUtil.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_ParReduce.H"
+#include "amr-wind/utilities/trig_ops.H"
+#include "amr-wind/utilities/IOManager.H"
+#include "amr-wind/utilities/io_utils.H"
+#include "amr-wind/utilities/linear_interpolation.H"
+
+namespace amr_wind::superellipsebody {
+
+namespace {} // namespace
+
+SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
+    : m_sim(sim)
+    , m_repo(sim.repo())
+    , m_mesh(sim.mesh())
+    , m_body_blank(sim.repo().declare_int_field("body_blank", 1, 1, 1))
+    , m_body_drag(sim.repo().declare_int_field("body_drag", 1, 1, 1))
+    , m_bodyz0(sim.repo().declare_field("bodyz0", 1, 1, 1))
+    , m_body_height(sim.repo().declare_field("body_height", 1, 1, 1))
+{
+
+    m_body_is_waves = sim.physics_manager().contains("OceanWaves") &&
+                         !sim.repo().field_exists("vof");
+
+    if (!m_body_is_waves) {
+        amrex::ParmParse pp(identifier());
+        pp.query("body_file", m_body_file);
+        pp.query("roughness_file", m_roughness_file);
+    } else {
+        m_wave_volume_fraction = &m_repo.get_field(m_wave_volume_fraction_name);
+        m_wave_negative_elevation =
+            &m_repo.get_field(m_wave_negative_elevation_name);
+    }
+
+    m_sim.io_manager().register_output_int_var("body_drag");
+    m_sim.io_manager().register_output_int_var("body_blank");
+    m_sim.io_manager().register_io_var("bodyz0");
+    m_sim.io_manager().register_io_var("body_height");
+
+    m_body_blank.setVal(0.0);
+    m_body_drag.setVal(0.0);
+    m_bodyz0.set_default_fillpatch_bc(m_sim.time());
+    m_body_height.set_default_fillpatch_bc(m_sim.time());
+}
+
+void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
+{
+    if (m_body_is_waves) {
+        return;
+    }
+
+    BL_PROFILE("amr-wind::" + this->identifier() + "::initialize_fields");
+
+    //! Reading the Body Coordinates from  file
+    amrex::Vector<amrex::Real> xbody;
+    amrex::Vector<amrex::Real> ybody;
+    amrex::Vector<amrex::Real> zbody;
+    ioutils::read_flat_grid_file(m_body_file, xbody, ybody, zbody);
+
+    // No checks for the file as it is optional currently
+    amrex::Vector<amrex::Real> xrough;
+    amrex::Vector<amrex::Real> yrough;
+    amrex::Vector<amrex::Real> z0rough;
+    std::ifstream file(m_roughness_file, std::ios::in);
+    if (file.good()) {
+        ioutils::read_flat_grid_file(m_roughness_file, xrough, yrough, z0rough);
+    }
+    file.close();
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    auto& blanking = m_body_blank(level);
+    auto& bodyz0 = m_bodyz0(level);
+    auto& body_height = m_body_height(level);
+    auto& drag = m_body_drag(level);
+    const auto xbody_size = xbody.size();
+    const auto ybody_size = ybody.size();
+    const auto zbody_size = zbody.size();
+    amrex::Gpu::DeviceVector<amrex::Real> d_xbody(xbody_size);
+    amrex::Gpu::DeviceVector<amrex::Real> d_ybody(ybody_size);
+    amrex::Gpu::DeviceVector<amrex::Real> d_zbody(zbody_size);
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, xbody.begin(), xbody.end(),
+        d_xbody.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, ybody.begin(), ybody.end(),
+        d_ybody.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, zbody.begin(), zbody.end(),
+        d_zbody.begin());
+    const auto* xbody_ptr = d_xbody.data();
+    const auto* ybody_ptr = d_ybody.data();
+    const auto* zbody_ptr = d_zbody.data();
+    // Copy Roughness to gpu
+    const auto xrough_size = xrough.size();
+    const auto yrough_size = yrough.size();
+    const auto z0rough_size = z0rough.size();
+    amrex::Gpu::DeviceVector<amrex::Real> d_xrough(xrough_size);
+    amrex::Gpu::DeviceVector<amrex::Real> d_yrough(yrough_size);
+    amrex::Gpu::DeviceVector<amrex::Real> d_z0rough(z0rough_size);
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, xrough.begin(), xrough.end(),
+        d_xrough.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, yrough.begin(), yrough.end(),
+        d_yrough.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, z0rough.begin(), z0rough.end(),
+        d_z0rough.begin());
+    const auto* xrough_ptr = d_xrough.data();
+    const auto* yrough_ptr = d_yrough.data();
+    const auto* z0rough_ptr = d_z0rough.data();
+    auto levelBlanking = blanking.arrays();
+    auto levelDrag = drag.arrays();
+    auto levelz0 = bodyz0.arrays();
+    auto levelheight = body_height.arrays();
+    amrex::ParallelFor(
+        blanking, m_body_blank.num_grow(),
+        [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+            const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+            const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+            const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+            const amrex::Real bodyHt = interp::bilinear(
+                xbody_ptr, xbody_ptr + xbody_size, ybody_ptr,
+                ybody_ptr + ybody_size, zbody_ptr, x, y);
+            levelBlanking[nbx](i, j, k, 0) =
+                static_cast<int>((z <= bodyHt) && (z > prob_lo[2]));
+            levelheight[nbx](i, j, k, 0) = bodyHt;
+
+            amrex::Real roughz0 = 0.1;
+            if (xrough_size > 0) {
+                roughz0 = interp::bilinear(
+                    xrough_ptr, xrough_ptr + xrough_size, yrough_ptr,
+                    yrough_ptr + yrough_size, z0rough_ptr, x, y);
+            }
+            levelz0[nbx](i, j, k, 0) = roughz0;
+        });
+    amrex::Gpu::streamSynchronize();
+    amrex::ParallelFor(
+        blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+            if ((levelBlanking[nbx](i, j, k, 0) == 0) && (k > 0) &&
+                (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
+                levelDrag[nbx](i, j, k, 0) = 1;
+            } else {
+                levelDrag[nbx](i, j, k, 0) = 0;
+            }
+        });
+    amrex::Gpu::streamSynchronize();
+}
+
+void SuperEllipseBody::post_init_actions()
+{
+    if (!m_body_is_waves) {
+        return;
+    }
+    BL_PROFILE("amr-wind::" + this->identifier() + "::post_init_actions");
+    convert_waves_to_body_fields();
+}
+
+void SuperEllipseBody::pre_advance_work()
+{
+    if (!m_body_is_waves) {
+        return;
+    }
+    BL_PROFILE("amr-wind::" + this->identifier() + "::pre_advance_work");
+    convert_waves_to_body_fields();
+}
+
+void SuperEllipseBody::post_regrid_actions()
+{
+    if (m_body_is_waves) {
+        convert_waves_to_body_fields();
+    } else {
+        const int nlevels = m_sim.repo().num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            initialize_fields(lev, m_sim.repo().mesh().Geom(lev));
+        }
+    }
+}
+
+void SuperEllipseBody::convert_waves_to_body_fields()
+{
+    const int nlevels = m_sim.repo().num_active_levels();
+    // Uniform, low roughness for waves
+    m_bodyz0.setVal(1e-4);
+    for (int level = 0; level < nlevels; ++level) {
+        const auto geom = m_sim.repo().mesh().Geom(level);
+        const auto& dx = geom.CellSizeArray();
+        const auto& prob_lo = geom.ProbLoArray();
+        auto& blanking = m_body_blank(level);
+        auto& body_height = m_body_height(level);
+        auto& drag = m_body_drag(level);
+
+        auto levelBlanking = blanking.arrays();
+        auto levelDrag = drag.arrays();
+        auto levelHeight = body_height.arrays();
+
+        const auto negative_wave_elevation =
+            (*m_wave_negative_elevation)(level).const_arrays();
+        const auto wave_vol_frac =
+            (*m_wave_volume_fraction)(level).const_arrays();
+
+        // Get body blanking from ocean waves fields
+        amrex::ParallelFor(
+            blanking, m_body_blank.num_grow(),
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+                const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+                levelBlanking[nbx](i, j, k, 0) = static_cast<int>(
+                    (wave_vol_frac[nbx](i, j, k) >= 0.5) && (z > prob_lo[2]));
+                levelHeight[nbx](i, j, k, 0) =
+                    -negative_wave_elevation[nbx](i, j, k);
+            });
+        amrex::ParallelFor(
+            blanking,
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+                if ((levelBlanking[nbx](i, j, k, 0) == 0) && (k > 0) &&
+                    (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
+                    levelDrag[nbx](i, j, k, 0) = 1;
+                } else {
+                    levelDrag[nbx](i, j, k, 0) = 0;
+                }
+            });
+    }
+}
+
+} // namespace amr_wind::superellipsebody

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -32,6 +32,7 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     , m_mesh(sim.mesh())
     , m_body_blank(sim.repo().declare_int_field("terrain_blank", 1, 1, 1))
     , m_terrain_drag(sim.repo().declare_int_field("terrain_drag", 1, 1, 1))
+    , m_terrainz0(sim.repo().declare_field("terrainz0", 1, 1, 1))
 {
 
     amrex::ParmParse pp(identifier());
@@ -40,8 +41,11 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
 
     m_sim.io_manager().register_output_int_var("terrain_blank");
     m_sim.io_manager().register_output_int_var("terrain_drag");
+    m_sim.io_manager().register_io_var("terrainz0");
     m_body_blank.setVal(0.0);
     m_terrain_drag.setVal(0.0);
+    m_terrainz0.setVal(1e-4);
+    m_terrainz0.set_default_fillpatch_bc(m_sim.time());
 
 }
 

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -19,104 +19,35 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     , m_mesh(sim.mesh())
     , m_body_blank(sim.repo().declare_int_field("body_blank", 1, 1, 1))
     , m_body_drag(sim.repo().declare_int_field("body_drag", 1, 1, 1))
-    , m_bodyz0(sim.repo().declare_field("bodyz0", 1, 1, 1))
-    , m_body_height(sim.repo().declare_field("body_height", 1, 1, 1))
 {
 
-    m_body_is_waves = sim.physics_manager().contains("OceanWaves") &&
-                         !sim.repo().field_exists("vof");
-
-    if (!m_body_is_waves) {
         amrex::ParmParse pp(identifier());
         pp.query("body_file", m_body_file);
-        pp.query("roughness_file", m_roughness_file);
-    } else {
-        m_wave_volume_fraction = &m_repo.get_field(m_wave_volume_fraction_name);
-        m_wave_negative_elevation =
-            &m_repo.get_field(m_wave_negative_elevation_name);
-    }
 
     m_sim.io_manager().register_output_int_var("body_drag");
     m_sim.io_manager().register_output_int_var("body_blank");
-    m_sim.io_manager().register_io_var("bodyz0");
-    m_sim.io_manager().register_io_var("body_height");
 
     m_body_blank.setVal(0.0);
     m_body_drag.setVal(0.0);
-    m_bodyz0.set_default_fillpatch_bc(m_sim.time());
-    m_body_height.set_default_fillpatch_bc(m_sim.time());
 }
 
 void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
 {
-    if (m_body_is_waves) {
-        return;
-    }
 
     BL_PROFILE("amr-wind::" + this->identifier() + "::initialize_fields");
 
-    //! Reading the Body Coordinates from  file
-    amrex::Vector<amrex::Real> xbody;
-    amrex::Vector<amrex::Real> ybody;
-    amrex::Vector<amrex::Real> zbody;
-    ioutils::read_flat_grid_file(m_body_file, xbody, ybody, zbody);
-
-    // No checks for the file as it is optional currently
-    amrex::Vector<amrex::Real> xrough;
-    amrex::Vector<amrex::Real> yrough;
-    amrex::Vector<amrex::Real> z0rough;
-    std::ifstream file(m_roughness_file, std::ios::in);
+    std::ifstream file(m_body_file, std::ios::in);
     if (file.good()) {
-        ioutils::read_flat_grid_file(m_roughness_file, xrough, yrough, z0rough);
+        // Read coordinates and orientation from body file
     }
     file.close();
 
     const auto& dx = geom.CellSizeArray();
     const auto& prob_lo = geom.ProbLoArray();
     auto& blanking = m_body_blank(level);
-    auto& bodyz0 = m_bodyz0(level);
-    auto& body_height = m_body_height(level);
     auto& drag = m_body_drag(level);
-    const auto xbody_size = xbody.size();
-    const auto ybody_size = ybody.size();
-    const auto zbody_size = zbody.size();
-    amrex::Gpu::DeviceVector<amrex::Real> d_xbody(xbody_size);
-    amrex::Gpu::DeviceVector<amrex::Real> d_ybody(ybody_size);
-    amrex::Gpu::DeviceVector<amrex::Real> d_zbody(zbody_size);
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, xbody.begin(), xbody.end(),
-        d_xbody.begin());
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, ybody.begin(), ybody.end(),
-        d_ybody.begin());
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, zbody.begin(), zbody.end(),
-        d_zbody.begin());
-    const auto* xbody_ptr = d_xbody.data();
-    const auto* ybody_ptr = d_ybody.data();
-    const auto* zbody_ptr = d_zbody.data();
-    // Copy Roughness to gpu
-    const auto xrough_size = xrough.size();
-    const auto yrough_size = yrough.size();
-    const auto z0rough_size = z0rough.size();
-    amrex::Gpu::DeviceVector<amrex::Real> d_xrough(xrough_size);
-    amrex::Gpu::DeviceVector<amrex::Real> d_yrough(yrough_size);
-    amrex::Gpu::DeviceVector<amrex::Real> d_z0rough(z0rough_size);
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, xrough.begin(), xrough.end(),
-        d_xrough.begin());
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, yrough.begin(), yrough.end(),
-        d_yrough.begin());
-    amrex::Gpu::copy(
-        amrex::Gpu::hostToDevice, z0rough.begin(), z0rough.end(),
-        d_z0rough.begin());
-    const auto* xrough_ptr = d_xrough.data();
-    const auto* yrough_ptr = d_yrough.data();
-    const auto* z0rough_ptr = d_z0rough.data();
     auto levelBlanking = blanking.arrays();
     auto levelDrag = drag.arrays();
-    auto levelz0 = bodyz0.arrays();
     auto levelheight = body_height.arrays();
     amrex::ParallelFor(
         blanking, m_body_blank.num_grow(),
@@ -124,20 +55,9 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
             const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
             const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
-            const amrex::Real bodyHt = interp::bilinear(
-                xbody_ptr, xbody_ptr + xbody_size, ybody_ptr,
-                ybody_ptr + ybody_size, zbody_ptr, x, y);
-            levelBlanking[nbx](i, j, k, 0) =
-                static_cast<int>((z <= bodyHt) && (z > prob_lo[2]));
-            levelheight[nbx](i, j, k, 0) = bodyHt;
 
-            amrex::Real roughz0 = 0.1;
-            if (xrough_size > 0) {
-                roughz0 = interp::bilinear(
-                    xrough_ptr, xrough_ptr + xrough_size, yrough_ptr,
-                    yrough_ptr + yrough_size, z0rough_ptr, x, y);
-            }
-            levelz0[nbx](i, j, k, 0) = roughz0;
+            // Determine whether point in body
+            levelBlanking[nbx](i, j, k, 0) = 1;
         });
     amrex::Gpu::streamSynchronize();
     amrex::ParallelFor(
@@ -154,35 +74,25 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
 
 void SuperEllipseBody::post_init_actions()
 {
-    if (!m_body_is_waves) {
-        return;
-    }
     BL_PROFILE("amr-wind::" + this->identifier() + "::post_init_actions");
-    convert_waves_to_body_fields();
+    compute_body_fields();
 }
 
 void SuperEllipseBody::pre_advance_work()
 {
-    if (!m_body_is_waves) {
-        return;
-    }
     BL_PROFILE("amr-wind::" + this->identifier() + "::pre_advance_work");
-    convert_waves_to_body_fields();
+    compute_body_fields();
 }
 
 void SuperEllipseBody::post_regrid_actions()
 {
-    if (m_body_is_waves) {
-        convert_waves_to_body_fields();
-    } else {
-        const int nlevels = m_sim.repo().num_active_levels();
-        for (int lev = 0; lev < nlevels; ++lev) {
-            initialize_fields(lev, m_sim.repo().mesh().Geom(lev));
-        }
+    const int nlevels = m_sim.repo().num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        initialize_fields(lev, m_sim.repo().mesh().Geom(lev));
     }
 }
 
-void SuperEllipseBody::convert_waves_to_body_fields()
+void SuperEllipseBody::compute_body_fields()
 {
     const int nlevels = m_sim.repo().num_active_levels();
     // Uniform, low roughness for waves
@@ -208,11 +118,12 @@ void SuperEllipseBody::convert_waves_to_body_fields()
         amrex::ParallelFor(
             blanking, m_body_blank.num_grow(),
             [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+                const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];                
                 const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
-                levelBlanking[nbx](i, j, k, 0) = static_cast<int>(
-                    (wave_vol_frac[nbx](i, j, k) >= 0.5) && (z > prob_lo[2]));
-                levelHeight[nbx](i, j, k, 0) =
-                    -negative_wave_elevation[nbx](i, j, k);
+                //Determine whether a point inside the superellipsebody
+                levelBlanking[nbx](i, j, k, 0) = 1;
+
             });
         amrex::ParallelFor(
             blanking,

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -78,7 +78,7 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
 
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
+            levelBlanking[nbx](i, j, k, 0) = 1; // static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
         });
     amrex::Gpu::streamSynchronize();
 }

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -78,7 +78,7 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
 
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( (xtransform.x/dim.x)^6 + (xtransform.y/dim.y)^6 + (xtransform.z/dim.z)^6 - 1.0 );
+            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( (xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0 );
         });
     amrex::Gpu::streamSynchronize();
 }

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -30,7 +30,7 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     : m_sim(sim)
     , m_repo(sim.repo())
     , m_mesh(sim.mesh())
-    , m_body_blank(sim.repo().declare_int_field("body_blank", 1, 1, 1))
+    , m_body_blank(sim.repo().declare_int_field("terrain_blank", 1, 1, 1))
 {
 
         amrex::ParmParse pp(identifier());

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -73,11 +73,11 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
             const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
-            // Transform to orientation inside 
+            // Transform to orientation of box
             vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
 
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
+            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( ( std::pow( xtransform.x() / dim.x(), 6 ) + std::pow( xtransform.y() / dim.y(), 6 ) + std::pow( xtransform.z() / dim.z(), 6) - 1.0) < 0.0 );
         });
     amrex::Gpu::streamSynchronize();
 }

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -77,7 +77,7 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
 
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = 1; // static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
+            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
         });
     amrex::Gpu::streamSynchronize();
 }

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -33,12 +33,11 @@ SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     , m_body_blank(sim.repo().declare_int_field("terrain_blank", 1, 1, 1))
 {
 
-        amrex::ParmParse pp(identifier());
-        pp.query("body_file", m_body_file);
-        m_dim = parse_vector(pp, "dimensions");
+    amrex::ParmParse pp(identifier());
+    pp.query("body_file", m_body_file);
+    m_dim = parse_vector(pp, "dimensions");
 
-    m_sim.io_manager().register_output_int_var("body_drag");
-
+    m_sim.io_manager().register_output_int_var("terrain_blank");
     m_body_blank.setVal(0.0);
 }
 

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -83,16 +83,6 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
     amrex::Gpu::streamSynchronize();
 }
 
-void SuperEllipseBody::post_init_actions()
-{
-    BL_PROFILE("amr-wind::" + this->identifier() + "::post_init_actions");
-}
-
-void SuperEllipseBody::pre_advance_work()
-{
-    BL_PROFILE("amr-wind::" + this->identifier() + "::pre_advance_work");
-}
-
 void SuperEllipseBody::post_regrid_actions()
 {
 

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -11,24 +11,35 @@
 
 namespace amr_wind::superellipsebody {
 
-namespace {} // namespace
+namespace {
+
+//! Utility function to parse inputs and return a vector instance
+inline vs::Vector parse_vector(amrex::ParmParse& pp, const std::string& key)
+{
+    amrex::Vector<amrex::Real> tmp;
+    pp.getarr(key.data(), tmp);
+    AMREX_ALWAYS_ASSERT(tmp.size() == 3U);
+
+    return vs::Vector{tmp[0], tmp[1], tmp[2]};
+}
+
+
+} // namespace
 
 SuperEllipseBody::SuperEllipseBody(CFDSim& sim)
     : m_sim(sim)
     , m_repo(sim.repo())
     , m_mesh(sim.mesh())
     , m_body_blank(sim.repo().declare_int_field("body_blank", 1, 1, 1))
-    , m_body_drag(sim.repo().declare_int_field("body_drag", 1, 1, 1))
 {
 
         amrex::ParmParse pp(identifier());
         pp.query("body_file", m_body_file);
+        m_dim = parse_vector(pp, "dimensions");
 
     m_sim.io_manager().register_output_int_var("body_drag");
-    m_sim.io_manager().register_output_int_var("body_blank");
 
     m_body_blank.setVal(0.0);
-    m_body_drag.setVal(0.0);
 }
 
 void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
@@ -39,16 +50,23 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
     std::ifstream file(m_body_file, std::ios::in);
     if (file.good()) {
         // Read coordinates and orientation from body file
+        // Just read 12 numbers one after the other. First 3 represent location, next 9 represent orientation
+        file >> m_loc[0] >> m_loc[1] >> m_loc[2];
+        file >> m_orient.xx() >> m_orient.xy() >> m_orient.xz() >> m_orient.yx()
+             >> m_orient.yy() >> m_orient.yz() >> m_orient.zx() >> m_orient.zy()
+             >> m_orient.zz();
     }
     file.close();
 
     const auto& dx = geom.CellSizeArray();
     const auto& prob_lo = geom.ProbLoArray();
     auto& blanking = m_body_blank(level);
-    auto& drag = m_body_drag(level);
     auto levelBlanking = blanking.arrays();
-    auto levelDrag = drag.arrays();
-    auto levelheight = body_height.arrays();
+
+    vs::Vector dim = m_dim;
+    vs::Tensor orient = m_orient;
+    vs::Vector loc = m_loc;
+
     amrex::ParallelFor(
         blanking, m_body_blank.num_grow(),
         [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
@@ -56,18 +74,11 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
             const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
 
+            // Transform to orientation inside 
+            vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
+
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = 1;
-        });
-    amrex::Gpu::streamSynchronize();
-    amrex::ParallelFor(
-        blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-            if ((levelBlanking[nbx](i, j, k, 0) == 0) && (k > 0) &&
-                (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
-                levelDrag[nbx](i, j, k, 0) = 1;
-            } else {
-                levelDrag[nbx](i, j, k, 0) = 0;
-            }
+            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( (xtransform.x/dim.x)^6 + (xtransform.y/dim.y)^6 + (xtransform.z/dim.z)^6 - 1.0 );
         });
     amrex::Gpu::streamSynchronize();
 }
@@ -75,66 +86,19 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
 void SuperEllipseBody::post_init_actions()
 {
     BL_PROFILE("amr-wind::" + this->identifier() + "::post_init_actions");
-    compute_body_fields();
 }
 
 void SuperEllipseBody::pre_advance_work()
 {
     BL_PROFILE("amr-wind::" + this->identifier() + "::pre_advance_work");
-    compute_body_fields();
 }
 
 void SuperEllipseBody::post_regrid_actions()
 {
+
     const int nlevels = m_sim.repo().num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
         initialize_fields(lev, m_sim.repo().mesh().Geom(lev));
-    }
-}
-
-void SuperEllipseBody::compute_body_fields()
-{
-    const int nlevels = m_sim.repo().num_active_levels();
-    // Uniform, low roughness for waves
-    m_bodyz0.setVal(1e-4);
-    for (int level = 0; level < nlevels; ++level) {
-        const auto geom = m_sim.repo().mesh().Geom(level);
-        const auto& dx = geom.CellSizeArray();
-        const auto& prob_lo = geom.ProbLoArray();
-        auto& blanking = m_body_blank(level);
-        auto& body_height = m_body_height(level);
-        auto& drag = m_body_drag(level);
-
-        auto levelBlanking = blanking.arrays();
-        auto levelDrag = drag.arrays();
-        auto levelHeight = body_height.arrays();
-
-        const auto negative_wave_elevation =
-            (*m_wave_negative_elevation)(level).const_arrays();
-        const auto wave_vol_frac =
-            (*m_wave_volume_fraction)(level).const_arrays();
-
-        // Get body blanking from ocean waves fields
-        amrex::ParallelFor(
-            blanking, m_body_blank.num_grow(),
-            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-                const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
-                const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];                
-                const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
-                //Determine whether a point inside the superellipsebody
-                levelBlanking[nbx](i, j, k, 0) = 1;
-
-            });
-        amrex::ParallelFor(
-            blanking,
-            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-                if ((levelBlanking[nbx](i, j, k, 0) == 0) && (k > 0) &&
-                    (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
-                    levelDrag[nbx](i, j, k, 0) = 1;
-                } else {
-                    levelDrag[nbx](i, j, k, 0) = 0;
-                }
-            });
     }
 }
 

--- a/amr-wind/physics/SuperEllipseBody.cpp
+++ b/amr-wind/physics/SuperEllipseBody.cpp
@@ -78,7 +78,7 @@ void SuperEllipseBody::initialize_fields(int level, const amrex::Geometry& geom)
             vs::Vector xtransform = orient & (vs::Vector(x, y, z) - loc);
 
             // Determine whether point in body
-            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( (xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0 );
+            levelBlanking[nbx](i, j, k, 0) = static_cast<int>( ((xtransform.x()/dim.x())^6 + (xtransform.y()/dim.y())^6 + (xtransform.z()/dim.z())^6 - 1.0) < 0 );
         });
     amrex::Gpu::streamSynchronize();
 }


### PR DESCRIPTION
## Summary

This is a draft pull request meant to initiate a discussion on if and how best to integrate this capability into AMR-Wind. Creates a capability to stop the flow inside a super ellipse defined by 

$$
\left (\frac{(x-x_{loc})}{x_c} \right )^6 + \left (\frac{(y-y_{loc})}{y_c} \right)^6 + \left (\frac{(z-z_{loc})}{z_c} \right)^6 = 1.
$$

Uses the terrain blanking approach and updates the same field name for lack of a better solution. Thanks to @hgopalan for help with this feature.

## Pull request type

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

This image shows the feature in action.

![image](https://github.com/user-attachments/assets/076072be-f607-4b7a-a81e-753ef8af4fd5)


Issue Number: <!-- Note related issues -->
