### PR TITLE
Document IO compression

### DIFF
--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -5,7 +5,7 @@ Compressing field output files
 
 When writing out field output files, sometimes called plot files or plt files, it is possible to output the files with HDF5 and compress these with ZFP. To enable this capability, AMR-Wind must be compiled with ``AMR_WIND_ENABLE_HDF5`` and ``AMR_WIND_ENABLE_HDF5_ZFP``. If using a spack installation of AMR-Wind, simply add ``+hdf5`` to the spec to enable these compression features. The input file :ref:`documentation <inputs_io>` documents the input options to output these files. The `AMReX HDF5 documentation <https://amrex-codes.github.io/amrex/docs_html/IO.html#hdf5-plotfile-compression>`_ further documents valid options.
 
-While generating the compressed files is straightforward, it takes a little work to read these into traditional visualization softwares (e.g., Paraview, Visit). However, the HDF5 files are easier to open with Python than traditional AMReX plotfiles.
+While generating the compressed files is straightforward, it takes a little work to read these into traditional visualization software (e.g., Paraview, Visit). However, the HDF5 files are easier to open with Python than traditional AMReX plotfiles.
 
 ParaView
 --------

--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -5,7 +5,7 @@ Compressing field output files
 
 When writing out field output files, sometimes called plot files or plt files, it is possible to output the files with HDF5 and compress these with ZFP. To enable this capability, AMR-Wind must be compiled with ``AMR_WIND_ENABLE_HDF5`` and ``AMR_WIND_ENABLE_HDF5_ZFP``. If using a spack installation of AMR-Wind, simply add ``+hdf5`` to the spec to enable these compression features. The input file :ref:`documentation <inputs_io>` documents the input options to output these files. The `AMReX HDF5 documentation <https://amrex-codes.github.io/amrex/docs_html/IO.html#hdf5-plotfile-compression>`_ further documents valid options.
 
-While generating the compressed files is straightforward, it takes a little work to read these in various post-processing utilities.
+While generating the compressed files is straightforward, it takes a little work to read these into traditional visualization softwares (e.g., Paraview, Visit). However, the HDF5 files are easier to open with Python than traditional AMReX plotfiles.
 
 ParaView
 --------
@@ -18,6 +18,17 @@ To read ZFP compressed HDF5 files into ParaView, ParaView must have the environm
     $ paraview
 
 Then the user can load the file as usual with the ``VisitChomboReader``.
+
+Convert to numpy (npy) files
+----------------------------
+
+To convert the HDF5 files to plain numpy data files, we have provided a script to do so in `tools` directory of this repository. It requires the ``h5py`` and ``hdf5plugin`` Python packages.
+
+.. code-block:: console
+
+    $ python convert_amrex_hdf5_plotfile.py -f plt117501-hdf5-zfp-0.0000001
+
+The resulting file can then be opened in Python with numpy.
 
 yt
 --

--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -1,0 +1,31 @@
+.. _compression:
+
+Compressing field output files
+==============================
+
+When writing out field output files, sometimes called plot files or plt files, it is possible to output the files with HDF5 and compress these with ZFP. To enable this capability, AMR-Wind must be compiled with ``AMR_WIND_ENABLE_HDF5`` and ``AMR_WIND_ENABLE_HDF5_ZFP``. The input file :ref:`documentation <inputs_io>` documents the input options to output these files. The `AMReX HDF5 documentation <https://amrex-codes.github.io/amrex/docs_html/IO.html#hdf5-plotfile-compression>`_ further documents valid options.
+
+While generating the compressed files is straightforward, it takes a little work to read these in various post-processing utilities.
+
+ParaView
+--------
+
+To read ZFP compressed HDF5 files into ParaView, ParaView must have the environment variable ``HDF5_PLUGIN_PATH`` populated and pointing to the HDF5 ZFP plugin location. Within a spack environment with the ``h5z-zfp`` package installed:
+
+.. code-block:: console
+
+    $ export HDF5_PLUGIN_PATH=$(spack location -i h5z-zfp)/plugin
+    $ paraview
+
+Then the user can load the file as usual.
+
+yt
+--
+
+To read HDF5 files into `yt <https://yt-project.org>`_, the HDF5 file attributes need to be modified. We have provided a script to do so in `tools` directory of this repository. It requires the ``h5py`` and ``hdf5plugin`` Python packages.
+
+.. code-block:: console
+
+    $ python modify_hdf5_attributes.py -f plt00000 plt00010
+
+The resulting file can then be opened in yt.

