### PR TITLE
Speedup ABLStats

### DIFF
--- a/amr-wind/wind_energy/ABLStats.cpp
+++ b/amr-wind/wind_energy/ABLStats.cpp
@@ -292,7 +292,7 @@ void ABLStats::compute_zi()
 #endif
                 const auto iv2d = box_indexer.intVect(blockIdx.x);
                 amrex::IntVect iv;
-                const int i2d = 0;
+                int i2d = 0;
                 for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                     if (idim != dir) {
                         iv[idim] = iv2d[i2d++];


### PR DESCRIPTION
## Summary

This speeds up the ABL stats considerably. For the precursor I was profiling, `compute_zi` took 27% of the total runtime (!). This takes it down to just 1%. Currently just for nvidia GPU. Need to generalize.

More granular profiling of the ABLStats.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
