### PR TITLE
Fix Typographical Errors in Compatibility Layer Documentation

### DIFF
--- a/docs/sphinx/user/inspect_abl_io.html
+++ b/docs/sphinx/user/inspect_abl_io.html
@@ -9129,8 +9129,8 @@ label {
 }
 /* Flexible box model classes */
 /* Taken from Alex Russell http://infrequently.org/2009/08/css-3-progress/ */
-/* This file is a compatability layer.  It allows the usage of flexible box 
-model layouts accross multiple browsers, including older browsers.  The newest,
+/* This file is a compatibility layer.  It allows the usage of flexible box 
+model layouts across multiple browsers, including older browsers.  The newest,
 universal implementation of the flexible box model is used when available (see
 `Modern browsers` comments below).  Browsers that are known to implement this 
 new spec completely include:


### PR DESCRIPTION


**Description:**
This pull request corrects typographical errors in the comments of the `inspect_abl_io.html` file. Specifically, it fixes the spelling of `compatability` to `compatibility` and `across` to `across` in the documentation. These changes improve the clarity and professionalism of the documentation. 