### PR TITLE
Fix RK2 approach for explicit diffusion

### DIFF
--- a/amr-wind/equation_systems/CompRHSOps.H
+++ b/amr-wind/equation_systems/CompRHSOps.H
@@ -262,6 +262,42 @@ struct ComputeRHSOp
         amrex::Gpu::streamSynchronize();
     }
 
+    void improve_explicit_diff(const amrex::Real dt)
+    {
+        explicit_RK2_post_hoc(dt);
+    }
+
+    void explicit_RK2_post_hoc(const amrex::Real dt)
+    {
+        // divtau must be the difference between new and old before calling this
+        const auto& d_divtau = fields.diff_term;
+
+        auto& dof = fields.field;
+        const auto& repo = fields.repo;
+        const auto& mask_cell = repo.get_int_field("mask_cell");
+
+        const int nlevels = repo.num_active_levels();
+        for (int lev = 0; lev < nlevels; ++lev) {
+            auto f_arrs = dof(lev).arrays();
+            const auto& d_diff_arrs = d_divtau(lev).const_arrays();
+            const auto& mask_arrs = mask_cell(lev).const_arrays();
+            const auto& rho_arrs = density(lev).const_arrays();
+
+            amrex::ParallelFor(
+                dof(lev), amrex::IntVect(0), dof.num_comp(),
+                [=] AMREX_GPU_DEVICE(
+                    int nbx, int i, int j, int k, int n) noexcept {
+                    auto factor =
+                        0.5 * dt * (amrex::Real)mask_arrs[nbx](i, j, k);
+                    if (PDE::multiply_rho) {
+                        factor /= rho_arrs[nbx](i, j, k);
+                    }
+                    f_arrs[nbx](i, j, k, n) +=
+                        factor * d_diff_arrs[nbx](i, j, k, n);
+                });
+        }
+    }
+
     // data members
     PDEFields& fields;
     Field& density;

--- a/amr-wind/equation_systems/CompRHSOps.H
+++ b/amr-wind/equation_systems/CompRHSOps.H
@@ -264,10 +264,10 @@ struct ComputeRHSOp
 
     void improve_explicit_diff(const amrex::Real dt)
     {
-        explicit_RK2_post_hoc(dt);
+        explicit_rk2_post_hoc(dt);
     }
 
-    void explicit_RK2_post_hoc(const amrex::Real dt)
+    void explicit_rk2_post_hoc(const amrex::Real dt)
     {
         // divtau must be the difference between new and old before calling this
         const auto& d_divtau = fields.diff_term;

--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -167,6 +167,16 @@ public:
 
     void post_solve_actions() override { m_post_solve_op(m_time.new_time()); }
 
+    void improve_explicit_diffusion(const amrex::Real dt) override
+    {
+        if (PDE::has_diffusion) {
+            BL_PROFILE(
+                "amr-wind::" + this->identifier() +
+                "::improve_explicit_diffusion");
+            m_rhs_op.improve_explicit_diff(dt);
+        }
+    }
+
 protected:
     //! CFD simulation controller instance
     CFDSim& m_sim;

--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -100,7 +100,7 @@ public:
     //! Perform post-processing actions after a system solve
     virtual void post_solve_actions() = 0;
 
-    virtual void improve_explicit_diffusion(const amrex::Real) {}
+    virtual void improve_explicit_diffusion(const amrex::Real dt) = 0;
 
     //! Base class identifier used for factory registration interface
     static std::string base_identifier() { return "PDESystem"; }

--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -100,6 +100,8 @@ public:
     //! Perform post-processing actions after a system solve
     virtual void post_solve_actions() = 0;
 
+    virtual void improve_explicit_diffusion(const amrex::Real dt) {}
+
     //! Base class identifier used for factory registration interface
     static std::string base_identifier() { return "PDESystem"; }
 };

--- a/amr-wind/equation_systems/PDEBase.H
+++ b/amr-wind/equation_systems/PDEBase.H
@@ -100,7 +100,7 @@ public:
     //! Perform post-processing actions after a system solve
     virtual void post_solve_actions() = 0;
 
-    virtual void improve_explicit_diffusion(const amrex::Real dt) {}
+    virtual void improve_explicit_diffusion(const amrex::Real) {}
 
     //! Base class identifier used for factory registration interface
     static std::string base_identifier() { return "PDESystem"; }