--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -19,8 +19,8 @@ To read ZFP compressed HDF5 files into ParaView, ParaView must have the environm
 
 Then the user can load the file as usual with the ``VisitChomboReader``.
 
-Convert to numpy (npy) files
-----------------------------
+Convert to numpy files
+----------------------
 
 To convert the HDF5 files to plain numpy data files, we have provided a script to do so in `tools` directory of this repository. It requires the ``h5py`` and ``hdf5plugin`` Python packages.
 

--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -3,7 +3,7 @@
 Compressing field output files
 ==============================
 
-When writing out field output files, sometimes called plot files or plt files, it is possible to output the files with HDF5 and compress these with ZFP. To enable this capability, AMR-Wind must be compiled with ``AMR_WIND_ENABLE_HDF5`` and ``AMR_WIND_ENABLE_HDF5_ZFP``. The input file :ref:`documentation <inputs_io>` documents the input options to output these files. The `AMReX HDF5 documentation <https://amrex-codes.github.io/amrex/docs_html/IO.html#hdf5-plotfile-compression>`_ further documents valid options.
+When writing out field output files, sometimes called plot files or plt files, it is possible to output the files with HDF5 and compress these with ZFP. To enable this capability, AMR-Wind must be compiled with ``AMR_WIND_ENABLE_HDF5`` and ``AMR_WIND_ENABLE_HDF5_ZFP``. If using a spack installation of AMR-Wind, simply add ``+hdf5`` to the spec to enable these compression features. The input file :ref:`documentation <inputs_io>` documents the input options to output these files. The `AMReX HDF5 documentation <https://amrex-codes.github.io/amrex/docs_html/IO.html#hdf5-plotfile-compression>`_ further documents valid options.
 
 While generating the compressed files is straightforward, it takes a little work to read these in various post-processing utilities.
 

--- a/docs/sphinx/user/compression.rst
+++ b/docs/sphinx/user/compression.rst
@@ -17,7 +17,7 @@ To read ZFP compressed HDF5 files into ParaView, ParaView must have the environm
     $ export HDF5_PLUGIN_PATH=$(spack location -i h5z-zfp)/plugin
     $ paraview
 
-Then the user can load the file as usual.
+Then the user can load the file as usual with the ``VisitChomboReader``.
 
 yt
 --

--- a/docs/sphinx/user/features.rst
+++ b/docs/sphinx/user/features.rst
@@ -140,7 +140,9 @@ Flow physics
 
    * Derived fields and field operators such as vorticity, q-criterion, strain-rates, gradients, divergence, Laplacian [:ref:`inp <inputs_io_derived>`]
 
-   * in-situ post-processing with Ascent
+   * In-situ post-processing with Ascent
+
+   * Compression for field files [:ref:`doc <compression>`, :ref:`inp <inputs_io>`]
 
 High performance computing
 --------------------------

--- a/docs/sphinx/user/user.rst
+++ b/docs/sphinx/user/user.rst
@@ -13,3 +13,4 @@ User Manual
    run.rst
    faq.rst
    post_processing_examples.rst
+   compression

