### PR TITLE
Add active wake control to Joukowsky Disk models

### DIFF
--- a/amr-wind/wind_energy/actuator/disk/Joukowsky.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky.H
@@ -40,8 +40,8 @@ struct JoukowskyData : public DiskBaseData
     // TODO: These might have to live in a different struct
     amrex::Real awc_amplitude{0.0};
     amrex::Real awc_angular_frequency{0.0};
-    amrex::Real awc_n{0.0};
-    amrex::Real awc_phi_clock{0.0};
+    amrex::Real awc_azimuthal_mode{0.0};
+    amrex::Real awc_clocking_angle{0.0};
 };
 
 struct Joukowsky : public DiskType

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky.H
@@ -37,7 +37,7 @@ struct JoukowskyData : public DiskBaseData
     vs::Vector disk_force{0.0, 0.0, 0.0};
     bool use_tip_correction{true};
     bool use_root_correction{true};
-    //TODO: These might have to live in a different struct
+    // TODO: These might have to live in a different struct
     amrex::Real awc_amplitude{0.0};
     amrex::Real awc_angular_frequency{0.0};
     amrex::Real awc_n{0.0};

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky.H
@@ -37,6 +37,11 @@ struct JoukowskyData : public DiskBaseData
     vs::Vector disk_force{0.0, 0.0, 0.0};
     bool use_tip_correction{true};
     bool use_root_correction{true};
+    //TODO: These might have to live in a different struct
+    amrex::Real awc_amplitude{0.0};
+    amrex::Real awc_angular_frequency{0.0};
+    amrex::Real awc_n{0.0};
+    amrex::Real awc_phi_clock{0.0};
 };
 
 struct Joukowsky : public DiskType

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -286,15 +286,16 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                 // eq 18
                 moment += x * ddata.radius() * f_theta * dArea;
 
-                grid.force[ip] =
-                    (f_z * ddata.normal_vec + f_theta * theta_vec) *
-                    ddata.density * uInfSqr * dArea;
-
                 const amrex::Real f_awc =
                     ddata.awc_amplitude *
                     std::cos(
                         ddata.awc_angular_frequency * current_time -
                         ddata.awc_n * theta_angle + ddata.awc_phi_clock);
+
+                grid.force[ip] =
+                    ((f_z + f_awc) * ddata.normal_vec + f_theta * theta_vec) *
+                    ddata.density * uInfSqr * dArea;
+
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -290,7 +290,11 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                     (f_z * ddata.normal_vec + f_theta * theta_vec) *
                     ddata.density * uInfSqr * dArea;
 
-                const amrex::Real f_awc = ddata.awc_amplitude * std::cos( ddata.awc_angular_frequency * current_time - ddata.awc_n * theta_angle + ddata.awc_phi_clock );
+                const amrex::Real f_awc =
+                    ddata.awc_amplitude *
+                    std::cos(
+                        ddata.awc_angular_frequency * current_time -
+                        ddata.awc_n * theta_angle + ddata.awc_phi_clock);
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -290,7 +290,7 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                     ddata.awc_amplitude *
                     std::cos(
                         ddata.awc_angular_frequency * current_time -
-                        ddata.awc_n * theta_angle + ddata.awc_phi_clock);
+                        ddata.awc_azimuthal_mode * theta_angle + ddata.awc_clocking_angle);
 
                 grid.force[ip] =
                     ((f_z + f_awc) * ddata.normal_vec + f_theta * theta_vec) *

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -247,7 +247,7 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
         int ip = 0;
 
         const auto dTheta = amr_wind::utils::two_pi() / ddata.num_vel_pts_t;
-        const auto current_time = data.sim().time();
+        const auto current_time = data.sim().time().current_time();
 
         for (int i = 0; i < ddata.num_vel_pts_r; i++) {
             const amrex::Real& F = ddata.tip_correction[i];

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.H
@@ -246,6 +246,9 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
 
         int ip = 0;
 
+        const auto dTheta = amr_wind::utils::two_pi() / ddata.num_vel_pts_t;
+        const auto current_time = data.sim().time();
+
         for (int i = 0; i < ddata.num_vel_pts_r; i++) {
             const amrex::Real& F = ddata.tip_correction[i];
             const amrex::Real& g = ddata.root_correction[i];
@@ -263,6 +266,7 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
 
             for (int j = 0; j < ddata.num_vel_pts_t; j++, ip++) {
                 const auto point_current = grid.pos[ip];
+                const auto theta_angle = j * dTheta;
 
                 // TODO add sign convention for rotation (+/- RPM)
                 // Negative sign on theta_vec means turbine is rotating
@@ -286,6 +290,7 @@ struct ComputeForceOp<Joukowsky, ActSrcDisk>
                     (f_z * ddata.normal_vec + f_theta * theta_vec) *
                     ddata.density * uInfSqr * dArea;
 
+                const amrex::Real f_awc = ddata.awc_amplitude * std::cos( ddata.awc_angular_frequency * current_time - ddata.awc_n * theta_angle + ddata.awc_phi_clock );
                 ddata.disk_force = ddata.disk_force + grid.force[ip];
             }
         }

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
@@ -32,9 +32,9 @@ void optional_parameters(JoukowskyData& meta, const utils::ActParser& pp)
     pp.query("S0_alpha2", meta.S0_alpha2);
     // TODO: read AWC parameters in a separate function?
     pp.query("awc_amplitude", meta.awc_amplitude);
-    pp.query("awc_n", meta.awc_n);
+    pp.query("awc_azimuthal_mode", meta.awc_azimuthal_mode);
     pp.query("awc_angular_frequency", meta.awc_angular_frequency);
-    pp.query("awc_phi_clock", meta.awc_phi_clock);
+    pp.query("awc_clocking_angle", meta.awc_clocking_angle);
 }
 
 void required_parameters(JoukowskyData& meta, const utils::ActParser& pp)

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
@@ -30,6 +30,11 @@ void optional_parameters(JoukowskyData& meta, const utils::ActParser& pp)
     pp.query("ct_region2", meta.Ct_rated);
     pp.query("S0_alpha1", meta.S0_alpha1);
     pp.query("S0_alpha2", meta.S0_alpha2);
+    //TODO: read AWC parameters in a separate function?
+    pp.query("awc_amplitude", meta.awc_amplitude);
+    pp.query("awc_n", meta.awc_n);
+    pp.query("awc_angular_frequency", meta.awc_angular_frequency);
+    pp.query("awc_phi_clock", meta.awc_phi_clock);
 }
 
 void required_parameters(JoukowskyData& meta, const utils::ActParser& pp)

--- a/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
+++ b/amr-wind/wind_energy/actuator/disk/Joukowsky_ops.cpp
@@ -30,7 +30,7 @@ void optional_parameters(JoukowskyData& meta, const utils::ActParser& pp)
     pp.query("ct_region2", meta.Ct_rated);
     pp.query("S0_alpha1", meta.S0_alpha1);
     pp.query("S0_alpha2", meta.S0_alpha2);
-    //TODO: read AWC parameters in a separate function?
+    // TODO: read AWC parameters in a separate function?
     pp.query("awc_amplitude", meta.awc_amplitude);
     pp.query("awc_n", meta.awc_n);
     pp.query("awc_angular_frequency", meta.awc_angular_frequency);


### PR DESCRIPTION
## Summary

Add the ability to enable active wake control on individual Joukowsky Disk turbines. The implementation is based on: https://doi.org/10.3390/en17040865

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [x] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
