### PR TITLE
multiphase-aware scalar advection: avoid OOB when multiplying src by rho

### DIFF
--- a/amr-wind/equation_systems/AdvOp_Godunov.H
+++ b/amr-wind/equation_systems/AdvOp_Godunov.H
@@ -156,6 +156,8 @@ struct AdvectionOp<
                 if (PDE::multiply_rho) {
                     auto rhotrac_box =
                         amrex::grow(bx, fvm::Godunov::nghost_state);
+                    auto srctrac_box =
+                        amrex::grow(bx, fvm::Godunov::nghost_src);
                     rhotracfab.resize(
                         rhotrac_box, PDE::ndim, amrex::The_Async_Arena());
                     rhotrac = rhotracfab.array();
@@ -176,7 +178,7 @@ struct AdvectionOp<
                                 rho_arr(i, j, k) * tra_arr(i, j, k, n);
                             rhotrac_nph(i, j, k, n) =
                                 rho_nph_arr(i, j, k) * tra_nph_arr(i, j, k, n);
-                            if (mphase_vof) {
+                            if (mphase_vof && srctrac_box.contains(i, j, k)) {
                                 // Need to remove the effect of the multiply_rho
                                 // routine -- the setup is different for
                                 // mass-consistent multiphase advection


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
