### PR TITLE
Improve time interpolation of Waves2AMR approach

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -785,9 +785,18 @@ struct UpdateTargetFieldsOp<W2AWaves>
             // Only perform reading where needed, communicate offset though
             amrex::ParallelDescriptor::ReduceIntMax(wdata.n_offset);
 
-            // If double read is required, then copy older wave data to ow_
-            // fields and modify interpolation parameters to get things right
-            if (double_data == 1) {
+            // Previous W2A data is more recent than last interpolated data
+            t_last = (wdata.ntime - 1) * wdata.dt_modes;
+
+            if (double_data == 0) {
+                // Previous W2A data needs to be copied into ow fields
+                amr_wind::field_ops::copy(
+                    ow_levelset, w2a_levelset, 0, 0, 1, ow_levelset.num_grow());
+                amr_wind::field_ops::copy(
+                    ow_velocity, w2a_velocity, 0, 0, AMREX_SPACEDIM,
+                    ow_velocity.num_grow());
+            } else if (double_data == 1) {
+                // Previous W2A data is unknown, read into ow fields
                 if (wdata.do_interp) {
                     populate_fields_all_levels(
                         wdata, geom, ow_levelset, ow_velocity, -1);
@@ -806,12 +815,8 @@ struct UpdateTargetFieldsOp<W2AWaves>
                 // Fill patch to get correct ghost cells after average down
                 ow_velocity.fillpatch(sim.time().new_time());
                 ow_levelset.fillpatch(sim.time().new_time());
-
-                // Prior t_last (corresponding to ow fields)
-                t_last = (wdata.ntime - 1) * wdata.dt_modes;
-            } else if (double_data == 2) {
-                t_last = (wdata.ntime - 1) * wdata.dt_modes;
             }
+            // ow fields cancel when double_data == 2, no modification
 
             // After possible prior read, now read data for this ntime
             if (wdata.do_interp) {

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -221,31 +221,14 @@ void time_interpolate_wave_fields(
     const amrex::Real t_new,
     const amrex::Real t_future)
 {
-    for (int lev = 0; lev < lvs_field.repo().num_active_levels(); ++lev) {
-        auto phi = lvs_field(lev).arrays();
-        auto vel = vel_field(lev).arrays();
-        const auto future_phi = future_lvs_field(lev).const_arrays();
-        const auto future_vel = future_vel_field(lev).const_arrays();
-
-        amrex::ParallelFor(
-            lvs_field(lev), lvs_field.num_grow(),
-            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-                // Interpolate temporally every time
-                phi[nbx](i, j, k) +=
-                    (future_phi[nbx](i, j, k) - phi[nbx](i, j, k)) *
-                    ((t_new - t_old) / (t_future - t_old + 1e-16));
-                vel[nbx](i, j, k, 0) +=
-                    (future_vel[nbx](i, j, k, 0) - vel[nbx](i, j, k, 0)) *
-                    ((t_new - t_old) / (t_future - t_old + 1e-16));
-                vel[nbx](i, j, k, 1) +=
-                    (future_vel[nbx](i, j, k, 1) - vel[nbx](i, j, k, 1)) *
-                    ((t_new - t_old) / (t_future - t_old + 1e-16));
-                vel[nbx](i, j, k, 2) +=
-                    (future_vel[nbx](i, j, k, 2) - vel[nbx](i, j, k, 2)) *
-                    ((t_new - t_old) / (t_future - t_old + 1e-16));
-            });
-    }
-    amrex::Gpu::streamSynchronize();
+    const amrex::Real b = (t_new - t_old) / (t_future - t_old + 1e-16);
+    const amrex::Real a = 1. - b;
+    amr_wind::field_ops::lincomb(
+        lvs_field, a, lvs_field, 0, b, future_lvs_field, 0, 0, 1,
+        lvs_field.num_grow());
+    amr_wind::field_ops::lincomb(
+        vel_field, a, vel_field, 0, b, future_vel_field, 0, 0, AMREX_SPACEDIM,
+        vel_field.num_grow());
 }
 
 } // namespace

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -212,6 +212,42 @@ void populate_fields_all_levels(
     postprocess_velocity_field_liquid(vel_field, lvs_field, geom_all);
 }
 
+void time_interpolate_wave_fields(
+    amr_wind::Field& lvs_field,
+    amr_wind::Field& vel_field,
+    const amr_wind::Field& future_lvs_field,
+    const amr_wind::Field& future_vel_field,
+    const amrex::Real t_old,
+    const amrex::Real t_new,
+    const amrex::Real t_future)
+{
+    for (int lev = 0; lev < lvs_field.repo().num_active_levels(); ++lev) {
+        auto phi = lvs_field(lev).arrays();
+        auto vel = vel_field(lev).arrays();
+        const auto future_phi = future_lvs_field(lev).const_arrays();
+        const auto future_vel = future_vel_field(lev).const_arrays();
+
+        amrex::ParallelFor(
+            lvs_field(lev), lvs_field.num_grow(),
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+                // Interpolate temporally every time
+                phi[nbx](i, j, k) +=
+                    (future_phi[nbx](i, j, k) - phi[nbx](i, j, k)) *
+                    ((t_new - t_old) / (t_future - t_old + 1e-16));
+                vel[nbx](i, j, k, 0) +=
+                    (future_vel[nbx](i, j, k, 0) - vel[nbx](i, j, k, 0)) *
+                    ((t_new - t_old) / (t_future - t_old + 1e-16));
+                vel[nbx](i, j, k, 1) +=
+                    (future_vel[nbx](i, j, k, 1) - vel[nbx](i, j, k, 1)) *
+                    ((t_new - t_old) / (t_future - t_old + 1e-16));
+                vel[nbx](i, j, k, 2) +=
+                    (future_vel[nbx](i, j, k, 2) - vel[nbx](i, j, k, 2)) *
+                    ((t_new - t_old) / (t_future - t_old + 1e-16));
+            });
+    }
+    amrex::Gpu::streamSynchronize();
+}
+
 } // namespace
 #endif
 
