### PR TITLE
prevent AMR-Wind from ending an overset simulation or glitching time step index

### DIFF
--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -170,6 +170,13 @@ public:
     //! Calculate minimum enforce dt tolerance based on all considerations
     void calculate_minimum_enforce_dt_abs_tol();
 
+    //! Deactivate ending parameters (overset should be externally controlled)
+    void override_simulation_end_parameters()
+    {
+        m_stop_time_index = -1;
+        m_stop_time = -1.;
+    }
+
 private:
     //! Timestep sizes
     amrex::Vector<amrex::Real> m_dt =

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -104,6 +104,7 @@ void incflo::init_amr_wind_modules()
 {
     BL_PROFILE("amr-wind::incflo::init_amr_wind_modules");
     if (m_sim.has_overset()) {
+        m_time.override_simulation_end_parameters();
         m_sim.overset_manager()->post_init_actions();
         m_ovst_ops.initialize(m_sim);
     } else {


### PR DESCRIPTION
## Summary

In AMR-Wind, the function new_timestep() is needed to advance the time step index, but this function also checks whether the max step index or max time have been exceeded. In overset simulations with exawind-driver, if there is a conflict between the end-of-simulation parameters, exawind will keep driving the simulation but the time step count in AMR-Wind will not increase.

On top of that, in adaptive time step simulations, the dt gets limited by the max time as well, to avoid overshooting the end of the simulation. In that case, exawind will keep driving the simulation but the dt will become machine 0, killing the simulation.

I think it makes the most sense to only allow exawind-driver to affect the end of the simulation and just to completely override whatever is in the amr-wind input concerning max steps or stop time. This makes it easier for users, too.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
