### PR TITLE
remove hard-coded inflow-on-outflow flag

### DIFF
--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -333,11 +333,6 @@ struct AdvectionOp<ICNS, fvm::Godunov>
                     limiter_type = PPM::default_limiter;
                 }
 
-                if ((godunov_scheme == godunov::scheme::WENOZ) ||
-                    (godunov_scheme == godunov::scheme::WENO_JS)) {
-                    m_allow_inflow_on_outflow = true;
-                }
-
                 // if state is NPH, then n and n+1 are known, and only
                 // spatial extrapolation is performed
                 const amrex::Real dt_extrap =


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

I thought this had already been done in #1340 (which followed after #1287), but that was only for the MAC velocity calculation. There should now be no flags turning on allow_inflow_on_outflow; it should only be turned on by an input file argument.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Might cause some small diffs for reg tests that use weno schemes
