### PR TITLE
Make initial iterations compatible with boundary planes

### DIFF
--- a/amr-wind/equation_systems/PDE.H
+++ b/amr-wind/equation_systems/PDE.H
@@ -137,7 +137,9 @@ public:
     {
         BL_PROFILE(
             "amr-wind::" + this->identifier() + "::pre_advection_actions");
-        m_adv_op->preadvect(fstate, m_time.delta_t(), m_time.current_time());
+        m_adv_op->preadvect(
+            fstate, m_time.delta_t(),
+            0.5 * (m_time.current_time() + m_time.new_time()));
     }
 
     void compute_predictor_rhs(const DiffusionType difftype) override

--- a/amr-wind/equation_systems/PDEBase.cpp
+++ b/amr-wind/equation_systems/PDEBase.cpp
@@ -94,7 +94,7 @@ void PDEMgr::prepare_boundaries()
 {
     // If state variables exist at NPH, fill their boundary cells
     const auto nph_time =
-        m_sim.time().current_time() + 0.5 * m_sim.time().delta_t();
+        0.5 * (m_sim.time().current_time() + m_sim.time().new_time());
     if (m_constant_density &&
         m_sim.repo().field_exists("density", FieldState::NPH)) {
         auto& nph_field =

--- a/amr-wind/equation_systems/icns/icns_advection.H
+++ b/amr-wind/equation_systems/icns/icns_advection.H
@@ -208,7 +208,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
         }
 
         // Populate boundaries (valid cells) using velocity BCs
-        m_macproj_op.set_inflow_velocity(time + 0.5 * dt);
+        m_macproj_op.set_inflow_velocity(time);
 
         // MAC projection
         m_macproj_op(fstate, dt);
@@ -218,7 +218,7 @@ struct AdvectionOp<ICNS, fvm::Godunov>
             amrex::Array<Field*, AMREX_SPACEDIM> mac_vel = {
                 AMREX_D_DECL(&u_mac, &v_mac, &w_mac)};
             dof_field.fillpatch_sibling_fields(
-                time + 0.5 * dt, u_mac.num_grow(), mac_vel);
+                time, u_mac.num_grow(), mac_vel);
         }
 
         for (int lev = 0; lev < repo.num_active_levels(); ++lev) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -403,6 +403,7 @@ endif()
 
 if(AMR_WIND_ENABLE_NETCDF)
   add_test_red(abl_bndry_input abl_bndry_output)
+  add_test_red(abl_bndry_input_init abl_bndry_output)
   add_test_red(abl_bndry_input_amr abl_bndry_output)
   add_test_red(abl_bndry_input_amr_inflow abl_bndry_output_amr_inflow)
   add_test_red(abl_bndry_input_amr_upper abl_bndry_output_amr_upper)

--- a/test/test_files/abl_bndry_input_init/abl_bndry_input_init.inp
+++ b/test/test_files/abl_bndry_input_init/abl_bndry_input_init.inp
@@ -6,13 +6,13 @@ time.max_step                =   10          # Max number of time steps
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #
 #.......................................#
-time.fixed_dt         =   0.5        # Use this constant dt if > 0
+time.fixed_dt         =   0.4        # Use this constant dt if > 0
 time.cfl              =   0.95         # CFL factor
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            INPUT AND OUTPUT           #
 #.......................................#
 time.plot_interval            =  10       # Steps between plot files
-time.checkpoint_interval      =  4       # Steps between checkpoint files
+time.checkpoint_interval      =  -1       # Steps between checkpoint files
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #               PHYSICS                 #
 #.......................................#
@@ -46,10 +46,8 @@ ABL.deltaU = 1.0
 ABL.deltaV = 1.0
 ABL.kappa = .41
 ABL.surface_roughness_z0 = 0.01
-ABL.bndry_file = "bndry_file.nc"
-ABL.bndry_io_mode = 0
-ABL.bndry_planes = ylo xlo
-ABL.bndry_output_start_time = 0.0
+ABL.bndry_file = "../abl_bndry_output/bndry_file.nc"
+ABL.bndry_io_mode = 1
 ABL.bndry_var_names = velocity temperature
 ABL.bndry_output_format = netcdf
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
@@ -62,10 +60,17 @@ amr.max_level           = 0           # Max AMR level in hierarchy
 #.......................................#
 geometry.prob_lo        =   0.       0.     0.  # Lo corner coordinates
 geometry.prob_hi        =   1000.  1000.  1000.  # Hi corner coordinates
-geometry.is_periodic    =   1   1   0   # Periodicity x y z (0/1)
+geometry.is_periodic    =   0   0   0   # Periodicity x y z (0/1)
 # Boundary conditions
+xlo.type = "mass_inflow"
+xlo.density = 1.0
+xlo.temperature = 0.0
+xhi.type = "pressure_outflow"
+ylo.type = "mass_inflow"
+ylo.density = 1.0
+ylo.temperature = 0.0
+yhi.type = "pressure_outflow"
 zlo.type =   "wall_model"
-
 zhi.type =   "slip_wall"
 zhi.temperature_type = "fixed_gradient"
 zhi.temperature = 0.0


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

Ever since the boundary fills were updated to be more accurate (filling at n+1/2 and n+1), this broke compatibility with the initial iterations because these go forward in time and back. This would lead to having data at n+1/2 when things needed to be filled at n, which isn't possible with the current boundary approach. By changing the calculation of time at n+1/2 to be 0.5*(current time + new time) instead of current time + 0.5*dt, things are made compatible again. During the initial iterations, the new time is the same as the current time, which eliminates the conflicts while still getting the same value during the actual simulation.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