--- a/tools/convert_amrex_hdf5_plotfile.py
+++ b/tools/convert_amrex_hdf5_plotfile.py
@@ -1,0 +1,88 @@
+import h5py
+import hdf5plugin
+import numpy as np
+from pathlib import Path
+import argparse
+
+
+def main():
+    """Convert an AMReX HDF5 plotfile 3D npy file."""
+    parser = argparse.ArgumentParser(
+        description="Convert an AMReX HDF5 plotfile 3D npy file"
+    )
+    parser.add_argument(
+        "-f",
+        "--fname",
+        help="AMReX HDF5 plotfile name",
+        required=True,
+        type=str,
+    )
+    parser.add_argument(
+        "-o",
+        "--odir",
+        help="Directory for output files",
+        default=".",
+        type=str,
+    )
+    args = parser.parse_args()
+
+    with h5py.File(args.fname, mode="r") as f:
+        dct = {}
+        for key in f.attrs.keys():
+            if "component_" in key:
+                field = f.attrs[key].decode("UTF-8")
+                component = int(key.split("_")[1])
+                dct[field] = component
+        nvars = len(dct)
+
+        # Characterize box array
+        ba_shape0 = f["level_0"]["boxes"][0]
+        ba_di = ba_shape0[3] - ba_shape0[0] + 1
+        ba_dj = ba_shape0[4] - ba_shape0[1] + 1
+        ba_dk = ba_shape0[5] - ba_shape0[2] + 1
+        ba_var_len = ba_di * ba_dj * ba_dk
+        boxstride = ba_var_len * nvars
+        nba = len(f["level_0"]["boxes"])
+
+        # Check that di/dj/dk are true for all shapes
+        for box in f["level_0"]["boxes"]:
+            assert box[0] + ba_di - 1 == box[3], box
+            assert box[1] + ba_dj - 1 == box[4], box
+            assert box[2] + ba_dk - 1 == box[5], box
+
+        # Characterize domain
+        dom_nx = f["level_0"].attrs["prob_domain"][3] + 1
+        dom_ny = f["level_0"].attrs["prob_domain"][4] + 1
+        dom_nz = f["level_0"].attrs["prob_domain"][5] + 1
+
+        # Reformat 1D into 3D data, iterating over variables
+        data = np.zeros((nvars, dom_nx, dom_ny, dom_nz))
+        for i, (field, comp) in enumerate(dct.items()):
+            var_offset = comp * ba_var_len
+
+            for lb in range(nba):
+                ba_inds = f["level_0"]["boxes"][lb]
+                lo_i, lo_j, lo_k = ba_inds[0], ba_inds[1], ba_inds[2]
+                hi_i, hi_j, hi_k = ba_inds[3] + 1, ba_inds[4] + 1, ba_inds[5] + 1
+
+                hdf5_data = f["level_0"]["data:datatype=0"][
+                    var_offset
+                    + lb * boxstride : var_offset
+                    + lb * boxstride
+                    + ba_var_len
+                ]
+
+                # Reshape into 3D
+                np_data = np.reshape(
+                    hdf5_data, (hi_i - lo_i, hi_j - lo_j, hi_k - lo_k), order="F"
+                )
+
+                # Place little 3D data into the big domain
+                data[i, lo_i:hi_i, lo_j:hi_j, lo_k:hi_k] = np_data
+
+        savename = f"{args.fname}.npy"
+        np.save(Path(args.odir, savename), data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/modify_hdf5_attributes.py
+++ b/tools/modify_hdf5_attributes.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+import argparse
+
+import h5py
+import hdf5plugin
+import numpy as np
+
+
+def modify_attributes(fname):
+    """Modifies HDF5 attributes from amrex plt files to be compatible with yt"""
+    hf = h5py.File(fname, "r+")
+    attr_keys = ["dim", "num_levels", "finest_level"]
+    for key in attr_keys:
+        if np.ndim(hf.attrs[key]):
+            hf.attrs.__setitem__(key, hf.attrs[key].item())
+    chombo_global_keys = ["SpaceDim"]
+    for key in chombo_global_keys:
+        if np.ndim(hf["Chombo_global"].attrs[key]):
+            hf["Chombo_global"].attrs.__setitem__(
+                key, hf["Chombo_global"].attrs[key].item()
+            )
+    hf.close()
+
+
+def main():
+    """Plot data."""
+    parser = argparse.ArgumentParser(
+        description="Modifies HDF5 attributes from amrex plt files to be compatible with yt"
+    )
+    parser.add_argument(
+        "-f",
+        "--fname",
+        help="plt h5 files to replace attrs in",
+        required=True,
+        type=str,
+        nargs="+",
+    )
+    args = parser.parse_args()
+
+    for fname in args.fname:
+        modify_attributes(fname)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Document IO compression

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Additional background
Still need to do:
- [ ] add the modify HDF5 attributes script
- [ ] add figures


Here's an example of IO write time, resulting plt file size for 72 million DoFs, and x-velocity error.

<img width="633" alt="Screenshot 2025-04-14 at 12 29 41 PM" src="https://github.com/user-attachments/assets/2900bb54-92a6-4791-aaba-26c31a8ffb7e" />

<img width="635" alt="Screenshot 2025-04-14 at 12 30 58 PM" src="https://github.com/user-attachments/assets/bdf9b28a-d206-4713-8c12-f226c9db68fe" />
