### PR TITLE
Kynema - input argument for number of tower structural nodes

### DIFF
--- a/amr-wind/wind_energy/actuator/turbine/kynema/KynemaIface.cpp
+++ b/amr-wind/wind_energy/actuator/turbine/kynema/KynemaIface.cpp
@@ -721,11 +721,9 @@ void ExtTurbIface<KynemaTurbine, KynemaSolverData>::ext_init_turbine(
 
     const YAML::Node wio = YAML::LoadFile(fi.input_file);
 
-    constexpr int num_pts_tower_struct{11};
-
     // Builds turbine, including blades, nacelle, and tower
     exw_kynema::build_turbine(
-        builder, wio, fi.num_blades, fi.num_blade_elem, num_pts_tower_struct,
+        builder, wio, fi.num_blades, fi.num_blade_elem, fi.num_tower_elem,
         fi.rotational_speed, fi.generator_power, fi.wind_speed, fi.yaw,
         fi.generator_efficiency);
 

--- a/amr-wind/wind_energy/actuator/turbine/kynema/turbine_kynema_ops.H
+++ b/amr-wind/wind_energy/actuator/turbine/kynema/turbine_kynema_ops.H
@@ -78,6 +78,7 @@ struct ReadInputsOp<TurbineKynema, SrcTrait>
 
         // Number of beam elements read in from file
         pp.get("num_struct_nodes_blade", tf.num_blade_elem);
+        pp.get("num_struct_nodes_tower", tf.num_tower_elem);
         // Initial or constant angular rotation speed
         pp.query("rot_speed_radps", tf.rotational_speed);
         if (!pp.contains("rot_speed_radps")) {

--- a/docs/sphinx/user/inputs_Actuator.rst
+++ b/docs/sphinx/user/inputs_Actuator.rst
@@ -415,8 +415,9 @@ Example for ``TurbineKynemaLine``::
    Actuator.type = TurbineKynemaLine
    ## Turbine discretization parameters
    Actuator.TurbineKynemaLine.num_struct_nodes_blade = 6
+   Actuator.TurbineKynemaLine.num_struct_nodes_tower = 6
    Actuator.TurbineKynemaLine.num_points_blade = 64
-   Actuator.TurbineKynemaLine.num_points_tower = 0 # not enabled yet
+   Actuator.TurbineKynemaLine.num_points_tower = 7
    ## Turbine setup
    Actuator.TurbineKynemaLine.rot_speed_rpm    = 12.1
    Actuator.TurbineKynemaLine.yaw_deg = 30
@@ -448,6 +449,12 @@ Example for ``TurbineKynemaLine``::
 
    This is the number of structural nodes for Kynema to use when modeling each turbine blade.
 
+.. input_param:: Actuator.TurbineKynemaLine.num_struct_nodes_tower
+
+   **type:** Int, required
+
+   This is the number of structural nodes for Kynema to use when modeling the turbine tower.
+
 .. input_param:: Actuator.TurbineKynemaLine.num_points_blade
 
    **type:** Int, required
@@ -460,8 +467,10 @@ Example for ``TurbineKynemaLine``::
 
    **type:** Int, required
 
-   This is the number of aerodynamic sections for Kynema to use when modeling the tower.
-   This feature is still under development, so this argument must be set to 0.
+   This is the number of aerodynamic sections for Kynema to use when modeling the tower. Setting this
+   value to zero will disable aerodynamic representation of the tower and any forces from the tower.
+   If nonzero, this must be the same number of points as provided in the Kynema input file under
+   the tower outer shape.
 
 .. input_param:: Actuator.TurbineKynemaLine.rot_speed_rpm
 

--- a/test/test_files/act_kynema_alm/act_kynema_alm.inp
+++ b/test/test_files/act_kynema_alm/act_kynema_alm.inp
@@ -107,6 +107,7 @@ tagging.T1_level_3_zone.T1_level_3_zone.zaxis = 0.0 0.0 151.2
 #---- actuator defs ----
 Actuator.TurbineKynemaLine.kynema_input_file      = NREL-5MW-aero.yaml
 Actuator.TurbineKynemaLine.num_struct_nodes_blade = 11
+Actuator.TurbineKynemaLine.num_struct_nodes_tower = 11
 Actuator.TurbineKynemaLine.num_points_blade       = 64
 Actuator.TurbineKynemaLine.num_points_tower       = 7
 Actuator.TurbineKynemaLine.rot_speed_rpm          = 12.1


### PR DESCRIPTION
## Summary

One thing that was overlooked in the kynema + amr-wind interface. The number of tower nodes was initially hard-coded and not replaced with an input argument until now.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler --> specifically the reg test that relies on kynema

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
