### PR TITLE
User-Defined Function Refinement 

### DIFF
--- a/amr-wind/physics/CMakeLists.txt
+++ b/amr-wind/physics/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${amr_wind_lib_name}
   ActuatorSourceTagging.cpp
   Intermittency.cpp
   ForestDrag.cpp
+  MetMastMarking.cpp
   )
 
 add_subdirectory(multiphase)

--- a/amr-wind/physics/MetMastMarking.H
+++ b/amr-wind/physics/MetMastMarking.H
@@ -1,0 +1,58 @@
+#ifndef MetMastMarking_H
+#define MetMastMarking_H
+
+#include "amr-wind/core/Physics.H"
+#include "amr-wind/core/Field.H"
+#include "amr-wind/CFDSim.H"
+
+namespace amr_wind::MetMastMarking {
+
+/** MetMastMarking Flow physics
+ *  \ingroup physics
+ */
+
+class MetMastMarking : public Physics::Register<MetMastMarking>
+{
+public:
+    static std::string identifier() { return "MetMastMarking"; }
+
+    explicit MetMastMarking(CFDSim& sim);
+
+    ~MetMastMarking() override = default;
+
+    void initialize_fields(int level, const amrex::Geometry& geom) override;
+
+    void pre_init_actions() override {}
+
+    void post_init_actions() override {}
+
+    void post_regrid_actions() override;
+
+    void pre_advance_work() override {}
+
+    void post_advance_work() override {}
+
+private:
+    CFDSim& m_sim;
+    const FieldRepo& m_repo;
+    const amrex::AmrCore& m_mesh;
+
+    //! Blanking field for met mast
+    Field& m_metmast_blank;
+
+    amrex::Vector<amrex::Real> m_metmast_x;
+    amrex::Vector<amrex::Real> m_metmast_y;
+    amrex::Vector<amrex::Real> m_metmast_z;
+    amrex::Vector<amrex::Real> m_metmast_horizontal_radius;
+    amrex::Vector<amrex::Real> m_metmast_vertical_radius;
+    amrex::Gpu::DeviceVector<amrex::Real> m_metmast_x_d;
+    amrex::Gpu::DeviceVector<amrex::Real> m_metmast_y_d;
+    amrex::Gpu::DeviceVector<amrex::Real> m_metmast_z_d;
+    amrex::Gpu::DeviceVector<amrex::Real> m_metmast_horizontal_radius_d;
+    amrex::Gpu::DeviceVector<amrex::Real> m_metmast_vertical_radius_d;
+    //! Met mast file
+    std::string m_metmast_file{"metmast.amrwind"};
+};
+} // namespace amr_wind::MetMastMarking
+
+#endif

