### PR TITLE
Terrain Aligned Profile

### DIFF
--- a/amr-wind/wind_energy/ABLFieldInit.H
+++ b/amr-wind/wind_energy/ABLFieldInit.H
@@ -68,6 +68,8 @@ private:
     //! Adding option for wind heights similar to temperature heights
     //! Speed-up RANS calculation using 1-D profile for flat surface
     bool m_initial_wind_profile{false};
+    bool m_terrain_aligned_profile{false};
+    std::string m_terrain_file{"terrain.amrwind"};
     //! File name for 1-D data file
     std::string m_1d_rans;
     amrex::Vector<amrex::Real> m_wind_heights;

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -221,8 +221,6 @@ void ABLFieldInit::operator()(
                 velocity(i, j, k, 1) += interp::linear_impl(th, vv, z, idx);
             });
     } else if (m_initial_wind_profile) {
-        //! Compute Terrain
-        //! Reading the Terrain Coordinates from  file
         amrex::Vector<amrex::Real> xterrain;
         amrex::Vector<amrex::Real> yterrain;
         amrex::Vector<amrex::Real> zterrain;
@@ -249,7 +247,6 @@ void ABLFieldInit::operator()(
         const auto* xterrain_ptr = d_xterrain.data();
         const auto* yterrain_ptr = d_yterrain.data();
         const auto* zterrain_ptr = d_zterrain.data();
-        //! RANS 1-D profile
         const amrex::Real* windh = m_windht_d.data();
         const amrex::Real* uu = m_prof_u_d.data();
         const amrex::Real* vv = m_prof_v_d.data();
@@ -423,8 +420,6 @@ void ABLFieldInit::init_tke(
     const auto& tke_arrs = tke_mf.arrays();
     const auto tiny = std::numeric_limits<amrex::Real>::epsilon();
     if (m_initial_wind_profile) {
-        //! Compute Terrain
-        //! Reading the Terrain Coordinates from  file
         amrex::Vector<amrex::Real> xterrain;
         amrex::Vector<amrex::Real> yterrain;
         amrex::Vector<amrex::Real> zterrain;
@@ -451,13 +446,9 @@ void ABLFieldInit::init_tke(
         const auto* xterrain_ptr = d_xterrain.data();
         const auto* yterrain_ptr = d_yterrain.data();
         const auto* zterrain_ptr = d_zterrain.data();
-        //! RANS 1-D profile
         const amrex::Real* windh = m_windht_d.data();
-        // const amrex::Real* uu = m_prof_u_d.data();
-        // const amrex::Real* vv = m_prof_v_d.data();
         const bool terrain_aligned_profile = m_terrain_aligned_profile;
         const int nwvals = static_cast<int>(m_wind_heights.size());
-        // const amrex::Real* windh = m_windht_d.data();
         const amrex::Real* tke_data = m_prof_tke_d.data();
         amrex::ParallelFor(
             tke_mf,

--- a/amr-wind/wind_energy/ABLFieldInit.cpp
+++ b/amr-wind/wind_energy/ABLFieldInit.cpp
@@ -8,6 +8,7 @@
 #include "AMReX_Gpu.H"
 #include "AMReX_ParmParse.H"
 #include "amr-wind/utilities/linear_interpolation.H"
+#include "amr-wind/utilities/io_utils.H"
 namespace amr_wind {
 
 ABLFieldInit::ABLFieldInit()
@@ -25,6 +26,9 @@ void ABLFieldInit::initialize_from_inputfile()
     amrex::ParmParse pp_abl("ABL");
     //! Check for wind profile
     pp_abl.query("initial_wind_profile", m_initial_wind_profile);
+    pp_abl.query("terrain_aligned_profile", m_terrain_aligned_profile);
+    amrex::ParmParse pp_terrain("TerrainDrag");
+    pp_terrain.query("terrain_file", m_terrain_file);
     if (m_initial_wind_profile) {
         pp_abl.query("rans_1dprofile_file", m_1d_rans);
         if (!m_1d_rans.empty()) {
@@ -217,15 +221,52 @@ void ABLFieldInit::operator()(
                 velocity(i, j, k, 1) += interp::linear_impl(th, vv, z, idx);
             });
     } else if (m_initial_wind_profile) {
+        //! Compute Terrain
+        //! Reading the Terrain Coordinates from  file
+        amrex::Vector<amrex::Real> xterrain;
+        amrex::Vector<amrex::Real> yterrain;
+        amrex::Vector<amrex::Real> zterrain;
+        if (m_terrain_aligned_profile) {
+            ioutils::read_flat_grid_file(
+                m_terrain_file, xterrain, yterrain, zterrain);
+        }
+        const auto xterrain_size = xterrain.size();
+        const auto yterrain_size = yterrain.size();
+        const auto zterrain_size = zterrain.size();
+        amrex::Gpu::DeviceVector<amrex::Real> d_xterrain(xterrain_size);
+        amrex::Gpu::DeviceVector<amrex::Real> d_yterrain(yterrain_size);
+        amrex::Gpu::DeviceVector<amrex::Real> d_zterrain(zterrain_size);
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, xterrain.begin(), xterrain.end(),
+            d_xterrain.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, yterrain.begin(), yterrain.end(),
+            d_yterrain.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, zterrain.begin(), zterrain.end(),
+            d_zterrain.begin());
+
+        const auto* xterrain_ptr = d_xterrain.data();
+        const auto* yterrain_ptr = d_yterrain.data();
+        const auto* zterrain_ptr = d_zterrain.data();
         //! RANS 1-D profile
         const amrex::Real* windh = m_windht_d.data();
         const amrex::Real* uu = m_prof_u_d.data();
         const amrex::Real* vv = m_prof_v_d.data();
-
+        const bool terrain_aligned_profile = m_terrain_aligned_profile;
         amrex::ParallelFor(
             vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
-
+                amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = problo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+                const amrex::Real terrainHt =
+                    terrain_aligned_profile
+                        ? interp::bilinear(
+                              xterrain_ptr, xterrain_ptr + xterrain_size,
+                              yterrain_ptr, yterrain_ptr + yterrain_size,
+                              zterrain_ptr, x, y)
+                        : 0.0;
+                z = std::max(0.5 * dx[2], z - terrainHt);
                 density(i, j, k) = rho_init;
                 const amrex::Real theta =
                     (ntvals > 0) ? interp::linear(th, th + ntvals, tv, z)
@@ -382,13 +423,56 @@ void ABLFieldInit::init_tke(
     const auto& tke_arrs = tke_mf.arrays();
     const auto tiny = std::numeric_limits<amrex::Real>::epsilon();
     if (m_initial_wind_profile) {
-        const int nwvals = static_cast<int>(m_wind_heights.size());
+        //! Compute Terrain
+        //! Reading the Terrain Coordinates from  file
+        amrex::Vector<amrex::Real> xterrain;
+        amrex::Vector<amrex::Real> yterrain;
+        amrex::Vector<amrex::Real> zterrain;
+        if (m_terrain_aligned_profile) {
+            ioutils::read_flat_grid_file(
+                m_terrain_file, xterrain, yterrain, zterrain);
+        }
+        const auto xterrain_size = xterrain.size();
+        const auto yterrain_size = yterrain.size();
+        const auto zterrain_size = zterrain.size();
+        amrex::Gpu::DeviceVector<amrex::Real> d_xterrain(xterrain_size);
+        amrex::Gpu::DeviceVector<amrex::Real> d_yterrain(yterrain_size);
+        amrex::Gpu::DeviceVector<amrex::Real> d_zterrain(zterrain_size);
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, xterrain.begin(), xterrain.end(),
+            d_xterrain.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, yterrain.begin(), yterrain.end(),
+            d_yterrain.begin());
+        amrex::Gpu::copy(
+            amrex::Gpu::hostToDevice, zterrain.begin(), zterrain.end(),
+            d_zterrain.begin());
+
+        const auto* xterrain_ptr = d_xterrain.data();
+        const auto* yterrain_ptr = d_yterrain.data();
+        const auto* zterrain_ptr = d_zterrain.data();
+        //! RANS 1-D profile
         const amrex::Real* windh = m_windht_d.data();
+        // const amrex::Real* uu = m_prof_u_d.data();
+        // const amrex::Real* vv = m_prof_v_d.data();
+        const bool terrain_aligned_profile = m_terrain_aligned_profile;
+        const int nwvals = static_cast<int>(m_wind_heights.size());
+        // const amrex::Real* windh = m_windht_d.data();
         const amrex::Real* tke_data = m_prof_tke_d.data();
         amrex::ParallelFor(
             tke_mf,
             [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-                const amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+                amrex::Real x = problo[0] + (i + 0.5) * dx[0];
+                amrex::Real y = problo[1] + (j + 0.5) * dx[1];
+                amrex::Real z = problo[2] + (k + 0.5) * dx[2];
+                const amrex::Real terrainHt =
+                    terrain_aligned_profile
+                        ? interp::bilinear(
+                              xterrain_ptr, xterrain_ptr + xterrain_size,
+                              yterrain_ptr, yterrain_ptr + yterrain_size,
+                              zterrain_ptr, x, y)
+                        : 0.0;
+                z = std::max(0.5 * dx[2], z - terrainHt);
                 const amrex::Real tke_prof =
                     (nwvals > 0)
                         ? interp::linear(windh, windh + nwvals, tke_data, z)

--- a/docs/sphinx/user/inputs_ABL.rst
+++ b/docs/sphinx/user/inputs_ABL.rst
@@ -233,5 +233,10 @@ This section is for setting atmospheric boundary layer parameters.
 
    Used in conjunction with `ABL.wall_het_model`. The default value runs a neutral boundary layer. 
 
+.. input_param:: ABL.terrain_aligned_profile 
 
+   **type:** Boolean, optional, default= false
+
+   Used in conjunction with immersed forcing for terrain. This option allows the user to align the wind, temperature and turbulence 
+   profiles to be aligned with the terrain.
 


### PR DESCRIPTION
## Summary

Ability to use 1-D profiles to initialize wind speed, turbulence and temperature has been existing in AMR-Wind in different form. However, the existing methods do not adjust the profile to be consistent with immersed forcing. When the immersed forcing physics is requested, the profiles should originate at the first point above the terrain. This PR modifies the ABL field initialization to provide this capability. It reuses the code snippet from the terrain drag physics. The reason that the code is re-used here as it is a one-time step and does not need the terrain drag physics. 



Please check the type of change introduced:

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [X ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<img width="566" alt="Screenshot 2025-05-16 at 10 27 03 AM (1)" src="https://github.com/user-attachments/assets/8f04f5ae-d16e-45ae-a82e-d4c50f04fd25" />