--- a/amr-wind/equation_systems/density/density_ops.H
+++ b/amr-wind/equation_systems/density/density_ops.H
@@ -76,6 +76,8 @@ struct ComputeRHSOp<Density, Scheme>
         amrex::Gpu::streamSynchronize();
     }
 
+    void improve_explicit_diff(const amrex::Real /*unused*/) {}
+
     // data members
     PDEFields& fields;
 };

--- a/amr-wind/equation_systems/levelset/levelset_ops.H
+++ b/amr-wind/equation_systems/levelset/levelset_ops.H
@@ -115,6 +115,8 @@ struct ComputeRHSOp<Levelset, Scheme>
         amrex::Gpu::streamSynchronize();
     }
 
+    void improve_explicit_diff(const amrex::Real /*unused*/) {}
+
     // data members
     PDEFields& fields;
 };

--- a/amr-wind/equation_systems/vof/vof_ops.H
+++ b/amr-wind/equation_systems/vof/vof_ops.H
@@ -54,6 +54,8 @@ struct ComputeRHSOp<VOF, Scheme>
         bool /*unused*/)
     {}
 
+    void improve_explicit_diff(const amrex::Real /*unused*/) {}
+
     // data members
     PDEFields& fields;
 };

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -398,6 +398,7 @@ void incflo::ApplyPredictor(
             icns().fields().diff_term.state(amr_wind::FieldState::New);
         amr_wind::field_ops::copy(*diff_old, diff_new, 0, 0, AMREX_SPACEDIM, 0);
         icns().compute_diffusion_term(amr_wind::FieldState::New);
+        amr_wind::field_ops::saxpy(diff_new, -1.0, *diff_old, 0, 0, AMREX_SPACEDIM, 0);
         icns().improve_explicit_diffusion(m_time.delta_t());
     }
     icns().post_solve_actions();

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -398,7 +398,8 @@ void incflo::ApplyPredictor(
             icns().fields().diff_term.state(amr_wind::FieldState::New);
         amr_wind::field_ops::copy(*diff_old, diff_new, 0, 0, AMREX_SPACEDIM, 0);
         icns().compute_diffusion_term(amr_wind::FieldState::New);
-        amr_wind::field_ops::saxpy(diff_new, -1.0, *diff_old, 0, 0, AMREX_SPACEDIM, 0);
+        amr_wind::field_ops::saxpy(
+            diff_new, -1.0, *diff_old, 0, 0, AMREX_SPACEDIM, 0);
         icns().improve_explicit_diffusion(m_time.delta_t());
     }
     icns().post_solve_actions();

--- a/amr-wind/incflo_advance.cpp
+++ b/amr-wind/incflo_advance.cpp
@@ -341,17 +341,14 @@ void incflo::ApplyPredictor(
             // Post-processing actions after a PDE solve
         } else if (m_diff_type == DiffusionType::Explicit && m_use_godunov) {
             // explicit RK2
-            std::unique_ptr<amr_wind::ScratchField> diff_old =
+            auto diff_old =
                 m_repo.create_scratch_field(1, 0, amr_wind::FieldLoc::CELL);
             auto& diff_new =
                 eqn->fields().diff_term.state(amr_wind::FieldState::New);
             amr_wind::field_ops::copy(*diff_old, diff_new, 0, 0, 1, 0);
             eqn->compute_diffusion_term(amr_wind::FieldState::New);
-            amrex::Real dto2 = 0.5 * m_time.delta_t();
-            amr_wind::field_ops::saxpy(
-                eqn->fields().field, -dto2, *diff_old, 0, 0, 1, 0);
-            amr_wind::field_ops::saxpy(
-                eqn->fields().field, +dto2, diff_new, 0, 0, 1, 0);
+            amr_wind::field_ops::saxpy(diff_new, -1.0, *diff_old, 0, 0, 1, 0);
+            eqn->improve_explicit_diffusion(m_time.delta_t());
         }
         eqn->post_solve_actions();
 

--- a/unit_tests/equation_systems/CMakeLists.txt
+++ b/unit_tests/equation_systems/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources(${amr_wind_unit_test_exe_name}
   test_icns_cstdens.cpp
   test_icns_gravityforcing.cpp
   test_icns_init.cpp
+  test_explicit_diffusion_rk2.cpp
   )

