### PR TITLE
Ocean Waves: relaxation zones in y

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
+++ b/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
@@ -27,6 +27,8 @@ struct RelaxZonesBaseData
     amrex::Real beach_length{8.0};
     amrex::Real beach_length_factor{1.0};
 
+    amrex::Real zone_length_y{0.0};
+
     amrex::Real current{0.0};
 
     bool init_wave_field{false};

--- a/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
+++ b/amr-wind/ocean_waves/relaxation_zones/RelaxationZones.H
@@ -36,7 +36,6 @@ struct RelaxZonesBaseData
     bool has_ramp{false};
 
     bool has_beach{true};
-    bool has_outprofile{false};
 
     amrex::Real ramp_period;
 

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -167,7 +167,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                     Gamma_ylo =
                         utils::gamma_generate(y - problo[1], zone_length_y);
                     Gamma_yhi = utils::gamma_absorb(
-                        y - (problo[1] - zone_length_y), zone_length_y, 1.0);
+                        y - (probhi[1] - zone_length_y), zone_length_y, 1.0);
                 }
                 const amrex::Real Gamma = std::min(
                     std::min(Gamma_xhi, Gamma_xlo),

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -34,6 +34,7 @@ void read_inputs(
         pp.query("numerical_beach_length_factor", wdata.beach_length_factor);
         pp.query("initialize_wave_field", wdata.init_wave_field);
     }
+    pp.query("relax_zone_length_y", wdata.zone_length_y);
 
     pp.query("current", wdata.current);
 
@@ -120,6 +121,8 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
         const amrex::Real gen_length = wdata.gen_length;
         const amrex::Real beach_length = wdata.beach_length;
         const amrex::Real beach_length_factor = wdata.beach_length_factor;
+        const amrex::Real zone_length_y = wdata.zone_length_y;
+        const bool has_zone_y = zone_length_y > constants::EPS;
         const amrex::Real zsl = wdata.zsl;
         const amrex::Real current = wdata.current;
         const bool has_beach = wdata.has_beach;
@@ -131,6 +134,9 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                 const amrex::Real x = amrex::min(
                     amrex::max(problo[0] + (i + 0.5) * dx[0], problo[0]),
                     probhi[0]);
+                const amrex::Real y = amrex::min(
+                    amrex::max(problo[1] + (j + 0.5) * dx[1], problo[1]),
+                    probhi[1]);
                 const amrex::Real z = amrex::min(
                     amrex::max(problo[2] + (k + 0.5) * dx[2], problo[2]),
                     probhi[2]);
@@ -141,6 +147,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                 const auto target_volfrac = target_volfrac_arrs[nbx];
                 const auto target_vel = target_vel_arrs[nbx];
 
+                // Skip if in or near terrain
                 bool in_or_near_terrain{false};
                 if (terrain_exists) {
                     in_or_near_terrain =
@@ -148,21 +155,60 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                          terrain_drag_flags[nbx](i, j, k) == 1);
                 }
 
