### PR TITLE
Force Re-Grid On Restart From Checkpoint File

### DIFF
--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -120,6 +120,12 @@ public:
     bool adaptive_timestep() const { return m_adaptive; }
 
     AMREX_FORCE_INLINE
+    bool force_regrid_restart() const { return m_regrid_restart; }
+
+    AMREX_FORCE_INLINE
+    int regrid_restart_startlevel() const { return m_regrid_restart_startlevel; }
+
+    AMREX_FORCE_INLINE
     bool use_force_cfl() const { return m_use_force_cfl; }
 
     AMREX_FORCE_INLINE
@@ -216,6 +222,12 @@ private:
 
     //! Initial starting time index for regriding
     int m_regrid_start_index{0};
+
+    //! Flag indicating if regrid on restart
+    bool m_regrid_restart{false};
+     
+    //! Start re-gridding on level
+    int m_regrid_restart_startlevel{0};
 
     //! Maximum timesteps for simulation
     int m_stop_time_index{-1};

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -23,6 +23,8 @@ void SimTime::parse_parameters()
     pp.query("cfl", m_max_cfl);
     pp.query("verbose", m_verbose);
     pp.query("regrid_interval", m_regrid_interval);
+    pp.query("force_regrid_on_restart", m_regrid_restart);
+    pp.query("regrid_restart_startlevel", m_regrid_restart_startlevel);
     pp.query("plot_interval", m_plt_interval);
     pp.query("plot_time_interval", m_plt_t_interval);
     pp.query("plot_delay", m_plt_delay);
@@ -215,7 +217,7 @@ void SimTime::set_current_cfl(
         // If user has specified fixed DT then issue a warning if the timestep
         // is larger than the delta_t determined from max. CFL considerations.
         // Only issue warnings when the error is greater than 1% of the timestep
-        // specified
+        // specifiedm_regrid
         if ((1.0 - (dt_new / m_fixed_dt)) > 0.01) {
             issue_cfl_warning = true;
         }
@@ -272,10 +274,12 @@ bool SimTime::continue_simulation() const
 
 bool SimTime::do_regrid() const
 {
-    return (
-        (m_regrid_interval > 0) &&
+    bool do_reg = 
+        ((m_regrid_interval > 0) &&
         ((m_time_index - m_regrid_start_index) > 0) &&
         ((m_time_index - m_regrid_start_index) % m_regrid_interval == 0));
+
+    return do_reg;
 }
 
 bool SimTime::write_plot_file() const


### PR DESCRIPTION
## Summary

Restarting from a checkpoint file only allows you to add refinements within existing levels. This PR attempts to allow you to restart a simulation and re-grid levels, choosing a specific starting level. This currently has the caveat that you most likely lose data on the levels you re-grid, so should be used with caution. The ideal scenario would be to map existing checkpoint levels back to the new grid.

## Pull request type

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [X] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Notes

Testing ongoing. Would love help finding the edge cases for this. 