### PR TITLE
Output better timing information with each step

### DIFF
--- a/amr-wind/core/SimTime.H
+++ b/amr-wind/core/SimTime.H
@@ -177,6 +177,11 @@ public:
         m_stop_time = -1.;
     }
 
+    /** Return true if TinyProfiler output should be sent to the log file at
+     * this timestep
+     */
+    bool output_profiling_info() const;
+
 private:
     //! Timestep sizes
     amrex::Vector<amrex::Real> m_dt =
@@ -286,6 +291,9 @@ private:
 
     //! Time interval for regridding
     int m_regrid_interval{-1};
+
+    //! Time step interval for profiling output
+    int m_profiling_interval{-1};
 
     //! Verbosity
     int m_verbose{0};

--- a/amr-wind/core/SimTime.cpp
+++ b/amr-wind/core/SimTime.cpp
@@ -39,6 +39,7 @@ void SimTime::parse_parameters()
     pp.query("plot_start", m_plt_start_index);
     pp.query("checkpoint_start", m_chkpt_start_index);
     pp.query("use_force_cfl", m_use_force_cfl);
+    pp.query("profiling_interval", m_profiling_interval);
 
     // Tolerances
     pp.query("plot_time_interval_reltol", m_plt_t_tol);
@@ -416,6 +417,13 @@ void SimTime::calculate_minimum_enforce_dt_abs_tol()
                                                m_postprocess_time_interval[npp])
                  : m_force_dt_abs_tol);
     }
+}
+
+bool SimTime::output_profiling_info() const
+{
+    return (
+        (m_profiling_interval > 0) &&
+        (m_time_index % m_profiling_interval == 0));
 }
 
 } // namespace amr_wind

--- a/amr-wind/incflo.cpp
+++ b/amr-wind/incflo.cpp
@@ -283,10 +283,10 @@ void incflo::Evolve()
 {
     BL_PROFILE("amr-wind::incflo::Evolve()");
 
-    amrex::Real init_time = amrex::ParallelDescriptor::second();
+    const amrex::Real init_time = amrex::ParallelDescriptor::second();
 
     while (m_time.new_timestep()) {
-        amrex::Real time0 = amrex::ParallelDescriptor::second();
+        const amrex::Real time0 = amrex::ParallelDescriptor::second();
 
         regrid_and_update();
 
@@ -300,7 +300,7 @@ void incflo::Evolve()
             pre_advance_stage2();
         }
 
-        amrex::Real time1 = amrex::ParallelDescriptor::second();
+        const amrex::Real time1 = amrex::ParallelDescriptor::second();
         // Advance to time t + dt
         for (int fixed_point_iteration = 0;
              fixed_point_iteration < m_fixed_point_iterations;
@@ -309,9 +309,9 @@ void incflo::Evolve()
         }
 
         amrex::Print() << std::endl;
-        amrex::Real time2 = amrex::ParallelDescriptor::second();
+        const amrex::Real time2 = amrex::ParallelDescriptor::second();
         post_advance_work();
-        amrex::Real time3 = amrex::ParallelDescriptor::second();
+        const amrex::Real time3 = amrex::ParallelDescriptor::second();
 
         amrex::Print() << "WallClockTime in Evolve() for step "
                        << m_time.time_index()
@@ -328,12 +328,6 @@ void incflo::Evolve()
             amrex::Print() << "\nCumulative times reported by TinyProfiler:";
             amrex::TinyProfiler::Finalize(true);
         }
-
-        // amrex::Print() << "Solve time per cell: " << std::setprecision(4)
-        //                << amrex::ParallelDescriptor::NProcs() *
-        //                       (time2 - time1) /
-        //                       static_cast<amrex::Real>(m_cell_count)
-        //                << std::endl;
     }
     amrex::Print() << "\n======================================================"
                       "========================\n"

--- a/docs/sphinx/user/inputs_time.rst
+++ b/docs/sphinx/user/inputs_time.rst
@@ -263,3 +263,11 @@ This section also addresses the time-dependent nature of checkpoint files, plot 
    When :input_param:`time.enforce_checkpoint_time_dt` is true, a tolerance is needed to determine when
    it is necessary to shrink the time step size. This tolerance is relative to the checkpoint time interval.
    In most cases, this parameter need not be modified, but it can be changed by the user.
+
+.. input_param:: time.profiling_interval
+
+   **type:** Integer, optional, default = -1
+
+   If this value is greater than zero, it indicates the frequency (in timesteps)
+   at which profiling information is written to the log file.
+


### PR DESCRIPTION
## Summary

Added a per-step line that outputs the cumulative time spent in the evolve portion of the simulation. Also added capability to periodically output tinyprofiler information to the log file.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

The user will now see by default:
```
WallClockTime in Evolve() for step 4: Pre: 0.0186 Solve: 10.29 Post: 0.0807 Total: 10.39
Cumulative WallClockTime in Evolve(): 41.49
```

The user can also set `time.profiling_interval` to also get TinyProfiler information at the end of a time step (modulo the time step interval.

I also removed 'solve time per cell" because it is actually a bit confusing and is redundant information.

Closes #1712