-                // Generation region
-                if (x <= problo[0] + gen_length && !in_or_near_terrain) {
-                    const amrex::Real Gamma =
-                        utils::gamma_generate(x - problo[0], gen_length);
-                    // Get bounded new vof, incorporate with increment
+                // Get gamma for each possible direction
+                const amrex::Real Gamma_xlo =
+                    utils::gamma_generate(x - problo[0], gen_length);
+                const amrex::Real Gamma_xhi = utils::gamma_absorb(
+                    x - (probhi[0] - beach_length), beach_length,
+                    beach_length_factor);
+                amrex::Real Gamma_ylo = 1.;
+                amrex::Real Gamma_yhi = 1.;
+                if (has_zone_y) {
+                    Gamma_ylo =
+                        utils::gamma_generate(y - problo[1], zone_length_y);
+                    Gamma_yhi = utils::gamma_absorb(
+                        y - (problo[1] - zone_length_y), zone_length_y, 1.0);
+                }
+                const amrex::Real Gamma = std::min(
+                    std::min(Gamma_xhi, Gamma_xlo),
+                    std::min(Gamma_yhi, Gamma_ylo));
+
+                // Skip if Gamma is close enough to 1
+                bool outside_zones = Gamma + constants::EPS > 1.;
+
+                if (!(outside_zones || in_or_near_terrain)) {
+                    // Create wave vector for generation, numerical beach
+                    const utils::WaveVec wave_sol{
+                        target_vel(i, j, k, 0), target_vel(i, j, k, 1),
+                        target_vel(i, j, k, 2), target_volfrac(i, j, k)};
+                    const utils::WaveVec quiescent{
+                        current, 0.0, 0.0,
+                        utils::free_surface_to_vof(zsl, z, dx[2])};
+                    const auto outlet = has_beach ? quiescent : wave_sol;
+
+                    // Check for in beach, needed for velocity forcing
+                    const bool in_beach =
+                        has_beach && x + beach_length >= probhi[0];
+
+                    // Harmonize between inlet/bulk profile and outlet profile
+                    const auto target_profile = utils::harmonize_profiles_1d(
+                        x, problo[0], gen_length, probhi[0], beach_length,
+                        wave_sol, wave_sol, outlet);
+
+                    // Nudge solution toward target
                     amrex::Real new_vof = utils::combine_linear(
-                        Gamma, target_volfrac(i, j, k), volfrac(i, j, k));
+                        Gamma, target_profile[3], volfrac(i, j, k));
                     new_vof = (new_vof > 1. - vof_tiny)
                                   ? 1.0
                                   : (new_vof < vof_tiny ? 0.0 : new_vof);
                     const amrex::Real dvf = new_vof - volfrac(i, j, k);
                     volfrac(i, j, k) += rampf * dvf;
-                    // Force liquid velocity only if target vof present
-                    const amrex::Real fvel_liq =
+                    // Liquid velocity forced only where velocity is known
+                    //  - in most of domain, that is where target vof is nonzero
+                    //  - in numerical beach, that is anywhere
+                    amrex::Real fvel_liq =
                         (target_volfrac(i, j, k) > vof_tiny) ? 1.0 : 0.0;
+                    fvel_liq = in_beach ? 1.0 : fvel_liq;
                     amrex::Real rho_ = rho1 * volfrac(i, j, k) +
                                        rho2 * (1.0 - volfrac(i, j, k));
                     for (int n = 0; n < vel.ncomp; ++n) {
@@ -170,7 +216,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                         amrex::Real vel_liq = vel(i, j, k, n);
                         const amrex::Real dvel_liq =
                             utils::combine_linear(
-                                Gamma, target_vel(i, j, k, n), vel_liq) -
+                                Gamma, target_profile[n], vel_liq) -
                             vel_liq;
                         vel_liq += rampf * fvel_liq * dvel_liq;
                         // If liquid was added, that liquid has target_vel
@@ -178,91 +224,19 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                             volfrac(i, j, k) * vel_liq;
                         integrated_vel_liq +=
                             rampf * fvel_liq * amrex::max(0.0, dvf) *
-                            (target_vel(i, j, k, n) - vel(i, j, k, n));
+                            (target_profile[n] - vel(i, j, k, n));
                         // Update overall velocity using momentum
                         vel(i, j, k, n) =
                             (rho1 * integrated_vel_liq +
                              rho2 * (1. - volfrac(i, j, k)) * vel(i, j, k, n)) /
                             rho_;
                     }
-                }
-                // Outlet region
-                if (x + beach_length >= probhi[0] && !in_or_near_terrain) {
-                    const amrex::Real Gamma = utils::gamma_absorb(
-                        x - (probhi[0] - beach_length), beach_length,
-                        beach_length_factor);
-                    // Numerical beach (sponge layer)
-                    if (has_beach) {
-                        // Get bounded new vof, save increment
-                        amrex::Real new_vof = utils::combine_linear(
-                            Gamma, utils::free_surface_to_vof(zsl, z, dx[2]),
-                            volfrac(i, j, k));
-                        new_vof = (new_vof > 1. - vof_tiny)
-                                      ? 1.0
-                                      : (new_vof < vof_tiny ? 0.0 : new_vof);
-                        const amrex::Real dvf = new_vof - volfrac(i, j, k);
-                        volfrac(i, j, k) = new_vof;
-                        // Conserve momentum when density changes
-                        amrex::Real rho_ = rho1 * volfrac(i, j, k) +
-                                           rho2 * (1.0 - volfrac(i, j, k));
-                        // Target vel is current, 0, 0
-                        amrex::Real out_vel{0.0};
-                        for (int n = 0; n < vel.ncomp; ++n) {
-                            if (n == 0) {
-                                out_vel = current;
-                            } else {
-                                out_vel = 0.0;
-                            }
-                            const amrex::Real vel_liq = utils::combine_linear(
-                                Gamma, out_vel, vel(i, j, k, n));
-                            amrex::Real integrated_vel_liq =
-                                volfrac(i, j, k) * vel_liq;
-                            integrated_vel_liq += amrex::max(0.0, dvf) *
-                                                  (out_vel - vel(i, j, k, n));
-                            vel(i, j, k, n) = (rho1 * integrated_vel_liq +
-                                               rho2 * (1. - volfrac(i, j, k)) *
-                                                   vel(i, j, k, n)) /
-                                              rho_;
-                        }
-                    }
-                    // Forcing to wave profile instead
-                    if (has_outprofile) {
-                        // Same steps as in wave generation region
-                        amrex::Real new_vof = utils::combine_linear(
-                            Gamma, target_volfrac(i, j, k), volfrac(i, j, k));
-                        new_vof = (new_vof > 1. - vof_tiny)
-                                      ? 1.0
-                                      : (new_vof < vof_tiny ? 0.0 : new_vof);
-                        const amrex::Real dvf = new_vof - volfrac(i, j, k);
-                        volfrac(i, j, k) += dvf;
-                        const amrex::Real fvel_liq =
-                            (target_volfrac(i, j, k) > vof_tiny) ? 1.0 : 0.0;
-                        amrex::Real rho_ = rho1 * volfrac(i, j, k) +
-                                           rho2 * (1.0 - volfrac(i, j, k));
-                        for (int n = 0; n < vel.ncomp; ++n) {
-                            amrex::Real vel_liq = vel(i, j, k, n);
-                            const amrex::Real dvel_liq =
-                                utils::combine_linear(
-                                    Gamma, target_vel(i, j, k, n), vel_liq) -
-                                vel_liq;
-                            vel_liq += rampf * fvel_liq * dvel_liq;
-                            amrex::Real integrated_vel_liq =
-                                volfrac(i, j, k) * vel_liq;
-                            integrated_vel_liq +=
-                                rampf * fvel_liq * amrex::max(0.0, dvf) *
-                                (target_vel(i, j, k, n) - vel(i, j, k, n));
-                            vel(i, j, k, n) = (rho1 * integrated_vel_liq +
-                                               rho2 * (1. - volfrac(i, j, k)) *
-                                                   vel(i, j, k, n)) /
-                                              rho_;
-                        }
-                    }
-                }
 
