### PR TITLE
Fix FPE in waves2amr initialization that incorporates y relax zones

### DIFF
--- a/amr-wind/ocean_waves/utils/wave_utils_K.H
+++ b/amr-wind/ocean_waves/utils/wave_utils_K.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_FArrayBox.H>
 #include <cmath>
+#include "amr-wind/utilities/constants.H"
 
 namespace amr_wind::ocean_waves::utils {
 


### PR DESCRIPTION
## Summary

skips harmonizing profiles in the y direction when the y length is 0, i.e., there is no relaxation zone in y.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
