### PR TITLE
add limits to stokes wave sinh, cosh to avoid FPE, regardless of precision

### DIFF
--- a/src/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/src/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -6,7 +6,6 @@
 #include <numbers>
 #include "AMReX_FArrayBox.H"
 #include "src/utilities/math_ops.H"
-#include "src/utilities/constants.H"
 
 using namespace amrex::literals;
 
@@ -287,6 +286,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     amrex::Real z,
     amrex::Real time,
     amrex::Real phase_offset,
+    amrex::Real hyp_lo_limit,
+    amrex::Real hyp_hi_limit,
     amrex::Real& eta,
     amrex::Real& u_w,
     amrex::Real& v_w,
@@ -365,11 +366,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
         amrex::Real cosh_nkdz = std::cosh(nkdz);
         amrex::Real sinh_nkdz = std::sinh(nkdz);
         cosh_nkdz = amrex::min<amrex::Real>(
-            constants::LARGE_NUM,
-            amrex::max<amrex::Real>(constants::LOW_NUM, cosh_nkdz));
+            hyp_hi_limit, amrex::max<amrex::Real>(hyp_lo_limit, cosh_nkdz));
         sinh_nkdz = amrex::min<amrex::Real>(
-            constants::LARGE_NUM,
-            amrex::max<amrex::Real>(constants::LOW_NUM, sinh_nkdz));
+            hyp_hi_limit, amrex::max<amrex::Real>(hyp_lo_limit, sinh_nkdz));
         // Contributions to velocity
         u_w += utils::powi(eps, n) * static_cast<amrex::Real>(n) * a[n - 1] *
                cosh_nkdz * std::cos(static_cast<amrex::Real>(n) * phase);

--- a/src/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/src/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -360,14 +360,16 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     v_w = 0.0_rt;
     w_w = 0.0_rt;
     for (int n = 1; n <= stokes_order; ++n) {
-        // Upper bound for deep water case
-        // This ensure finite values of velocity for large kd's
+        // Ensure finite values of velocity for large kd
         const amrex::Real nkdz = n * wavenumber * (water_depth + (z - zsl));
-        // Limit the output of hyperbolic functions instead of the output
         amrex::Real cosh_nkdz = std::cosh(nkdz);
         amrex::Real sinh_nkdz = std::sinh(nkdz);
-        cosh_nkdz = amrex::min<amrex::Real>(constants::LARGE_NUM, amrex::max<amrex::Real>(constants::LOW_NUM, cosh_nkdz));
-        sinh_nkdz = amrex::min<amrex::Real>(constants::LARGE_NUM, amrex::max<amrex::Real>(constants::LOW_NUM, sinh_nkdz));
+        cosh_nkdz = amrex::min<amrex::Real>(
+            constants::LARGE_NUM,
+            amrex::max<amrex::Real>(constants::LOW_NUM, cosh_nkdz));
+        sinh_nkdz = amrex::min<amrex::Real>(
+            constants::LARGE_NUM,
+            amrex::max<amrex::Real>(constants::LOW_NUM, sinh_nkdz));
         // Contributions to velocity
         u_w += utils::powi(eps, n) * static_cast<amrex::Real>(n) * a[n - 1] *
                cosh_nkdz * std::cos(static_cast<amrex::Real>(n) * phase);

--- a/src/ocean_waves/relaxation_zones/stokes_waves_K.H
+++ b/src/ocean_waves/relaxation_zones/stokes_waves_K.H
@@ -6,6 +6,7 @@
 #include <numbers>
 #include "AMReX_FArrayBox.H"
 #include "src/utilities/math_ops.H"
+#include "src/utilities/constants.H"
 
 using namespace amrex::literals;
 
@@ -361,13 +362,17 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void stokes_waves(
     for (int n = 1; n <= stokes_order; ++n) {
         // Upper bound for deep water case
         // This ensure finite values of velocity for large kd's
-        amrex::Real nkdz = n * wavenumber * (water_depth + (z - zsl));
-        nkdz = amrex::min<amrex::Real>(
-            nkdz, 50.0_rt * std::numbers::pi_v<amrex::Real>);
+        const amrex::Real nkdz = n * wavenumber * (water_depth + (z - zsl));
+        // Limit the output of hyperbolic functions instead of the output
+        amrex::Real cosh_nkdz = std::cosh(nkdz);
+        amrex::Real sinh_nkdz = std::sinh(nkdz);
+        cosh_nkdz = amrex::min<amrex::Real>(constants::LARGE_NUM, amrex::max<amrex::Real>(constants::LOW_NUM, cosh_nkdz));
+        sinh_nkdz = amrex::min<amrex::Real>(constants::LARGE_NUM, amrex::max<amrex::Real>(constants::LOW_NUM, sinh_nkdz));
+        // Contributions to velocity
         u_w += utils::powi(eps, n) * static_cast<amrex::Real>(n) * a[n - 1] *
-               std::cosh(nkdz) * std::cos(static_cast<amrex::Real>(n) * phase);
+               cosh_nkdz * std::cos(static_cast<amrex::Real>(n) * phase);
         w_w += utils::powi(eps, n) * static_cast<amrex::Real>(n) * a[n - 1] *
-               std::sinh(nkdz) * std::sin(static_cast<amrex::Real>(n) * phase);
+               sinh_nkdz * std::sin(static_cast<amrex::Real>(n) * phase);
     }
     u_w *= (c0 * std::sqrt(g / wavenumber));
     w_w *= (c0 * std::sqrt(g / wavenumber));

--- a/src/ocean_waves/relaxation_zones/stokes_waves_ops.H
+++ b/src/ocean_waves/relaxation_zones/stokes_waves_ops.H
@@ -7,6 +7,7 @@
 #include "src/ocean_waves/OceanWaves.H"
 #include "src/ocean_waves/relaxation_zones/relaxation_zones_ops.H"
 #include "src/equation_systems/vof/volume_fractions.H"
+#include "src/utilities/constants.H"
 #include "AMReX_REAL.H"
 
 using namespace amrex::literals;
@@ -140,8 +141,9 @@ struct InitDataOp<StokesWaves>
                     w_w{0.0_rt};
                 relaxation_zones::stokes_waves(
                     order, wave_length, water_depth, wave_height,
-                    zero_sea_level, g, x, z, 0.0_rt, phase_offset, eta_w, u_w,
-                    v_w, w_w);
+                    zero_sea_level, g, x, z, 0.0_rt, phase_offset,
+                    constants::LOW_NUM, constants::LARGE_NUM, eta_w, u_w, v_w,
+                    w_w);
                 const utils::WaveVec wave_sol{u_w, v_w, w_w, eta_w};
 
                 // Quiescent profile
@@ -216,8 +218,9 @@ struct UpdateTargetFieldsOp<StokesWaves>
 
                     relaxation_zones::stokes_waves(
                         order, wave_length, water_depth, wave_height,
-                        zero_sea_level, g, x, z, time, phase_offset, eta, u_w,
-                        v_w, w_w);
+                        zero_sea_level, g, x, z, time, phase_offset,
+                        constants::LOW_NUM, constants::LARGE_NUM, eta, u_w, v_w,
+                        w_w);
 
                     phi[nbx](i, j, k) = eta - z;
                     const amrex::Real cell_length_2D =

