### PR TITLE
Improve VOF BC defaults and density BC with VOF

### DIFF
--- a/amr-wind/equation_systems/vof/vof.H
+++ b/amr-wind/equation_systems/vof/vof.H
@@ -27,6 +27,7 @@ struct VOF : ScalarTransport
     static constexpr bool need_nph_state = true;
 
     static constexpr amrex::Real default_bc_value = 0.0;
+    static constexpr amrex::Real default_density_bc_value = 1.0;
 };
 
 } // namespace amr_wind::pde

--- a/amr-wind/equation_systems/vof/vof_bciface.H
+++ b/amr-wind/equation_systems/vof/vof_bciface.H
@@ -41,6 +41,8 @@ protected:
             case BC::zero_gradient:
             case BC::no_slip_wall:
             case BC::symmetric_wall:
+            case BC::slip_wall:
+            case BC::wall_model:
                 if (side == amrex::Orientation::low) {
                     set_bcrec_lo(dir, amrex::BCType::foextrap);
                 } else {
@@ -48,14 +50,7 @@ protected:
                 }
                 break;
 
-            case BC::slip_wall:
-            case BC::wall_model:
-                if (side == amrex::Orientation::low) {
-                    set_bcrec_lo(dir, amrex::BCType::hoextrap);
-                } else {
-                    set_bcrec_hi(dir, amrex::BCType::hoextrap);
-                }
-                break;
+                // Never do hoextrap because it is unbounded
 
             case BC::wave_generation:
             case BC::mass_inflow:
@@ -70,11 +65,93 @@ protected:
             // Fixed gradient BC is not allowed for VOF
             case BC::fixed_gradient:
             default:
-                amrex::Abort("Invalid BC type for VOF encountered");
+                amrex::Abort(
+                    "Invalid BC type for VOF encountered: fixed_gradient");
             }
         }
     }
     // Copied from BC interface for scalars
+    void read_values() override
+    {
+        const auto& fname = m_field.name();
+        const auto& bctype = m_field.bc_type();
+        auto& bcval = m_field.bc_values();
+        const int ndim = m_field.num_comp();
+        for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
+            auto ori = oit();
+            const auto& bcid = bcnames[ori];
+            const auto bct = bctype[ori];
+
+            amrex::ParmParse pp(bcid);
+            if (bct == BC::mass_inflow || bct == BC::mass_inflow_outflow) {
+                pp.getarr(fname.c_str(), bcval[ori], 0, ndim);
+            } else {
+                pp.queryarr(fname.c_str(), bcval[ori], 0, ndim);
+            }
+        }
+    }
+};
+
+class BCDensityMod : public BCIface
+{
+public:
+    explicit BCDensityMod(Field& field) : BCIface(field) {}
+
+protected:
+    void set_bcrec() override
+    {
+        const auto& ibctype = m_field.bc_type();
+
+        for (amrex::OrientationIter oit; oit != nullptr; ++oit) {
+            auto ori = oit();
+            const auto side = ori.faceDir();
+            const auto bct = ibctype[ori];
+            const int dir = ori.coordDir();
+
+            switch (bct) {
+            case BC::periodic:
+                if (side == amrex::Orientation::low) {
+                    set_bcrec_lo(dir, amrex::BCType::int_dir);
+                } else {
+                    set_bcrec_hi(dir, amrex::BCType::int_dir);
+                }
+                break;
+
+            // Both extrapolations are consistent between vof and density
+            case BC::pressure_outflow:
+            case BC::zero_gradient:
+            case BC::no_slip_wall:
+            case BC::symmetric_wall:
+            case BC::slip_wall:
+            case BC::wall_model:
+                if (side == amrex::Orientation::low) {
+                    set_bcrec_lo(dir, amrex::BCType::foextrap);
+                } else {
+                    set_bcrec_hi(dir, amrex::BCType::foextrap);
+                }
+                break;
+
+                // Never do hoextrap because it is unbounded
+
+            case BC::wave_generation:
+            case BC::mass_inflow:
+            case BC::mass_inflow_outflow:
+                if (side == amrex::Orientation::low) {
+                    set_bcrec_lo(dir, amrex::BCType::ext_dir);
+                } else {
+                    set_bcrec_hi(dir, amrex::BCType::ext_dir);
+                }
+                break;
+
+            case BC::fixed_gradient:
+            default:
+                amrex::Abort(
+                    "Invalid BC type for density (vof-compatible) encountered: "
+                    "fixed_gradient");
+            }
+        }
+    }
+
     void read_values() override
     {
         const auto& fname = m_field.name();

--- a/amr-wind/equation_systems/vof/vof_bcop.H
+++ b/amr-wind/equation_systems/vof/vof_bcop.H
@@ -22,6 +22,10 @@ struct BCOp<VOF>
         BCVOF bc(m_fields.field);
         bc(VOF::default_bc_value);
 
+        auto& density = m_fields.repo.get_field("density");
+        BCDensityMod bc_dens(density);
+        bc(VOF::default_density_bc_value);
+
         // No source terms currently exist for VOF, so this is inconsequential
         BCSrcTerm bc_src(m_fields.src_term);
         bc_src();

--- a/amr-wind/equation_systems/vof/vof_bcop.H
+++ b/amr-wind/equation_systems/vof/vof_bcop.H
@@ -24,7 +24,7 @@ struct BCOp<VOF>
 
         auto& density = m_fields.repo.get_field("density");
         BCDensityMod bc_dens(density);
-        bc(VOF::default_density_bc_value);
+        bc_dens(VOF::default_density_bc_value);
 
         // No source terms currently exist for VOF, so this is inconsequential
         BCSrcTerm bc_src(m_fields.src_term);

--- a/unit_tests/multiphase/test_vof_BCs.cpp
+++ b/unit_tests/multiphase/test_vof_BCs.cpp
@@ -192,7 +192,7 @@ protected:
             bc_string = "mass_inflow";
         } else if (option == 2) {
             // Slip wall
-            vof_distr = 1;        // high-order extrapolation
+            vof_distr = 2;        // first-order extrapolation
             nonzero_flux = false; // flux cannot occur
             bc_string = "slip_wall";
         } else if (option == 3) {
@@ -341,7 +341,7 @@ constexpr double tol1 = 1.0e-15;
 constexpr double tol2 = 6.0e-2;
 
 TEST_F(VOFBCTest, dirichletX) { testing_bc_coorddir(1, 0, tol1); }
-TEST_F(VOFBCTest, slipwallY) { testing_bc_coorddir(2, 1, tol2); }
+TEST_F(VOFBCTest, slipwallY) { testing_bc_coorddir(2, 1, tol1); }
 TEST_F(VOFBCTest, noslipwallZ) { testing_bc_coorddir(3, 2, tol1); }
 TEST_F(VOFBCTest, pressureX) { testing_bc_coorddir(4, 0, tol1); }
 

--- a/unit_tests/multiphase/test_vof_BCs.cpp
+++ b/unit_tests/multiphase/test_vof_BCs.cpp
@@ -371,7 +371,6 @@ protected:
 };
 
 constexpr double tol1 = 1.0e-15;
-constexpr double tol2 = 6.0e-2;
 
 TEST_F(VOFBCTest, dirichletX) { testing_bc_coorddir(1, 0, tol1); }
 TEST_F(VOFBCTest, slipwallY) { testing_bc_coorddir(2, 1, tol1); }

--- a/unit_tests/multiphase/test_vof_BCs.cpp
+++ b/unit_tests/multiphase/test_vof_BCs.cpp
@@ -21,7 +21,9 @@ void get_accuracy_vofsol(
     const int dir,
     const int vof_distr,
     const amrex::Real vof_bdyval,
-    const amr_wind::Field& vof)
+    const amr_wind::Field& vof,
+    const amrex::Real wt1 = 1.0,
+    const amrex::Real wt2 = 0.)
 {
     /* -- Check VOF boundary values from fillpatch -- */
 #ifdef AMREX_USE_OMP
@@ -67,11 +69,27 @@ void get_accuracy_vofsol(
                         ref_val = 1.0 - 0.1 * (ii + jj + kk);
                     }
                     // Check against reference value
-                    err_arr(i, j, k, 0) = std::abs(vof_arr(i, j, k) - ref_val);
+                    const amrex::Real wt_ref =
+                        wt1 * ref_val + wt2 * (1.0 - ref_val);
+                    err_arr(i, j, k, 0) = std::abs(vof_arr(i, j, k) - wt_ref);
                 }
             }
         });
     }
