### PR TITLE
Modify density check at initialization

### DIFF
--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -162,10 +162,10 @@ void PDEMgr::density_check()
         amrex::Real rho_g_max{1.0}, rho_g_min{1.0};
         diagnostics::get_field_extrema(
             rho_l_max, rho_l_min, m_sim.repo().get_field("density"),
-            m_sim.repo().get_field("vof"), 1.0, 0, 1);
+            m_sim.repo().get_field("vof"), 1.0, 0, 1, 1);
         diagnostics::get_field_extrema(
             rho_g_max, rho_g_min, m_sim.repo().get_field("density"),
-            m_sim.repo().get_field("vof"), 0.0, 0, 1);
+            m_sim.repo().get_field("vof"), 0.0, 0, 1, 1);
         if (std::abs(rho_l_max - rho_l_min) > constants::LOOSE_TOL) {
             amrex::Abort(
                 "Density check failed. Liquid density maximum is too different "
@@ -185,7 +185,7 @@ void PDEMgr::density_check()
     } else if (m_constant_density) {
         amrex::Real rho_max{1.0}, rho_min{1.0};
         diagnostics::get_field_extrema(
-            rho_max, rho_min, m_sim.repo().get_field("density"), 0, 1);
+            rho_max, rho_min, m_sim.repo().get_field("density"), 0, 1, 1);
         if (std::abs(rho_max - rho_min) > constants::LOOSE_TOL) {
             amrex::Abort(
                 "Density check failed. Density maximum is too different "

--- a/amr-wind/utilities/diagnostics.H
+++ b/amr-wind/utilities/diagnostics.H
@@ -17,7 +17,7 @@ void get_field_extrema(
     const amr_wind::Field& field,
     const int comp,
     const int ncomp,
-    const bool include_ghosts = true);
+    const int nghost);
 
 void get_field_extrema(
     amrex::Real& field_max_val,
@@ -27,7 +27,7 @@ void get_field_extrema(
     const amrex::Real mask_val,
     const int comp,
     const int ncomp,
-    const bool include_ghosts = true);
+    const int nghost);
 
 amrex::Real get_vel_max(
     const amrex::MultiFab& vel,


### PR DESCRIPTION
## Summary

Have density check evaluate only 1 ghost cell, not all available. I think this matters for external boundaries; though the field might have 3 ghost cells, only the first one gets populated by the boundary fill. Uninitialized values show up with multiple levels and can erroneously trip the density check.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Fixes the density check related problems in the issue below

Issue Number: #1561 
