### PR TITLE
avoid dividing by 0 for 2D HOS-NWT inputs

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -354,7 +354,8 @@ struct ReadInputsOp<W2AWaves>
             wdata.n1_sp = wdata.r_rmodes.get_second_spatial_dimension();
             // Get resolution (slightly different for NWT)
             wdata.dx0 = wdata.r_rmodes.get_xlen() / (wdata.n0_sp - 1);
-            wdata.dx1 = wdata.r_rmodes.get_ylen() / (wdata.n1_sp - 1);
+            wdata.dx1 =
+                wdata.r_rmodes.get_ylen() / amrex::max(wdata.n1_sp - 1, 1);
             // Get depth
             depth = wdata.r_rmodes.get_depth();
             // Get dimensional length


### PR DESCRIPTION
## Summary

dx1 doesn't actually get used for 2D HOS-NWT cases, but without this fix, dividing by 0 will happen.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: closes #1556