--- a/unit_tests/ocean_waves/test_wave_theories.cpp
+++ b/unit_tests/ocean_waves/test_wave_theories.cpp
@@ -4,6 +4,7 @@
 #include "ks_test_utils/test_utils.H"
 #include "src/ocean_waves/relaxation_zones/stokes_waves_K.H"
 #include "src/utilities/math_ops.H"
+#include "src/utilities/constants.H"
 
 using namespace amrex::literals;
 
@@ -98,7 +99,8 @@ TEST_F(WaveTheoriesTest, StokesWavesFreeSurfaceProfile)
 
     kynema_sgf::ocean_waves::relaxation_zones::stokes_waves(
         stokes_order, wavelength, water_depth, wave_height, zsl, g, x, z, time,
-        phase_offset, eta, u_w, v_w, w_w);
+        phase_offset, kynema_sgf::constants::LOW_NUM,
+        kynema_sgf::constants::LARGE_NUM, eta, u_w, v_w, w_w);
 
     // Coefficients values taken from column 3 of table 2 of
     // Fenton, J. Fifth Order Stokes Theory for Steady Waves
@@ -166,7 +168,8 @@ TEST_F(WaveTheoriesTest, StokesWavesFreeSurfaceProfile)
 
     kynema_sgf::ocean_waves::relaxation_zones::stokes_waves(
         stokes_order, wavelength, water_depth, wave_height, zsl, g, x, z, time,
-        phase_offset, eta, u_w, v_w, w_w);
+        phase_offset, kynema_sgf::constants::LOW_NUM,
+        kynema_sgf::constants::LARGE_NUM, eta, u_w, v_w, w_w);
 
     // Coefficients values taken from column 1 of table 2 of
     // Fenton, J. Fifth Order Stokes Theory for Steady Waves
@@ -238,7 +241,8 @@ TEST_F(WaveTheoriesTest, StokesWavesVelocityComponents)
 
     kynema_sgf::ocean_waves::relaxation_zones::stokes_waves(
         stokes_order, wavelength, water_depth, wave_height, zsl, g, x, z, time,
-        phase_offset, eta, u_w, v_w, w_w);
+        phase_offset, kynema_sgf::constants::LOW_NUM,
+        kynema_sgf::constants::LARGE_NUM, eta, u_w, v_w, w_w);
 
     // Coefficients values taken from column 3 of table 2 of
     // Fenton, J. Fifth Order Stokes Theory for Steady Waves


### PR DESCRIPTION
## Summary

This fixes FPEs I was getting in a stokes waves case in single precision

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
