### PR TITLE
Terrain Drag Marking Update 

### DIFF
--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -347,18 +347,6 @@ void DragForcing::operator()(
                     -(tmp_wind_target[0] - uz1) / dt * blank(i, j + 1, k);
                 bc_forcing_x +=
                     -(tmp_wind_target[1] - ux1) / dt * blank(i, j + 1, k);
-                // const amrex::Real sum_blank_x = blank(i, j - 1, k) +
-                //                                 blank(i, j + 1, k) +
-                //                                 blank(i, j, k - 1);
-                // bc_forcing_x /= (sum_blank_x + amr_wind::constants::EPS);
-                // const amrex::Real sum_blank_y = blank(i - 1, j, k) +
-                //                                 blank(i + 1, j, k) +
-                //                                 blank(i, j, k - 1);
-                // bc_forcing_y /= (sum_blank_y + amr_wind::constants::EPS);
-                // const amrex::Real sum_blank_z =
-                //     blank(i - 1, j, k) + blank(i + 1, j, k) +
-                //     blank(i, j - 1, k) + blank(i, j + 1, k);
-                // bc_forcing_z /= (sum_blank_z + amr_wind::constants::EPS);
             }
         }
         // Target velocity intended for within terrain

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -316,46 +316,49 @@ void DragForcing::operator()(
             bc_forcing_x = -(uxTarget - ux1) / dt;
             bc_forcing_y = -(uyTarget - uy1) / dt;
             //! Adding horizonal drag
-            if(drag(i,j,k)>1){
-            //! West
-            amrex::GpuArray<amrex::Real, 2> tmp_wind_target =
-                compute_target_wind(
-                    vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), dx[0], z0, kappa);
-            bc_forcing_z +=
-                -(tmp_wind_target[0] - uz1) / dt * blank(i - 1, j, k);
-            bc_forcing_y +=
-                -(tmp_wind_target[1] - uy1) / dt * blank(i - 1, j, k);
-            //! East
-            tmp_wind_target = compute_target_wind(
-                vel(i + 1, j, k, 2), vel(i + 1, j, k, 1), dx[0], z0, kappa);
-            bc_forcing_z +=
-                -(tmp_wind_target[0] - uz1) / dt * blank(i + 1, j, k);
-            bc_forcing_y +=
-                -(tmp_wind_target[1] - uy1) / dt * blank(i + 1, j, k);
-            //! South
-            tmp_wind_target = compute_target_wind(
-                vel(i, j - 1, k, 2), vel(i, j - 1, k, 0), dx[1], z0, kappa);
-            bc_forcing_z +=
-                -(tmp_wind_target[0] - uz1) / dt * blank(i, j - 1, k);
-            bc_forcing_x +=
-                -(tmp_wind_target[1] - ux1) / dt * blank(i, j - 1, k);
-            //! North
-            tmp_wind_target = compute_target_wind(
-                vel(i, j + 1, k, 2), vel(i, j + 1, k, 0), dx[1], z0, kappa);
-            bc_forcing_z +=
-                -(tmp_wind_target[0] - uz1) / dt * blank(i, j + 1, k);
-            bc_forcing_x +=
-                -(tmp_wind_target[1] - ux1) / dt * blank(i, j + 1, k);
-            const amrex::Real sum_blank_x =
-                blank(i, j - 1, k) + blank(i, j + 1, k) + blank(i, j, k - 1);
-            bc_forcing_x /= (sum_blank_x + amr_wind::constants::EPS);
-            const amrex::Real sum_blank_y =
-                blank(i - 1, j, k) + blank(i + 1, j, k) + blank(i, j, k - 1);
-            bc_forcing_y /= (sum_blank_y + amr_wind::constants::EPS);
-            const amrex::Real sum_blank_z =
-                blank(i - 1, j, k) + blank(i + 1, j, k) + blank(i, j - 1, k) +
-                blank(i, j + 1, k);
-            bc_forcing_z /= (sum_blank_z + amr_wind::constants::EPS);
+            if (drag(i, j, k) > 1) {
+                //! West
+                amrex::GpuArray<amrex::Real, 2> tmp_wind_target =
+                    compute_target_wind(
+                        vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), dx[0], z0,
+                        kappa);
+                bc_forcing_z +=
+                    -(tmp_wind_target[0] - uz1) / dt * blank(i - 1, j, k);
+                bc_forcing_y +=
+                    -(tmp_wind_target[1] - uy1) / dt * blank(i - 1, j, k);
+                //! East
+                tmp_wind_target = compute_target_wind(
+                    vel(i + 1, j, k, 2), vel(i + 1, j, k, 1), dx[0], z0, kappa);
+                bc_forcing_z +=
+                    -(tmp_wind_target[0] - uz1) / dt * blank(i + 1, j, k);
+                bc_forcing_y +=
+                    -(tmp_wind_target[1] - uy1) / dt * blank(i + 1, j, k);
+                //! South
+                tmp_wind_target = compute_target_wind(
+                    vel(i, j - 1, k, 2), vel(i, j - 1, k, 0), dx[1], z0, kappa);
+                bc_forcing_z +=
+                    -(tmp_wind_target[0] - uz1) / dt * blank(i, j - 1, k);
+                bc_forcing_x +=
+                    -(tmp_wind_target[1] - ux1) / dt * blank(i, j - 1, k);
+                //! North
+                tmp_wind_target = compute_target_wind(
+                    vel(i, j + 1, k, 2), vel(i, j + 1, k, 0), dx[1], z0, kappa);
+                bc_forcing_z +=
+                    -(tmp_wind_target[0] - uz1) / dt * blank(i, j + 1, k);
+                bc_forcing_x +=
+                    -(tmp_wind_target[1] - ux1) / dt * blank(i, j + 1, k);
+                const amrex::Real sum_blank_x = blank(i, j - 1, k) +
+                                                blank(i, j + 1, k) +
+                                                blank(i, j, k - 1);
+                bc_forcing_x /= (sum_blank_x + amr_wind::constants::EPS);
+                const amrex::Real sum_blank_y = blank(i - 1, j, k) +
+                                                blank(i + 1, j, k) +
+                                                blank(i, j, k - 1);
+                bc_forcing_y /= (sum_blank_y + amr_wind::constants::EPS);
+                const amrex::Real sum_blank_z =
+                    blank(i - 1, j, k) + blank(i + 1, j, k) +
+                    blank(i, j - 1, k) + blank(i, j + 1, k);
+                bc_forcing_z /= (sum_blank_z + amr_wind::constants::EPS);
             }
         }
         // Target velocity intended for within terrain

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -315,7 +315,7 @@ void DragForcing::operator()(
             // BC forcing pushes nonrelative velocity toward target velocity
             bc_forcing_x = -(uxTarget - ux1) / dt;
             bc_forcing_y = -(uyTarget - uy1) / dt;
-            //! Adding horizonal drag
+            //! Adding horizontal drag
             if (drag(i, j, k) > 1) {
                 //! West
                 amrex::GpuArray<amrex::Real, 2> tmp_wind_target =

--- a/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/amr-wind/equation_systems/icns/source_terms/DragForcing.cpp
@@ -347,18 +347,18 @@ void DragForcing::operator()(
                     -(tmp_wind_target[0] - uz1) / dt * blank(i, j + 1, k);
                 bc_forcing_x +=
                     -(tmp_wind_target[1] - ux1) / dt * blank(i, j + 1, k);
-                const amrex::Real sum_blank_x = blank(i, j - 1, k) +
-                                                blank(i, j + 1, k) +
-                                                blank(i, j, k - 1);
-                bc_forcing_x /= (sum_blank_x + amr_wind::constants::EPS);
-                const amrex::Real sum_blank_y = blank(i - 1, j, k) +
-                                                blank(i + 1, j, k) +
-                                                blank(i, j, k - 1);
-                bc_forcing_y /= (sum_blank_y + amr_wind::constants::EPS);
-                const amrex::Real sum_blank_z =
-                    blank(i - 1, j, k) + blank(i + 1, j, k) +
-                    blank(i, j - 1, k) + blank(i, j + 1, k);
-                bc_forcing_z /= (sum_blank_z + amr_wind::constants::EPS);
+                // const amrex::Real sum_blank_x = blank(i, j - 1, k) +
+                //                                 blank(i, j + 1, k) +
+                //                                 blank(i, j, k - 1);
+                // bc_forcing_x /= (sum_blank_x + amr_wind::constants::EPS);
+                // const amrex::Real sum_blank_y = blank(i - 1, j, k) +
+                //                                 blank(i + 1, j, k) +
+                //                                 blank(i, j, k - 1);
+                // bc_forcing_y /= (sum_blank_y + amr_wind::constants::EPS);
+                // const amrex::Real sum_blank_z =
+                //     blank(i - 1, j, k) + blank(i + 1, j, k) +
+                //     blank(i, j - 1, k) + blank(i, j + 1, k);
+                // bc_forcing_z /= (sum_blank_z + amr_wind::constants::EPS);
             }
         }
         // Target velocity intended for within terrain

--- a/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
@@ -131,29 +131,36 @@ void DragTempForcing::operator()(
             surf_temp +
             thetastar / kappa * (std::log(0.5 * dx[2] / z0) - psi_h_cell);
         amrex::Real bc_forcing_t = -(tTarget - theta) / dt;
-        // //! West
-        // amrex::Real tmp_temp_target
-        // =compute_target_theta(vel(i-1,j,k,2),vel(i-1,j,k,1),theta,
-        // monin_obukhov_length, gravity_mod, dx[0],z0, kappa);
-        // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i-1,j,k);
-        // //! East
-        // tmp_temp_target =
-        // compute_target_theta(vel(i+1,j,k,2),vel(i+1,j,k,1),theta,
-        // monin_obukhov_length, gravity_mod, dx[0],z0, kappa);
-        // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i+1,j,k);
-        // //! South
-        // tmp_temp_target =
-        // compute_target_theta(vel(i,j-1,k,2),vel(i,j-1,k,0),theta,
-        // monin_obukhov_length, gravity_mod, dx[1],z0, kappa);
-        // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i,j-1,k);
-        // //! North
-        // tmp_temp_target =
-        // compute_target_theta(vel(i,j+1,k,2),vel(i,j+1,k,0),theta,
-        // monin_obukhov_length, gravity_mod, dx[1],z0, kappa);
-        // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i,j+1,k);
-        // const amrex::Real sum_blank_t =  blank(i,j,k-1)+blank(i - 1, j, k) +
-        // blank(i + 1, j, k) + blank(i, j - 1, k) + blank(i, j + 1, k);
-        // bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
+        if (cell_drag > 1) {
+            //! West
+            amrex::Real tmp_temp_target = compute_target_theta(
+                vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), theta,
+                monin_obukhov_length, gravity_mod, dx[0], z0, kappa);
+            bc_forcing_t +=
+                -(tmp_temp_target - theta) / dt * blank(i - 1, j, k);
+            //! East
+            tmp_temp_target = compute_target_theta(
+                vel(i + 1, j, k, 2), vel(i + 1, j, k, 1), theta,
+                monin_obukhov_length, gravity_mod, dx[0], z0, kappa);
+            bc_forcing_t +=
+                -(tmp_temp_target - theta) / dt * blank(i + 1, j, k);
+            //! South
+            tmp_temp_target = compute_target_theta(
+                vel(i, j - 1, k, 2), vel(i, j - 1, k, 0), theta,
+                monin_obukhov_length, gravity_mod, dx[1], z0, kappa);
+            bc_forcing_t +=
+                -(tmp_temp_target - theta) / dt * blank(i, j - 1, k);
+            //! North
+            tmp_temp_target = compute_target_theta(
+                vel(i, j + 1, k, 2), vel(i, j + 1, k, 0), theta,
+                monin_obukhov_length, gravity_mod, dx[1], z0, kappa);
+            bc_forcing_t +=
+                -(tmp_temp_target - theta) / dt * blank(i, j + 1, k);
+            const amrex::Real sum_blank_t =
+                blank(i, j, k - 1) + blank(i - 1, j, k) + blank(i + 1, j, k) +
+                blank(i, j - 1, k) + blank(i, j + 1, k);
+            bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
+        }
         const amrex::Real m = std::sqrt(ux1 * ux1 + uy1 * uy1 + uz1 * uz1);
         const amrex::Real Cd =
             std::min(drag_coefficient / (m + tiny), cd_max / dx[2]);

--- a/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
@@ -131,7 +131,7 @@ void DragTempForcing::operator()(
             surf_temp +
             thetastar / kappa * (std::log(0.5 * dx[2] / z0) - psi_h_cell);
         amrex::Real bc_forcing_t = -(tTarget - theta) / dt;
-        if (cell_drag > 1) {
+        if (drag(i, j, k) > 1) {
             //! West
             amrex::Real tmp_temp_target = compute_target_theta(
                 vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), theta,
@@ -156,10 +156,6 @@ void DragTempForcing::operator()(
                 monin_obukhov_length, gravity_mod, dx[1], z0, kappa);
             bc_forcing_t +=
                 -(tmp_temp_target - theta) / dt * blank(i, j + 1, k);
-            // const amrex::Real sum_blank_t =
-            //     blank(i, j, k - 1) + blank(i - 1, j, k) + blank(i + 1, j, k) +
-            //     blank(i, j - 1, k) + blank(i, j + 1, k);
-            // bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
         }
         const amrex::Real m = std::sqrt(ux1 * ux1 + uy1 * uy1 + uz1 * uz1);
         const amrex::Real Cd =

--- a/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
@@ -8,9 +8,8 @@
 #include "AMReX_Random.H"
 #include "amr-wind/utilities/constants.H"
 
-namespace{
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
-compute_target_theta(
+namespace {
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real compute_target_theta(
     const amrex::Real ux,
     const amrex::Real uy,
     const amrex::Real theta,
@@ -23,17 +22,14 @@ compute_target_theta(
     const amrex::Real wspd = std::sqrt(ux * ux + uy * uy);
     const amrex::Real ustar = wspd * kappa / std::log(1.5 * dx / z0);
     const amrex::Real thetastar =
-        theta * ustar * ustar /
-        (kappa * gravity_mod * monin_obukhov_length);
+        theta * ustar * ustar / (kappa * gravity_mod * monin_obukhov_length);
     const amrex::Real surf_temp =
-        theta -
-        thetastar / kappa * (std::log(1.5 * dx / z0));
+        theta - thetastar / kappa * (std::log(1.5 * dx / z0));
     const amrex::Real tTarget =
-        surf_temp +
-        thetastar / kappa * (std::log(0.5 * dx / z0));
+        surf_temp + thetastar / kappa * (std::log(0.5 * dx / z0));
     return tTarget;
 }
-}
+} // namespace
 namespace amr_wind::pde::temperature {
 
 DragTempForcing::DragTempForcing(const CFDSim& sim)
@@ -114,7 +110,7 @@ void DragTempForcing::operator()(
     const amrex::Real cd_max = 10.0;
     const amrex::Real T0 = m_soil_temperature;
     amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        const int cell_drag = (drag(i,j,k)> 0) ? 1 : 0;
+        const int cell_drag = (drag(i, j, k) > 0) ? 1 : 0;
         const amrex::Real z0 = std::max(terrainz0(i, j, k), z0_min);
         const amrex::Real ux1 = vel(i, j, k, 0);
         const amrex::Real uy1 = vel(i, j, k, 1);
@@ -136,29 +132,33 @@ void DragTempForcing::operator()(
             thetastar / kappa * (std::log(0.5 * dx[2] / z0) - psi_h_cell);
         amrex::Real bc_forcing_t = -(tTarget - theta) / dt;
         // //! West
-        // amrex::Real tmp_temp_target =compute_target_theta(vel(i-1,j,k,2),vel(i-1,j,k,1),theta,
+        // amrex::Real tmp_temp_target
+        // =compute_target_theta(vel(i-1,j,k,2),vel(i-1,j,k,1),theta,
         // monin_obukhov_length, gravity_mod, dx[0],z0, kappa);
         // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i-1,j,k);
         // //! East
-        // tmp_temp_target = compute_target_theta(vel(i+1,j,k,2),vel(i+1,j,k,1),theta,
+        // tmp_temp_target =
+        // compute_target_theta(vel(i+1,j,k,2),vel(i+1,j,k,1),theta,
         // monin_obukhov_length, gravity_mod, dx[0],z0, kappa);
         // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i+1,j,k);
         // //! South
-        // tmp_temp_target = compute_target_theta(vel(i,j-1,k,2),vel(i,j-1,k,0),theta,
+        // tmp_temp_target =
+        // compute_target_theta(vel(i,j-1,k,2),vel(i,j-1,k,0),theta,
         // monin_obukhov_length, gravity_mod, dx[1],z0, kappa);
         // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i,j-1,k);
         // //! North
-        // tmp_temp_target = compute_target_theta(vel(i,j+1,k,2),vel(i,j+1,k,0),theta,
+        // tmp_temp_target =
+        // compute_target_theta(vel(i,j+1,k,2),vel(i,j+1,k,0),theta,
         // monin_obukhov_length, gravity_mod, dx[1],z0, kappa);
         // bc_forcing_t += -(tmp_temp_target - theta) / dt * blank(i,j+1,k);
-        // const amrex::Real sum_blank_t =  blank(i,j,k-1)+blank(i - 1, j, k) + blank(i + 1, j, k) + blank(i, j - 1, k) + blank(i, j + 1, k);
+        // const amrex::Real sum_blank_t =  blank(i,j,k-1)+blank(i - 1, j, k) +
+        // blank(i + 1, j, k) + blank(i, j - 1, k) + blank(i, j + 1, k);
         // bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
         const amrex::Real m = std::sqrt(ux1 * ux1 + uy1 * uy1 + uz1 * uz1);
         const amrex::Real Cd =
             std::min(drag_coefficient / (m + tiny), cd_max / dx[2]);
         src_term(i, j, k, 0) -=
-            (Cd * (theta - T0) * blank(i, j, k, 0) +
-             bc_forcing_t * cell_drag);
+            (Cd * (theta - T0) * blank(i, j, k, 0) + bc_forcing_t * cell_drag);
     });
 }
 

--- a/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
@@ -131,8 +131,8 @@ void DragTempForcing::operator()(
             surf_temp +
             thetastar / kappa * (std::log(0.5 * dx[2] / z0) - psi_h_cell);
         amrex::Real bc_forcing_t = -(tTarget - theta) / dt;
+        //! West
         if (drag(i, j, k) > 1) {
-            //! West
             amrex::Real tmp_temp_target = compute_target_theta(
                 vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), theta,
                 monin_obukhov_length, gravity_mod, dx[0], z0, kappa);

--- a/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
+++ b/amr-wind/equation_systems/temperature/source_terms/DragTempForcing.cpp
@@ -156,10 +156,10 @@ void DragTempForcing::operator()(
                 monin_obukhov_length, gravity_mod, dx[1], z0, kappa);
             bc_forcing_t +=
                 -(tmp_temp_target - theta) / dt * blank(i, j + 1, k);
-            const amrex::Real sum_blank_t =
-                blank(i, j, k - 1) + blank(i - 1, j, k) + blank(i + 1, j, k) +
-                blank(i, j - 1, k) + blank(i, j + 1, k);
-            bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
+            // const amrex::Real sum_blank_t =
+            //     blank(i, j, k - 1) + blank(i - 1, j, k) + blank(i + 1, j, k) +
+            //     blank(i, j - 1, k) + blank(i, j + 1, k);
+            // bc_forcing_t /= (sum_blank_t + amr_wind::constants::EPS);
         }
         const amrex::Real m = std::sqrt(ux1 * ux1 + uy1 * uy1 + uz1 * uz1);
         const amrex::Real Cd =

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -164,9 +164,10 @@ void KransAxell::operator()(
         const auto& terrainz0 = (*m_terrainz0)(lev).const_array(mfi);
         amrex::ParallelFor(
             bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                const int cell_drag = (drag_arr(i, j, k) > 0) ? 1 : 0;
                 const amrex::Real cell_z0 =
-                    drag_arr(i, j, k) * std::max(terrainz0(i, j, k), z0_min) +
-                    (1 - drag_arr(i, j, k)) * z0;
+                    cell_drag * std::max(terrainz0(i, j, k), z0_min) +
+                    (1 - cell_drag) * z0;
                 amrex::Real terrainforcing = 0;
                 amrex::Real dragforcing = 0;
                 amrex::Real ux = vel(i, j, k + 1, 0);
@@ -211,7 +212,7 @@ void KransAxell::operator()(
                     1.0 / dt * (tke_arr(i, j, k) - ref_tke);
                 src_term(i, j, k) =
                     (1 - blank_arr(i, j, k)) * src_term(i, j, k) +
-                    drag_arr(i, j, k) * terrainforcing +
+                    cell_drag * terrainforcing +
                     blank_arr(i, j, k) * dragforcing -
                     static_cast<int>(has_terrain) *
                         (sponge_forcing - bcforcing);

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -199,7 +199,7 @@ void KransAxell::operator()(
                 terrainforcing =
                     (ustar * ustar / (Cmu * Cmu) + rans_b - tke_arr(i, j, k)) /
                     dt;
-                if (cell_drag > 1) {
+                if (drag(i, j, k) > 1) {
                     //! West
                     ustar = compute_target_ustar(
                         vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), dx[0], z0,
@@ -228,12 +228,6 @@ void KransAxell::operator()(
                     terrainforcing +=
                         (ustar * ustar / (Cmu * Cmu) - tke_arr(i, j, k)) / dt *
                         blank_arr(i, j + 1, k);
-                    // const amrex::Real sum_blank_tke =
-                    //     blank_arr(i, j, k - 1) + blank_arr(i - 1, j, k) +
-                    //     blank_arr(i + 1, j, k) + blank_arr(i, j - 1, k) +
-                    //     blank_arr(i, j + 1, k);
-                    // terrainforcing /=
-                    //     (sum_blank_tke + amr_wind::constants::EPS);
                 }
                 amrex::Real bcforcing = 0;
                 if (k == 0) {

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -199,7 +199,7 @@ void KransAxell::operator()(
                 terrainforcing =
                     (ustar * ustar / (Cmu * Cmu) + rans_b - tke_arr(i, j, k)) /
                     dt;
-                if (drag(i, j, k) > 1) {
+                if (drag_arr(i, j, k) > 1) {
                     //! West
                     ustar = compute_target_ustar(
                         vel(i - 1, j, k, 2), vel(i - 1, j, k, 1), dx[0], z0,

--- a/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/amr-wind/equation_systems/tke/source_terms/KransAxell.cpp
@@ -228,12 +228,12 @@ void KransAxell::operator()(
                     terrainforcing +=
                         (ustar * ustar / (Cmu * Cmu) - tke_arr(i, j, k)) / dt *
                         blank_arr(i, j + 1, k);
-                    const amrex::Real sum_blank_tke =
-                        blank_arr(i, j, k - 1) + blank_arr(i - 1, j, k) +
-                        blank_arr(i + 1, j, k) + blank_arr(i, j - 1, k) +
-                        blank_arr(i, j + 1, k);
-                    terrainforcing /=
-                        (sum_blank_tke + amr_wind::constants::EPS);
+                    // const amrex::Real sum_blank_tke =
+                    //     blank_arr(i, j, k - 1) + blank_arr(i - 1, j, k) +
+                    //     blank_arr(i + 1, j, k) + blank_arr(i, j - 1, k) +
+                    //     blank_arr(i, j + 1, k);
+                    // terrainforcing /=
+                    //     (sum_blank_tke + amr_wind::constants::EPS);
                 }
                 amrex::Real bcforcing = 0;
                 if (k == 0) {

--- a/amr-wind/physics/TerrainDrag.H
+++ b/amr-wind/physics/TerrainDrag.H
@@ -5,6 +5,7 @@
 #include "amr-wind/core/Field.H"
 #include "amr-wind/CFDSim.H"
 
+
 namespace amr_wind::terraindrag {
 
 /** Terraindrag Flow physics
@@ -55,6 +56,7 @@ private:
     IntField& m_terrain_blank;
     //! Terrain drag force term
     IntField& m_terrain_drag;
+
 
     //! Terrain file
     std::string m_terrain_file{"terrain.amrwind"};

--- a/amr-wind/physics/TerrainDrag.H
+++ b/amr-wind/physics/TerrainDrag.H
@@ -5,7 +5,6 @@
 #include "amr-wind/core/Field.H"
 #include "amr-wind/CFDSim.H"
 
-
 namespace amr_wind::terraindrag {
 
 /** Terraindrag Flow physics
@@ -56,7 +55,6 @@ private:
     IntField& m_terrain_blank;
     //! Terrain drag force term
     IntField& m_terrain_drag;
-
 
     //! Terrain file
     std::string m_terrain_file{"terrain.amrwind"};

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -141,53 +141,6 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
             levelz0[nbx](i, j, k, 0) = roughz0;
         });
     amrex::Gpu::streamSynchronize();
-    // amrex::ParallelFor(
-    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept
-    //     {
-    //         const amrex::GpuArray<int, 5> cell_blanking{
-    //             levelBlanking[nbx](i, j, k - 1, 0),
-    //             levelBlanking[nbx](i - 1, j, k, 0),
-    //             levelBlanking[nbx](i + 1, j, k, 0),
-    //             levelBlanking[nbx](i, j - 1, k, 0),
-    //             levelBlanking[nbx](i, j + 1, k, 0)};
-    //         levelDrag[nbx](i, j, k, 0) = 0;
-    //         for (int index = 0; index <= 4; ++index) {
-    //             if ((levelBlanking[nbx](i, j, k, 0) == 0) &&
-    //                 (cell_blanking[index] == 1) && (levelDrag[nbx](i, j, k,
-    //                 0) == 0)) { levelDrag[nbx](i, j, k, 0) = index + 1;
-    //             }
-    //         }
-    //     });
-    // amrex::Gpu::streamSynchronize();
-
-    //     amrex::ParallelFor(
-    //         blanking,
-    //         [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-    //             if ((levelBlanking[nbx](i, j, k, 0) == 0) &&
-    //                 (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
-    //                 levelDrag[nbx](i, j, k, 0) = 1;
-    //             } else {
-    //                 levelDrag[nbx](i, j, k, 0) = 0;
-    //             }
-    //         });
-    // amrex::Gpu::streamSynchronize();
-    // amrex::ParallelFor(
-    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept
-    //     {
-    //         const amrex::GpuArray<int, 4> cell_blanking{
-    //             levelBlanking[nbx](i - 1, j, k, 0),
-    //             levelBlanking[nbx](i + 1, j, k, 0),
-    //             levelBlanking[nbx](i, j - 1, k, 0),
-    //             levelBlanking[nbx](i, j + 1, k, 0)};
-    //         levelDrag[nbx](i, j, k, 0) = 0;
-    //         for (int index = 0; index <= 3; ++index) {
-    //             if ((levelBlanking[nbx](i, j, k, 0) == 0) &&
-    //                 (cell_blanking[index] == 1) ) {
-    //                 levelDrag[nbx](i, j, k, 0) = 1;
-    //             }
-    //         }
-    //     });
-    // amrex::Gpu::streamSynchronize();
     amrex::ParallelFor(
         blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
             const int blankxp = std::abs(
@@ -214,6 +167,7 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
                     : (blankxp + blankxm + blankyp + blankym + blankzp +
                        blankzm);
         });
+    amrex::Gpu::streamSynchronize();
 }
 
 void TerrainDrag::post_init_actions()

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -162,11 +162,12 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
                 levelBlanking[nbx](i, j, k - 1, 0) -
                 levelBlanking[nbx](i, j, k, 0));
             levelDrag[nbx](i, j, k, 0) =
-                ((k == 0 && levelBlanking[nbx](i, j, k, 0) == 1))
+                ((k == 0)
                     ? 0
                     : (blankxp + blankxm + blankyp + blankym + blankzp +
-                       blankzm);
-        });
+                       blankzm));
+            }
+        );
     amrex::Gpu::streamSynchronize();
 }
 

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -142,7 +142,8 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
         });
     amrex::Gpu::streamSynchronize();
     // amrex::ParallelFor(
-    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept
+    //     {
     //         const amrex::GpuArray<int, 5> cell_blanking{
     //             levelBlanking[nbx](i, j, k - 1, 0),
     //             levelBlanking[nbx](i - 1, j, k, 0),
@@ -152,17 +153,17 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
     //         levelDrag[nbx](i, j, k, 0) = 0;
     //         for (int index = 0; index <= 4; ++index) {
     //             if ((levelBlanking[nbx](i, j, k, 0) == 0) &&
-    //                 (cell_blanking[index] == 1) && (levelDrag[nbx](i, j, k, 0) == 0)) {
-    //                 levelDrag[nbx](i, j, k, 0) = index + 1;
+    //                 (cell_blanking[index] == 1) && (levelDrag[nbx](i, j, k,
+    //                 0) == 0)) { levelDrag[nbx](i, j, k, 0) = index + 1;
     //             }
     //         }
     //     });
-    //amrex::Gpu::streamSynchronize();
+    // amrex::Gpu::streamSynchronize();
 
     //     amrex::ParallelFor(
     //         blanking,
     //         [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-    //             if ((levelBlanking[nbx](i, j, k, 0) == 0) && 
+    //             if ((levelBlanking[nbx](i, j, k, 0) == 0) &&
     //                 (levelBlanking[nbx](i, j, k - 1, 0) == 1)) {
     //                 levelDrag[nbx](i, j, k, 0) = 1;
     //             } else {
@@ -171,7 +172,8 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
     //         });
     // amrex::Gpu::streamSynchronize();
     // amrex::ParallelFor(
-    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+    //     blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept
+    //     {
     //         const amrex::GpuArray<int, 4> cell_blanking{
     //             levelBlanking[nbx](i - 1, j, k, 0),
     //             levelBlanking[nbx](i + 1, j, k, 0),
@@ -188,17 +190,30 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
     // amrex::Gpu::streamSynchronize();
     amrex::ParallelFor(
         blanking, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
-            const int blankxp= std::abs(levelBlanking[nbx](i + 1, j, k, 0) - levelBlanking[nbx](i, j, k, 0));
-            const int blankxm= std::abs(levelBlanking[nbx](i - 1, j, k, 0) - levelBlanking[nbx](i, j, k, 0));
-            const int blankyp= std::abs(levelBlanking[nbx](i, j + 1, k, 0) - levelBlanking[nbx](i, j, k, 0));
-            const int blankym= std::abs(levelBlanking[nbx](i, j - 1, k, 0) - levelBlanking[nbx](i, j, k, 0));
-            const int blankzp= std::abs(levelBlanking[nbx](i, j, k + 1, 0) - levelBlanking[nbx](i, j, k, 0));
-            const int blankzm= std::abs(levelBlanking[nbx](i, j, k - 1, 0) - levelBlanking[nbx](i, j, k, 0));
-            levelDrag[nbx](i,j,k,0)= ((k==0 && levelBlanking[nbx](i, j, k, 0) == 1))? 
-            0:
-            (blankxp + blankxm + blankyp + blankym + blankzp + blankzm);
+            const int blankxp = std::abs(
+                levelBlanking[nbx](i + 1, j, k, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            const int blankxm = std::abs(
+                levelBlanking[nbx](i - 1, j, k, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            const int blankyp = std::abs(
+                levelBlanking[nbx](i, j + 1, k, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            const int blankym = std::abs(
+                levelBlanking[nbx](i, j - 1, k, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            const int blankzp = std::abs(
+                levelBlanking[nbx](i, j, k + 1, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            const int blankzm = std::abs(
+                levelBlanking[nbx](i, j, k - 1, 0) -
+                levelBlanking[nbx](i, j, k, 0));
+            levelDrag[nbx](i, j, k, 0) =
+                ((k == 0 && levelBlanking[nbx](i, j, k, 0) == 1))
+                    ? 0
+                    : (blankxp + blankxm + blankyp + blankym + blankzp +
+                       blankzm);
         });
-
 }
 
 void TerrainDrag::post_init_actions()

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -162,11 +162,11 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
                 levelBlanking[nbx](i, j, k - 1, 0) -
                 levelBlanking[nbx](i, j, k, 0));
             levelDrag[nbx](i, j, k, 0) =
-                ((k == 0 && levelBlanking[nbx](i, j, k, 0) == 1) )
+                ((k == 0 && levelBlanking[nbx](i, j, k, 0) == 1))
                     ? 0
-                    : (blankxp + blankxm + blankyp + blankym + blankzp + blankzm);
-            }
-        );
+                    : (blankxp + blankxm + blankyp + blankym + blankzp +
+                       blankzm);
+        });
     amrex::Gpu::streamSynchronize();
 }
 

--- a/amr-wind/physics/TerrainDrag.cpp
+++ b/amr-wind/physics/TerrainDrag.cpp
@@ -162,10 +162,9 @@ void TerrainDrag::initialize_fields(int level, const amrex::Geometry& geom)
                 levelBlanking[nbx](i, j, k - 1, 0) -
                 levelBlanking[nbx](i, j, k, 0));
             levelDrag[nbx](i, j, k, 0) =
-                ((k == 0)
+                ((k == 0 && levelBlanking[nbx](i, j, k, 0) == 1) )
                     ? 0
-                    : (blankxp + blankxm + blankyp + blankym + blankzp +
-                       blankzm));
+                    : (blankxp + blankxm + blankyp + blankym + blankzp + blankzm);
             }
         );
     amrex::Gpu::streamSynchronize();


### PR DESCRIPTION
## Summary

The existing approach for marking terrain is rudimentary. We only check the terrain height. This works well for neutral boundary layer as the terrain is forced to zero wind speed. However, for non-neutral condition at very stable or unstable states, soil temperature leaks into the domain providing a unrealistic stratification effect. This PR updates the terrain marking algorithm to account for the terrain effects in the horizontal direction. The horizontal wall function is computed using MOST. 

Please check the type of change introduced:

- [ X] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [X ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Before 

<img width="486" alt="Original_Drag" src="https://github.com/user-attachments/assets/ecc8ed88-70f8-4d51-bebb-ee114ab17a57" />

After 

<img width="487" alt="modified_drag" src="https://github.com/user-attachments/assets/a3ccee18-481f-4e5e-a499-2d75d514e398" />