--- a/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
+++ b/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
@@ -30,7 +30,7 @@ void init_scalar(amr_wind::Field& scalar)
 class ExplicitDiffusionRK2Test : public MeshTest
 {
 protected:
-    void populate_parameters()
+    void populate_parameters() override
     {
         {
             amrex::ParmParse pp("amr");

--- a/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
+++ b/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
@@ -74,7 +74,6 @@ protected:
         pde_mgr.register_icns();
         sim().create_turbulence_model();
         sim().init_physics();
-        // auto& density = sim().repo().declare_cc_field("density", 1, 3, 3);
         auto& k_eqn = pde_mgr.register_transport_pde("TKE");
         auto& tke = k_eqn.fields().field;
         auto& tke_old = tke.state(amr_wind::FieldState::Old);
@@ -99,7 +98,7 @@ protected:
         k_eqn.initialize();
         // Calculate diffusion term explicitly
         k_eqn.compute_diffusion_term(amr_wind::FieldState::Old);
-        // Incorporate RHS, which should only be the explicit diffusion\n";
+        // Incorporate RHS, which should only be the explicit diffusion
         k_eqn.compute_predictor_rhs(DiffusionType::Explicit);
     }
 

--- a/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
+++ b/unit_tests/equation_systems/test_explicit_diffusion_rk2.cpp
@@ -1,0 +1,175 @@
+#include "aw_test_utils/MeshTest.H"
+#include "aw_test_utils/test_utils.H"
+#include "amr-wind/incflo_enums.H"
+#include "amr-wind/core/field_ops.H"
+#include "amr-wind/equation_systems/PDEBase.H"
+
+namespace amr_wind_tests {
+
+namespace {
+
+void init_scalar(amr_wind::Field& scalar)
+{
+    const int nlevels = scalar.repo().num_active_levels();
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        const auto& sarrs = scalar(lev).arrays();
+
+        amrex::ParallelFor(
+            scalar(lev), scalar.num_grow(),
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                sarrs[nbx](i, j, k) = 1. + i * i + 0.2 * (j - 1) * (j - 1) +
+                                      0.01 * (k + 1) * (k + 1) * (k + 1);
+            });
+    }
+    amrex::Gpu::streamSynchronize();
+}
+
+} // namespace
+
+class ExplicitDiffusionRK2Test : public MeshTest
+{
+protected:
+    void populate_parameters()
+    {
+        {
+            amrex::ParmParse pp("amr");
+            amrex::Vector<int> ncell{{m_nx, m_ny, m_nz}};
+            pp.add("max_level", 0);
+            pp.add("max_grid_size", m_nx);
+            pp.addarr("n_cell", ncell);
+        }
+        {
+            amrex::ParmParse pp("geometry");
+            amrex::Vector<amrex::Real> problo{{0.0, 0.0, 0.0}};
+            amrex::Vector<amrex::Real> probhi{{1.0, 1.0, 1.0}};
+
+            pp.addarr("prob_lo", problo);
+            pp.addarr("prob_hi", probhi);
+
+            amrex::Vector<int> periodic{{1, 1, 1}};
+            pp.addarr("is_periodic", periodic);
+        }
+        {
+            amrex::ParmParse pp("incflo");
+            pp.add("use_godunov", 1);
+            pp.add("diffusion_type", 0);
+            pp.add("density", m_rho_0);
+        }
+        {
+            amrex::ParmParse pp("time");
+            pp.add("fixed_dt", m_dt);
+        }
+    }
+
+    void init_sim_calc_diffusion()
+    {
+
+        // High-level setup
+        populate_parameters();
+        initialize_mesh();
+
+        // Initialize scalar with multiply_rho = true
+        auto& pde_mgr = sim().pde_manager();
+        pde_mgr.register_icns();
+        sim().create_turbulence_model();
+        sim().init_physics();
+        // auto& density = sim().repo().declare_cc_field("density", 1, 3, 3);
+        auto& k_eqn = pde_mgr.register_transport_pde("TKE");
+        auto& tke = k_eqn.fields().field;
+        auto& tke_old = tke.state(amr_wind::FieldState::Old);
+        auto& density = sim().repo().get_field("density");
+        auto& density_old = density.state(amr_wind::FieldState::Old);
+        auto& density_nph = density.state(amr_wind::FieldState::NPH);
+        // Set up initial arrays
+        density.setVal(m_rho_0);
+        density_old.setVal(m_rho_0);
+        density_nph.setVal(m_rho_0);
+        init_scalar(tke);
+        init_scalar(tke_old);
+        // Zero other RHS terms for tke equation
+        k_eqn.fields().conv_term.setVal(0.);
+        k_eqn.fields().src_term.setVal(0.);
+        // Set up mask field
+        auto& mask_cell = sim().repo().declare_int_field("mask_cell", 1, 1);
+        mask_cell.setVal(1);
+        // Set up diffusion coefficient
+        k_eqn.fields().mueff.setVal(0.1);
+
+        k_eqn.initialize();
+        // Calculate diffusion term explicitly
+        k_eqn.compute_diffusion_term(amr_wind::FieldState::Old);
+        // Incorporate RHS, which should only be the explicit diffusion\n";
+        k_eqn.compute_predictor_rhs(DiffusionType::Explicit);
+    }
+
+    const amrex::Real m_rho_0 = 2.0;
+    const amrex::Real m_dt = 0.5;
+    const int m_nx = 8;
+    const int m_ny = 8;
+    const int m_nz = 16;
+};
+
+TEST_F(ExplicitDiffusionRK2Test, old_approach)
+{
+    init_sim_calc_diffusion();
+    auto& pde_mgr = sim().pde_manager();
+    auto& k_eqn = pde_mgr("TKE-Godunov");
+    auto& tke = k_eqn.fields().field;
+    auto& tke_old = tke.state(amr_wind::FieldState::Old);
+
+    // Subtract diffusion term manually, mimicking the assumption in the code
+    // If correct, should go back to old value
+    const auto dt = sim().time().delta_t();
+    auto& diff_old = k_eqn.fields().diff_term.state(amr_wind::FieldState::New);
+    amr_wind::field_ops::saxpy(tke, -dt, diff_old, 0, 0, 1, 0);
+
+    // Subtract original tke from result for comparison
+    amr_wind::field_ops::saxpy(tke, -1., tke_old, 0, 0, 1, 0);
+
+    auto min_diff = utils::field_min(tke);
+    auto max_diff = utils::field_max(tke);
+    const auto abs_diff_tke = amrex::max(-min_diff, max_diff);
+    // We know this approach is wrong, so expect error to be greater
+    EXPECT_GT(abs_diff_tke, 1e-8);
+
+    // As a sanity check for the test, confirm that diff_term is not 0
+    min_diff = utils::field_min(diff_old);
+    max_diff = utils::field_max(diff_old);
+    const auto abs_diff_term = amrex::max(-min_diff, max_diff);
+    EXPECT_GT(abs_diff_term, 1e-8);
+}
+
+TEST_F(ExplicitDiffusionRK2Test, correct_approach)
+{
+    init_sim_calc_diffusion();
+    auto& pde_mgr = sim().pde_manager();
+    auto& k_eqn = pde_mgr("TKE-Godunov");
+    auto& tke = k_eqn.fields().field;
+    auto& tke_old = tke.state(amr_wind::FieldState::Old);
+
+    // Change term to -2 times original value so it will cancel RHS contribution
+    const auto dt = sim().time().delta_t();
+    auto& diff_new = k_eqn.fields().diff_term.state(amr_wind::FieldState::New);
+    amr_wind::field_ops::saxpy(diff_new, -3., diff_new, 0, 0, 1, 0);
+
+    // Apply operation through PDE function
+    k_eqn.improve_explicit_diffusion(dt);
+
+    // Subtract original tke from result for comparison
+    amr_wind::field_ops::saxpy(tke, -1., tke_old, 0, 0, 1, 0);
+
+    // Check that difference is less than tolerance
+    auto min_diff = utils::field_min(tke);
+    auto max_diff = utils::field_max(tke);
+    const auto abs_diff_tke = amrex::max(-min_diff, max_diff);
+    EXPECT_LT(abs_diff_tke, 1e-8);
+
+    // As a sanity check for the test, confirm that diff_term is not 0
+    min_diff = utils::field_min(diff_new);
+    max_diff = utils::field_max(diff_new);
+    const auto abs_diff_term = amrex::max(-min_diff, max_diff);
+    EXPECT_GT(abs_diff_term, 1e-8);
+}
+
+} // namespace amr_wind_tests


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

Looks like there is a bug in the RK2 formulation for explicit diffusion. Does not account properly for density, which is a problem for equations that have multiply_rho = true, and does not account for masking, which is a problem for overset simulations.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This is only a problem for diffusion_type = 0, i.e., fully explicit.

Issue Number: <!-- Note related issues -->
