### PR TITLE
create a smooth buffer between y relaxation zones and numerical beach

### DIFF
--- a/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
+++ b/amr-wind/ocean_waves/relaxation_zones/relaxation_zones_ops.cpp
@@ -166,6 +166,13 @@ void apply_relaxation_zones(CFDSim& sim, const RelaxZonesBaseData& wdata)
                         utils::gamma_generate(y - problo[1], zone_length_y);
                     Gamma_yhi = utils::gamma_absorb(
                         y - (probhi[1] - zone_length_y), zone_length_y, 1.0);
+                    const amrex::Real Gamma_y_to_xhi = utils::gamma_generate(
+                        x - (probhi[1] - 2. * beach_length),
+                        0.5 * beach_length);
+                    if (has_beach) {
+                        Gamma_ylo = std::max(Gamma_ylo, Gamma_y_to_xhi);
+                        Gamma_yhi = std::max(Gamma_yhi, Gamma_y_to_xhi);
+                    }
                 }
                 const amrex::Real Gamma = std::min(
                     std::min(Gamma_xhi, Gamma_xlo),


### PR DESCRIPTION
## Summary

Things are more stable when there is a gap between the relaxation zones in y and the numerical beach at xhi. Plus, forcing within the transition between the wave profile and the beach profile is not physical. However, the boundary values themselves will still be populated; they just aren't volumetrically enforced any more.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
