### PR TITLE
tweaking vof-aware masking: limit to cells near overset boundary

### DIFF
--- a/amr-wind/overset/overset_ops_routines.cpp
+++ b/amr-wind/overset/overset_ops_routines.cpp
@@ -66,20 +66,24 @@ void iblank_node_to_mask_vof(
                         }
                     }
                 }
-                // Check nodes neighboring node for being near solid
+                // Check nodes neighboring node for being near solid or overset
                 bool near_solid = false;
+                bool near_overset_boundary = false;
                 for (int ii = i - 1; ii < i + 2; ii++) {
                     for (int jj = j - 1; jj < j + 2; jj++) {
                         for (int kk = k - 1; kk < k + 2; kk++) {
                             near_solid = ibarrs[nbx](ii, jj, kk) == 0
                                              ? true
                                              : near_solid;
+                            near_overset_boundary = ibarrs[nbx](ii, jj, kk) == 1
+                                                        ? true
+                                                        : near_overset_boundary;
                         }
                     }
                 }
-                // Do mask -1 cells near interface
+                // Do mask -1 cells near interface and overset boundary
                 if (ibarrs[nbx](i, j, k) == -1 &&
-                    (near_interface && !near_solid)) {
+                    (near_overset_boundary && near_interface && !near_solid)) {
                     marrs[nbx](i, j, k) = 1;
                 }
             });
@@ -119,20 +123,26 @@ void prepare_mask_cell_for_mac(FieldRepo& repo)
                     // Check cells neighboring node for being near interface
                     bool near_interface = amr_wind::multiphase::interface_band(
                         i, j, k, vofarrs[nbx], 1, band_tol);
-                    // Check neighboring cells for being near solid
+                    // Check neighboring cells for being near solid or overset
                     bool near_solid = false;
+                    bool near_overset_boundary = false;
                     for (int ii = i - 1; ii < i + 2; ii++) {
                         for (int jj = j - 1; jj < j + 2; jj++) {
                             for (int kk = k - 1; kk < k + 2; kk++) {
                                 near_solid = ibarrs[nbx](ii, jj, kk) == 0
                                                  ? true
                                                  : near_solid;
+                                near_overset_boundary =
+                                    ibarrs[nbx](ii, jj, kk) == 1
+                                        ? true
+                                        : near_overset_boundary;
                             }
                         }
                     }
                     // Do mask -1 cells near interface
                     if (ibarrs[nbx](i, j, k) == -1 &&
-                        (near_interface && !near_solid)) {
+                        (near_overset_boundary && near_interface &&
+                         !near_solid)) {
                         marrs[nbx](i, j, k) = 1;
                     }
                 });


### PR DESCRIPTION
## Summary

When vof is in the domain, the overset masking in the projections is turned off near the phase interface, which helps reduce spurious currents. It's unnecessary to do this in the full overset region, though, so this PR limits this only to cells near the overset boundary as well.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Will only affect overset simulations
