### PR TITLE
field norms: switching to scientific, correct width

### DIFF
--- a/amr-wind/utilities/sampling/FieldNorms.H
+++ b/amr-wind/utilities/sampling/FieldNorms.H
@@ -78,7 +78,7 @@ private:
     int m_width{18};
 
     //! precision in ASCII output
-    int m_precision{12};
+    int m_precision{10};
 
     //! Type of norm
     int m_norm_type{2};

--- a/amr-wind/utilities/sampling/FieldNorms.cpp
+++ b/amr-wind/utilities/sampling/FieldNorms.cpp
@@ -248,7 +248,7 @@ void FieldNorms::write_ascii()
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream f(m_out_fname.c_str(), std::ios_base::app);
-        f << m_sim.time().time_index() << std::fixed
+        f << m_sim.time().time_index() << std::scientific
           << std::setprecision(m_precision) << std::setw(m_width)
           << m_sim.time().new_time();
         for (double m_fnorm : m_fnorms) {


### PR DESCRIPTION
## Summary

because of std::fixed approach, things would get messed up for ordinary hydrostatic pressure values (more than 4 digits to the left of the 0). switching to scientific makes sure the overall width stays the same and increasing the width for the additional characters in scientific.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