@@ -839,32 +875,9 @@ struct UpdateTargetFieldsOp<W2AWaves>
         }
 
         // Temporally interpolate at every timestep to get target solution
-        for (int lev = 0; lev < nlevels; ++lev) {
-            auto phi = ow_levelset(lev).arrays();
-            auto vel = ow_velocity(lev).arrays();
-            const auto W2A_phi = w2a_levelset(lev).const_arrays();
-            const auto W2A_vel = w2a_velocity(lev).const_arrays();
-
-            const amrex::Real W2A_t = wdata.t;
-            amrex::ParallelFor(
-                ow_levelset(lev), amrex::IntVect(3),
-                [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-                    // Interpolate temporally every time
-                    phi[nbx](i, j, k) +=
-                        (W2A_phi[nbx](i, j, k) - phi[nbx](i, j, k)) *
-                        ((time - t_last) / (W2A_t - t_last + 1e-16));
-                    vel[nbx](i, j, k, 0) +=
-                        (W2A_vel[nbx](i, j, k, 0) - vel[nbx](i, j, k, 0)) *
-                        ((time - t_last) / (W2A_t - t_last + 1e-16));
-                    vel[nbx](i, j, k, 1) +=
-                        (W2A_vel[nbx](i, j, k, 1) - vel[nbx](i, j, k, 1)) *
-                        ((time - t_last) / (W2A_t - t_last + 1e-16));
-                    vel[nbx](i, j, k, 2) +=
-                        (W2A_vel[nbx](i, j, k, 2) - vel[nbx](i, j, k, 2)) *
-                        ((time - t_last) / (W2A_t - t_last + 1e-16));
-                });
-        }
-        amrex::Gpu::streamSynchronize();
+        time_interpolate_wave_fields(
+            ow_levelset, ow_velocity, w2a_levelset, w2a_velocity, t_last, time,
+            wdata.t);
 #else
         amrex::ignore_unused(data, time);
 #endif

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -810,13 +810,7 @@ struct UpdateTargetFieldsOp<W2AWaves>
                 // Prior t_last (corresponding to ow fields)
                 t_last = (wdata.ntime - 1) * wdata.dt_modes;
             } else if (double_data == 2) {
-                // Restarting simulation or taking a big step, new time at ntime
-                // Initialize ow fields to 0 for time interp, will be replaced
-                if (wdata.do_interp) {
-                    ow_levelset.setVal(0.0, ow_levelset.num_grow()[0]);
-                    ow_velocity.setVal(0.0, ow_levelset.num_grow()[0]);
-                }
-                // No modification needed for t_last, leads to interp factor = 1
+                t_last = (wdata.ntime - 1) * wdata.dt_modes;
             }
 
             // After possible prior read, now read data for this ntime
@@ -853,16 +847,16 @@ struct UpdateTargetFieldsOp<W2AWaves>
                     // Interpolate temporally every time
                     phi[nbx](i, j, k) +=
                         (W2A_phi[nbx](i, j, k) - phi[nbx](i, j, k)) *
-                        (time - t_last) / (W2A_t - t_last + 1e-16);
+                        ((time - t_last) / (W2A_t - t_last + 1e-16));
                     vel[nbx](i, j, k, 0) +=
                         (W2A_vel[nbx](i, j, k, 0) - vel[nbx](i, j, k, 0)) *