-                // Make sure that density is updated before entering the
-                // solution
-                rho(i, j, k) =
-                    rho1 * volfrac(i, j, k) + rho2 * (1. - volfrac(i, j, k));
+                    // Make sure that density is updated before entering the
+                    // solution
+                    rho(i, j, k) = rho1 * volfrac(i, j, k) +
+                                   rho2 * (1. - volfrac(i, j, k));
+                }
             });
     }
     amrex::Gpu::streamSynchronize();

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -25,7 +25,6 @@ void read_inputs(
     pp.query("relax_zone_gen_length", wdata.gen_length);
     if (pp.contains("relax_zone_out_length")) {
         wdata.has_beach = false;
-        wdata.has_outprofile = true;
         wdata.init_wave_field = true;
         pp.query("relax_zone_out_length", wdata.beach_length);
     } else {
@@ -126,7 +125,6 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
         const amrex::Real zsl = wdata.zsl;
         const amrex::Real current = wdata.current;
         const bool has_beach = wdata.has_beach;
-        const bool has_outprofile = wdata.has_outprofile;
 
         amrex::ParallelFor(
             velocity(lev), amrex::IntVect(0),

--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -174,7 +174,7 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                     std::min(Gamma_yhi, Gamma_ylo));
 
                 // Skip if Gamma is close enough to 1
-                bool outside_zones = Gamma + constants::EPS > 1.;
+                bool outside_zones = Gamma + constants::EPS >= 1.;
 
                 if (!(outside_zones || in_or_near_terrain)) {
                     // Create wave vector for generation, numerical beach

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -828,7 +828,7 @@ struct UpdateTargetFieldsOp<W2AWaves>
                          wdata.gen_length, 0, ow_velocity.vec_ptrs(), geom) ==
                      1);
                 // No overlap with gen region means no interp, unless ...
-                if (wdata.has_outprofile) {
+                if (!wdata.has_beach) {
                     // ... if overlap exists here, needing interp
                     flag_xhi =
                         (interp_to_mfab::check_lateral_overlap_hi(

--- a/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
+++ b/amr-wind/ocean_waves/relaxation_zones/waves2amr_ops.H
@@ -813,6 +813,8 @@ struct UpdateTargetFieldsOp<W2AWaves>
                 bool flag_z = false;
                 bool flag_xlo = false;
                 bool flag_xhi = false;
+                bool flag_ylo = false;
+                bool flag_yhi = false;
                 // Get heights for this processor, check overlap in z
                 flag_z =
                     (interp_to_mfab::get_local_height_indices(
@@ -821,17 +823,27 @@ struct UpdateTargetFieldsOp<W2AWaves>
                 // No overlap from heights definitely means no interp
 
                 // Check lateral bounds (in x)
-                const int dir = 0;
                 flag_xlo =
                     (interp_to_mfab::check_lateral_overlap_lo(
-                         wdata.gen_length, dir, ow_velocity.vec_ptrs(), geom) ==
+                         wdata.gen_length, 0, ow_velocity.vec_ptrs(), geom) ==
                      1);
                 // No overlap with gen region means no interp, unless ...
                 if (wdata.has_outprofile) {
                     // ... if overlap exists here, needing interp
                     flag_xhi =
                         (interp_to_mfab::check_lateral_overlap_hi(
-                             wdata.beach_length, dir, ow_velocity.vec_ptrs(),
+                             wdata.beach_length, 0, ow_velocity.vec_ptrs(),
+                             geom) == 1);
+                }
+                // Then in y, if y zones are present
+                if (wdata.zone_length_y > constants::EPS) {
+                    flag_ylo =
+                        (interp_to_mfab::check_lateral_overlap_lo(
+                             wdata.zone_length_y, 1, ow_velocity.vec_ptrs(),
+                             geom) == 1);
+                    flag_yhi =
+                        (interp_to_mfab::check_lateral_overlap_hi(
+                             wdata.zone_length_y, 1, ow_velocity.vec_ptrs(),
                              geom) == 1);
                 }
 
@@ -842,7 +854,7 @@ struct UpdateTargetFieldsOp<W2AWaves>
                     flag_xhi = true;
                 }
 
-                if (flag_z && (flag_xlo || flag_xhi)) {
+                if (flag_z && (flag_xlo || flag_xhi || flag_ylo || flag_yhi)) {
                     // Interpolation is needed
                     wdata.do_interp = true;
                     // Do resizing

--- a/test/test_files/ow_w2a_nonperiodic/ow_w2a_nonperiodic.inp
+++ b/test/test_files/ow_w2a_nonperiodic/ow_w2a_nonperiodic.inp
@@ -22,6 +22,7 @@ OceanWaves.W2A1.HOS_modes_filename = ../ow_w2a/modes_HOS_SWENSE.dat
 OceanWaves.W2A1.relax_zone_gen_length=200
 OceanWaves.W2A1.numerical_beach_length=200
 OceanWaves.W2A1.numerical_beach_length_factor=2.0
+OceanWaves.W2A1.relax_zone_length_y=50
 # These variables should change with resolution in z
 OceanWaves.W2A1.number_interp_points_in_z = 35
 OceanWaves.W2A1.interp_spacing_at_surface = 1.
@@ -57,10 +58,12 @@ geometry.is_periodic    =     0    0     0   # Periodicity x y z (0/1)
 
 xlo.type =   wave_generation
 xhi.type =   pressure_outflow
-ylo.type =   slip_wall
-yhi.type =   slip_wall
+ylo.type =   wave_generation
+yhi.type =   wave_generation
 zlo.type =   slip_wall
 zhi.type =   slip_wall
 
 # density at inflow condition must match the gas density specified above
 xlo.density = 1.25
+ylo.density = 1.25
+yhi.density = 1.25

--- a/unit_tests/ocean_waves/test_wave_utils.cpp
+++ b/unit_tests/ocean_waves/test_wave_utils.cpp
@@ -202,16 +202,15 @@ TEST_F(WaveUtilsTest, gamma_xy)
     constexpr amrex::Real tol = 1e-12;
     constexpr amrex::Real zone_length = 0.25;
 
-    const amrex::Vector<const amrex::Real> x{
+    const amrex::Vector<amrex::Real> x{
         0., 1., 0.5, 0.5, zone_length, zone_length, 0.5 * zone_length};
-    const amrex::Vector<const amrex::Real> y{
+    const amrex::Vector<amrex::Real> y{
         0.5, 0.5, 0., 1., zone_length, 0.5, 0.5 * zone_length};
     const amrex::Real gm =
         1.0 -
         (std::exp(std::pow(1. - x[x.size() - 1] / zone_length, 3.5)) - 1.0) /
             (std::exp(1.0) - 1.0);
-    const amrex::Vector<const amrex::Real> gold_gamma{0., 0., 0., 0.,
-                                                      1., 1., gm};
+    const amrex::Vector<amrex::Real> gold_gamma{0., 0., 0., 0., 1., 1., gm};
 
     for (int n = 0; n < x.size(); ++n) {
         const amrex::Real gamma_xlo =


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

Previously, we have relied on slip walls or periodic boundary conditions for y boundaries in wave simulations. However, those only make sense when the waves are perpendicular with y or if the domain lines up exactly with a periodic boundary from the precursor waves. For complex multi-directional wavefields, when the domain is different from a precursor, relaxation zones in y are necessary.

The unusual aspect of relaxation zones in y is that it touches both the generation zone (xlo) and the numerical beach absorption zone (xhi), so the target field for these zones in y needs to be able to do both.

The most straightforward way of doing this was to generalize the existing relaxation approach and using the harmonize_profiles_1d routine that I originally wrote for initialization.

Passes the ocean wave regression tests with 0's for all except machine diffs for ow_w2a, and I modified an existing test to include the new features.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [x] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
