### PR TITLE
Improve FreeSurfaceSampler

### DIFF
--- a/unit_tests/utilities/test_free_surface.cpp
+++ b/unit_tests/utilities/test_free_surface.cpp
@@ -142,9 +142,6 @@ void init_vof_diffuse(amr_wind::Field& vof_fld, amrex::Real water_level)
                     1.0, amrex::max<amrex::Real>(
                              0.0, 0.5 + 0.25 * (water_level - z) / dx[2]));
                 farrs[nbx](i, j, k) = local_vof;
-                if (i == 0 && j == 0) {
-                    std::cout << k << " " << local_vof << " " << z << std::endl;
-                }
             });
     }
     amrex::Gpu::streamSynchronize();


### PR DESCRIPTION
## Summary

FreeSurfaceSampler has always assumed that the interface can be "found" in any cell that has a non-integer vof value (i.e., between 0 and 1). Though this isn't wrong, it isn't the best approach in some cases. In particular, when the vof field is smoothed out (as it is when coming from nalu-wind), this will mis-identify the interface. With the changes in this PR, FreeSurfaceSampler now looks at the neighboring cells to find intersections with vof = 0.5 and then finds the interface accordingly.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Makes the biggest difference by enabling this for sampling within Nalu-Wind regions, but it also helps with some edge cases in standalone AMR-Wind simulations.