-                        (time - t_last) / (W2A_t - t_last + 1e-16);
+                        ((time - t_last) / (W2A_t - t_last + 1e-16));
                     vel[nbx](i, j, k, 1) +=
                         (W2A_vel[nbx](i, j, k, 1) - vel[nbx](i, j, k, 1)) *
-                        (time - t_last) / (W2A_t - t_last + 1e-16);
+                        ((time - t_last) / (W2A_t - t_last + 1e-16));
                     vel[nbx](i, j, k, 2) +=
                         (W2A_vel[nbx](i, j, k, 2) - vel[nbx](i, j, k, 2)) *
-                        (time - t_last) / (W2A_t - t_last + 1e-16);
+                        ((time - t_last) / (W2A_t - t_last + 1e-16));
                 });
         }
         amrex::Gpu::streamSynchronize();

--- a/unit_tests/ocean_waves/test_waves_2_amr.cpp
+++ b/unit_tests/ocean_waves/test_waves_2_amr.cpp
@@ -294,7 +294,7 @@ TEST_F(OceanWavesW2ATest, time_interp)
 
     if (t_sim > t_w2a) {
         // Copy current w2a data and update old time
-        amr_wind::field_ops::copy(lvs,w2a_lvs,0,0,1,lvs.num_grow());
+        amr_wind::field_ops::copy(lvs, w2a_lvs, 0, 0, 1, lvs.num_grow());
         t_last = t_w2a;
         // Update w2a values (as in a file read)
         w2a_lvs.setVal(0.);

--- a/unit_tests/ocean_waves/test_waves_2_amr.cpp
+++ b/unit_tests/ocean_waves/test_waves_2_amr.cpp
@@ -259,4 +259,57 @@ TEST_F(OceanWavesW2ATest, time_reset)
     EXPECT_EQ(ntime + noff, 1);
 }
 
+TEST_F(OceanWavesW2ATest, time_interp)
+{
+    populate_parameters();
+    initialize_mesh();
+    // Set up fields and initial values
+    auto& lvs = sim().repo().declare_cc_field("ow_levelset", 1, 3, 1);
+    auto& vel = sim().repo().declare_cc_field("ow_velocity", 3, 3, 1);
+    auto& w2a_lvs = sim().repo().declare_cc_field("w2a_levelset", 1, 3, 1);
+    auto& w2a_vel = sim().repo().declare_cc_field("w2a_velocity", 3, 3, 1);
+    lvs.setVal(0.);
+    amrex::Real t_last = 0.;
+
+    // First time from "file"
+    w2a_lvs.setVal(1.0);
+    amrex::Real t_w2a = 1.;
+
+    // Interpolate once in time
+    amrex::Real t_sim = 0.5;
+    time_interpolate_wave_fields(
+        lvs, vel, w2a_lvs, w2a_vel, t_last, t_sim, t_w2a);
+
+    // Record time that data has been interpolated to
+    t_last = t_sim;
+
+    // Check value of levelset
+    const amrex::Real fmax1 = utils::field_max(lvs);
+    const amrex::Real fmin1 = utils::field_min(lvs);
+    EXPECT_NEAR(fmax1, 0.5, 1e-10);
+    EXPECT_NEAR(fmin1, 0.5, 1e-10);
+
+    // Step forward in time, after current w2a data
+    t_sim += 1.;
+
+    if (t_sim > t_w2a) {
+        // Copy current w2a data and update old time
+        amr_wind::field_ops::copy(lvs,w2a_lvs,0,0,1,lvs.num_grow());
+        t_last = t_w2a;
+        // Update w2a values (as in a file read)
+        w2a_lvs.setVal(0.);
+        t_w2a += 1.;
+    }
+
+    // Interpolate again
+    time_interpolate_wave_fields(
+        lvs, vel, w2a_lvs, w2a_vel, t_last, t_sim, t_w2a);
+
+    // Check value of levelset
+    const amrex::Real fmax2 = utils::field_max(lvs);
+    const amrex::Real fmin2 = utils::field_min(lvs);
+    EXPECT_NEAR(fmax2, 0.5, 1e-10);
+    EXPECT_NEAR(fmin2, 0.5, 1e-10);
+}
+
 } // namespace amr_wind_tests


### PR DESCRIPTION
## Summary

When new data is read in, the code was not properly handling the known w2a fields for the sake of the linear interpolation, which kept things less accurate, especially when the simulation times don't line up with the data times being read.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

This includes refactoring, too. I did local regression tests for the w2a cases to confirm that none of the refactoring changed something by accident. The bugfix, though, will cause clear diffs for all the w2a cases.
