### PR TITLE
Write out sampling time in yaml file with more precision

### DIFF
--- a/amr-wind/utilities/sampling/Sampling.cpp
+++ b/amr-wind/utilities/sampling/Sampling.cpp
@@ -428,7 +428,7 @@ void Sampling::write_info_file(const std::string& fname)
     }
 
     // YAML formatting
-    fh << "time: " << std::setprecision(6) << m_sim.time().new_time() 
+    fh << "time: " << std::setprecision(6) << m_sim.time().new_time()
        << std::endl;
     fh << "samplers:" << std::endl;
     for (int i = 0; i < m_samplers.size(); ++i) {


### PR DESCRIPTION
## Summary

This addresses issue 1820.  It adds a std::setprecision(6) before a write out of sampling time to the post_processing/*/sampling_info.yaml.  For small time steps and long times not enough precision is used.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability
- [x] None of these are needed for this small a change

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