+}
+
+void get_accuracy_density(
+    amr_wind::ScratchField& err_fld,
+    const int lev,
+    const int dir,
+    const int vof_distr,
+    const amrex::Real vof_bdyval,
+    const amr_wind::Field& density,
+    const amrex::Real rho1,
+    const amrex::Real rho2)
+{
+    get_accuracy_vofsol(
+        err_fld, lev, dir, vof_distr, vof_bdyval, density, rho1, rho2);
 }
 
 void get_accuracy_advalpha(
@@ -219,9 +237,9 @@ protected:
             if (option == 1) {
                 // Specify vof
                 pp.add("vof", m_vof_bdyval);
+                pp.add("density", m_rho1);
                 // Specify other quantities to avoid errors, not actually used
                 pp.add("levelset", 0.0);
-                pp.add("density", 1.0);
                 pp.addarr(
                     "velocity", amrex::Vector<amrex::Real>{0.0, 0.0, 0.0});
             }
@@ -231,8 +249,8 @@ protected:
             pp.add("type", bc_string);
             if (option == 1) {
                 pp.add("vof", m_vof_bdyval);
+                pp.add("density", m_rho1);
                 pp.add("levelset", 0.0);
-                pp.add("density", 1.0);
                 pp.addarr(
                     "velocity", amrex::Vector<amrex::Real>{0.0, 0.0, 0.0});
             }
@@ -291,7 +309,22 @@ protected:
 
         // Check error from first part
         constexpr amrex::Real refval_check = 0.0;
-        EXPECT_NEAR(error_fld(lev).max(0, 1), refval_check, tol);
+        const amrex::Real vof_distr_err = error_fld(lev).max(0, 1);
+        EXPECT_NEAR(vof_distr_err, refval_check, tol);
+
+        // Calculate density and fillpatch
+        auto& density = repo.get_field("density");
+        auto& multiphase = sim().physics_manager().get<amr_wind::MultiPhase>();
+        multiphase.set_density_via_vof();
+        density.fillpatch(0.);
+
+        // Compute error of density field and check
+        error_fld(lev).setVal(0.0);
+        get_accuracy_density(
+            error_fld, lev, dir, vof_distr, m_vof_bdyval, density, m_rho1,
+            m_rho2);
+        const amrex::Real density_distr_err = error_fld(lev).max(0, 1);
+        EXPECT_NEAR(density_distr_err, refval_check, tol);
 
         // Test positive and negative velocity
         for (int sign = -1; sign < 2; sign += 2) {


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

hoextrap was default vof bc for slip_wall and wall_model; this can lead to unbounded (>1, <0) values of vof. More careful implementation is to use foextrap; will not be unbounded if the interior is correct. This also redoes the density BCs to match the vof bcs when the vof equation is present.

These aren't very consequential changes but it's good to be consistent and bounded. The vof values in walls can affect the interface reconstruction within the domain, while the density values probably do not affect anything but the density bounds (involved in the density check).

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