--- a/amr-wind/physics/MetMastMarking.cpp
+++ b/amr-wind/physics/MetMastMarking.cpp
@@ -1,0 +1,118 @@
+#include "amr-wind/physics/MetMastMarking.H"
+#include "amr-wind/CFDSim.H"
+#include "AMReX_iMultiFab.H"
+#include "AMReX_MultiFabUtil.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_ParReduce.H"
+#include "amr-wind/utilities/trig_ops.H"
+#include "amr-wind/utilities/IOManager.H"
+#include "amr-wind/utilities/io_utils.H"
+#include "amr-wind/utilities/linear_interpolation.H"
+
+namespace amr_wind::MetMastMarking {
+
+namespace {} // namespace
+
+MetMastMarking::MetMastMarking(CFDSim& sim)
+    : m_sim(sim)
+    , m_repo(sim.repo())
+    , m_mesh(sim.mesh())
+    , m_metmast_blank(sim.repo().declare_field("metmast_blank", 1, 1, 1))
+{
+    amrex::ParmParse pp_abl("ABL");
+    pp_abl.query("metmast_location_file", m_metmast_file);
+    if (!m_metmast_file.empty()) {
+        std::ifstream mastfile(m_metmast_file, std::ios::in);
+        if (!mastfile.good()) {
+            amrex::Abort("Cannot find Met Mast profile file " + m_metmast_file);
+        }
+        //! x y z horizontal_radius vertical_radius
+        amrex::Real value1, value2, value3, value4, value5;
+        while (mastfile >> value1 >> value2 >> value3 >> value4 >> value5) {
+            m_metmast_x.push_back(value1);
+            m_metmast_y.push_back(value2);
+            m_metmast_z.push_back(value3);
+            m_metmast_horizontal_radius.push_back(value4);
+            m_metmast_vertical_radius.push_back(value5);
+        }
+    } else {
+        amrex::Abort("Cannot find Met Mast profile file " + m_metmast_file);
+    }
+    int num_wind_values = static_cast<int>(m_metmast_x.size());
+    m_metmast_x_d.resize(num_wind_values);
+    m_metmast_y_d.resize(num_wind_values);
+    m_metmast_z_d.resize(num_wind_values);
+    m_metmast_horizontal_radius_d.resize(num_wind_values);
+    m_metmast_vertical_radius_d.resize(num_wind_values);
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, m_metmast_x.begin(), m_metmast_x.end(),
+        m_metmast_x_d.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, m_metmast_y.begin(), m_metmast_y.end(),
+        m_metmast_y_d.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, m_metmast_z.begin(), m_metmast_z.end(),
+        m_metmast_z_d.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, m_metmast_horizontal_radius.begin(),
+        m_metmast_horizontal_radius.end(),
+        m_metmast_horizontal_radius_d.begin());
+    amrex::Gpu::copy(
+        amrex::Gpu::hostToDevice, m_metmast_vertical_radius.begin(),
+        m_metmast_vertical_radius.end(), m_metmast_vertical_radius_d.begin());
+    m_sim.io_manager().register_output_var("metmast_blank");
+    m_metmast_blank.setVal(0.0);
+    m_metmast_blank.set_default_fillpatch_bc(m_sim.time());
+}
+
+void MetMastMarking::initialize_fields(int level, const amrex::Geometry& geom)
+{
+
+    BL_PROFILE("amr-wind::" + this->identifier() + "::initialize_fields");
+
+    const auto& dx = geom.CellSizeArray();
+    const auto& prob_lo = geom.ProbLoArray();
+    auto& blanking = m_metmast_blank(level);
+    auto levelBlanking = blanking.arrays();
+    const auto* metmast_x_d = m_metmast_x_d.data();
+    const auto* metmast_y_d = m_metmast_y_d.data();
+    const auto* metmast_z_d = m_metmast_z_d.data();
+    const auto* horizontal_radius_d = m_metmast_horizontal_radius_d.data();
+    const auto* vertical_radius_d = m_metmast_vertical_radius_d.data();
+    for (int ii = 0; ii < static_cast<int>(m_metmast_x.size()); ii++) {
+        amrex::Print() << "Met Mast " << ii << " at " << metmast_x_d[ii] << ", "
+                       << metmast_y_d[ii] << ", " << metmast_z_d[ii]
+                       << " with horizontal radius " << horizontal_radius_d[ii]
+                       << " and vertical radius " << vertical_radius_d[ii]
+                       << "\n";
+        amrex::ParallelFor(
+            blanking, m_metmast_blank.num_grow(),
+            [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) noexcept {
+                const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+                const amrex::Real y = prob_lo[1] + (j + 0.5) * dx[1];
+                const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
+                amrex::Real ri2 = (x - metmast_x_d[ii]) * (x - metmast_x_d[ii]);
+                ri2 += (y - metmast_y_d[ii]) * (y - metmast_y_d[ii]);
+                if (((ri2 <=
+                      (horizontal_radius_d[ii] * horizontal_radius_d[ii])) &&
+                     (std::abs(z - metmast_z_d[ii]) <=
+                      vertical_radius_d[ii])) ||
+                    (levelBlanking[nbx](i, j, k, 0) == 1.0)) {
+                    levelBlanking[nbx](i, j, k, 0) = 1.0;
+                } else {
+                    levelBlanking[nbx](i, j, k, 0) = 0.0;
+                }
+            });
+    }
+    amrex::Gpu::streamSynchronize();
+}
+
+void MetMastMarking::post_regrid_actions()
+{
+    const int nlevels = m_sim.repo().num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        initialize_fields(lev, m_sim.repo().mesh().Geom(lev));
+    }
+}
+
+} // namespace amr_wind::MetMastMarking


### PR DESCRIPTION
## Summary

As the coarse-fine grid boundary size does not matter a lot for  URANS solutions, the default field refinement levels are not always required. Also the existing refinement methods for wakes are limited to box or cylindrical regions. This PR defines a template for creating a blanking region which can be used to perform field refinement similar to the terrain_blank based field refinement for immersed boundaries. The current implementation is restricted to a cylindrical region as a proof of concept and the function can be modified in the future to incorporate analytical wake shape profiles or nacelle or other structures. This is expected to reduce the cell count significantly. 


Please check the type of change introduced:

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Additional background

Sample Mesh with the blanking 

<img width="776" alt="Screenshot 2025-06-24 at 4 01 47 PM (1)" src="https://github.com/user-attachments/assets/a9b4e516-e602-4723-b85f-d159fdcd0bc9" />



