### PR TITLE
fix for fused kernels PR

### DIFF
--- a/src/equation_systems/icns/source_terms/VelocityFreeAtmosphereForcing.cpp
+++ b/src/equation_systems/icns/source_terms/VelocityFreeAtmosphereForcing.cpp
@@ -104,7 +104,7 @@ void VelocityFreeAtmosphereForcing::operator()(
                 ref_wind = kynema_sgf::interp::linear(
                     wind_heights_d, wind_ht_end, vals, z);
             }
-            src_arrs[nbx](i, j, k, n) -= zi * zi / meso_timescale *
+            src_arrs[nbx](i, j, k, n) -= 1.0_rt / meso_timescale *
                                          (vel_arrs[nbx](i, j, k, n) - ref_wind);
         });
 }


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

As noted here, there was a factor changed in VelocityFreeAtmosphereForcing from the latest fused kernels PR. This led to diffs in the abl_specifiedmol_* reg tests. This PR fixes that incidental change.

https://github.com/kynema/kynema-sgf/pull/1921/changes#r3268443101

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
