### PR TITLE
fix boundary plane timing for overset

### DIFF
--- a/src/boundary_conditions/field_boundary_fill/BoundaryPlane.H
+++ b/src/boundary_conditions/field_boundary_fill/BoundaryPlane.H
@@ -202,6 +202,7 @@ public:
     }
 
 private:
+    const CFDSim& m_sim;
     const kynema_sgf::SimTime& m_time;
     const FieldRepo& m_repo;
     const amrex::AmrCore& m_mesh;
@@ -262,10 +263,6 @@ private:
 
     //! IO mode
     io_mode m_io_mode{io_mode::undefined};
-
-    //! Flag indicating if the simulation is overset -- needed for complicated
-    //! timing of pre_advance_work
-    bool m_has_overset{false};
 
     //! controls extents on native bndry output
     const int m_in_rad = 1;

--- a/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
+++ b/src/boundary_conditions/field_boundary_fill/BoundaryPlane.cpp
@@ -285,7 +285,8 @@ bool InletData::is_populated(amrex::Orientation ori) const
 }
 
 BoundaryPlane::BoundaryPlane(CFDSim& sim)
-    : m_time(sim.time())
+    : m_sim(sim)
+    , m_time(sim.time())
     , m_repo(sim.repo())
     , m_mesh(sim.mesh())
     , m_mbc(sim.mbc())
@@ -319,7 +320,6 @@ BoundaryPlane::BoundaryPlane(CFDSim& sim)
             "BoundaryPlane: io_mode must be specified as 0 for output or 1 for "
             "input. \n");
     }
-    m_has_overset = sim.has_overset();
 
     if (!original_input) {
         pp.query("write_frequency", m_write_frequency);
@@ -372,7 +372,7 @@ void BoundaryPlane::post_init_actions()
 // of the boundaries during advection to nph time (n+1/2)
 void BoundaryPlane::pre_advance_work()
 {
-    if (!m_has_overset) {
+    if (!m_sim.has_overset()) {
         pre_advance_inner_calls();
     }
 }


### PR DESCRIPTION
- previous overset check happened too early, prior to overset being activated
- now, keep sim object so overset status can be checked properly

## Summary

<!--- Please provide a one sentence summary of your changes  -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

Fixes failing kynema-driver reg test (abl-bndry-input) that was caused by #1896.
