### PR TITLE
ABLStats: relative zref

### DIFF
--- a/docs/sphinx/user/inputs_ABL.rst
+++ b/docs/sphinx/user/inputs_ABL.rst
@@ -48,7 +48,7 @@ This section is for setting atmospheric boundary layer parameters.
    When not specified, this is taken from the lower problem-domain boundary in the
    selected normal direction. This value is used together with
    :input_param:`ABL.log_law_height` to determine the sampling location for the
-   planar averages used in thewall model.
+   planar averages used in the wall model.
 
 .. input_param:: ABL.log_law_height
 

--- a/docs/sphinx/user/inputs_ABL.rst
+++ b/docs/sphinx/user/inputs_ABL.rst
@@ -40,6 +40,16 @@ This section is for setting atmospheric boundary layer parameters.
 
    Wall model normal direction. x-direction = 0, y-direction = 1, z-direction = 2.
 
+.. input_param:: ABL.wall_position
+
+   **type:** Real, optional, default = lower domain boundary in :input_param:`ABL.normal_direction` (typically zlo)
+
+   Physical location of the wall-modeled boundary along the wall-normal direction.
+   When not specified, this is taken from the lower problem-domain boundary in the
+   selected normal direction. This value is used together with
+   :input_param:`ABL.log_law_height` to determine the sampling location for the
+   planar averages used in thewall model.
+
 .. input_param:: ABL.log_law_height
 
    **type:** Real, optional

--- a/src/wind_energy/ABLWallFunction.H
+++ b/src/wind_energy/ABLWallFunction.H
@@ -53,7 +53,7 @@ private:
 
     int m_direction{2};   ///< Direction normal to wall
     bool m_use_fch{true}; ///< Use first cell height?
-
+    amrex::Real m_wall_pos{0.0_rt}; ///< Position of the wall in the normal direction
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};
 
     //! Ability to read in a table of surface temperature versus time.

--- a/src/wind_energy/ABLWallFunction.H
+++ b/src/wind_energy/ABLWallFunction.H
@@ -51,9 +51,9 @@ private:
     //! Monin-Obukhov instance
     MOData m_mo;
 
-    int m_direction{2};   ///< Direction normal to wall
-    bool m_use_fch{true}; ///< Use first cell height?
-    amrex::Real m_wall_pos{0.0_rt}; ///< Position of the wall in the normal direction
+    int m_direction{2};             ///< Direction normal to wall
+    bool m_use_fch{true};           ///< Use first cell height?
+    amrex::Real m_wall_pos{0.0_rt}; ///< Position of the wall
     amrex::Vector<amrex::Real> m_gravity{0.0_rt, 0.0_rt, -9.81_rt};
 
     //! Ability to read in a table of surface temperature versus time.

--- a/src/wind_energy/ABLWallFunction.cpp
+++ b/src/wind_energy/ABLWallFunction.cpp
@@ -188,12 +188,13 @@ void ABLWallFunction::update_umean(
         m_mo.Sv_mean = 0.0_rt; // TODO: need to fill this correctly
         m_mo.theta_mean = m_wf_theta;
     } else {
-        m_mo.vel_mean[0] = vpa.line_average_interpolated(m_mo.zref, 0);
-        m_mo.vel_mean[1] = vpa.line_average_interpolated(m_mo.zref, 1);
-        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(m_mo.zref);
-        m_mo.Su_mean = vpa.line_su_average_interpolated(m_mo.zref);
-        m_mo.Sv_mean = vpa.line_sv_average_interpolated(m_mo.zref);
-        m_mo.theta_mean = tpa.line_average_interpolated(m_mo.zref, 0);
+        const auto zlo = m_sim.mesh().Geom(0).ProbLo(m_direction);
+        m_mo.vel_mean[0] = vpa.line_average_interpolated(zlo + m_mo.zref, 0);
+        m_mo.vel_mean[1] = vpa.line_average_interpolated(zlo + m_mo.zref, 1);
+        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(zlo + m_mo.zref);
+        m_mo.Su_mean = vpa.line_su_average_interpolated(zlo + m_mo.zref);
+        m_mo.Sv_mean = vpa.line_sv_average_interpolated(zlo + m_mo.zref);
+        m_mo.theta_mean = tpa.line_average_interpolated(zlo + m_mo.zref, 0);
     }
 
     m_mo.update_fluxes();

--- a/src/wind_energy/ABLWallFunction.cpp
+++ b/src/wind_energy/ABLWallFunction.cpp
@@ -72,6 +72,8 @@ ABLWallFunction::ABLWallFunction(const CFDSim& sim)
                "Assuming log_law_height = first cell height"
             << '\n';
     }
+    m_wall_pos = m_sim.mesh().Geom(0).ProbLo(m_direction);
+    pp.query("wall_position", m_wall_pos);
 
     if (pp.contains("surface_temp_flux")) {
         pp.query("surface_temp_flux", m_mo.surf_temp_flux);
@@ -188,13 +190,16 @@ void ABLWallFunction::update_umean(
         m_mo.Sv_mean = 0.0_rt; // TODO: need to fill this correctly
         m_mo.theta_mean = m_wf_theta;
     } else {
-        const auto zlo = m_sim.mesh().Geom(0).ProbLo(m_direction);
-        m_mo.vel_mean[0] = vpa.line_average_interpolated(zlo + m_mo.zref, 0);
-        m_mo.vel_mean[1] = vpa.line_average_interpolated(zlo + m_mo.zref, 1);
-        m_mo.vmag_mean = vpa.line_hvelmag_average_interpolated(zlo + m_mo.zref);
-        m_mo.Su_mean = vpa.line_su_average_interpolated(zlo + m_mo.zref);
-        m_mo.Sv_mean = vpa.line_sv_average_interpolated(zlo + m_mo.zref);
-        m_mo.theta_mean = tpa.line_average_interpolated(zlo + m_mo.zref, 0);
+        m_mo.vel_mean[0] =
+            vpa.line_average_interpolated(m_wall_pos + m_mo.zref, 0);
+        m_mo.vel_mean[1] =
+            vpa.line_average_interpolated(m_wall_pos + m_mo.zref, 1);
+        m_mo.vmag_mean =
+            vpa.line_hvelmag_average_interpolated(m_wall_pos + m_mo.zref);
+        m_mo.Su_mean = vpa.line_su_average_interpolated(m_wall_pos + m_mo.zref);
+        m_mo.Sv_mean = vpa.line_sv_average_interpolated(m_wall_pos + m_mo.zref);
+        m_mo.theta_mean =
+            tpa.line_average_interpolated(m_wall_pos + m_mo.zref, 0);
     }
 
     m_mo.update_fluxes();


### PR DESCRIPTION
## Summary

Code currently assumes that the wall is at z = 0 in ABLStats:

- this affects the computation of key averages within ABLStats, which are computed by default at z = dz/2 (dz of the coarsest mesh level) regardless of the actual location of the zlo boundary
- log_law_height can change the location of these averages, but this parameter is meant to be a height, not a position, and it is used elsewhere in the Monin-Obukhov model
- that prompted me to add a wall position argument, so the calculation of the averages can be modified if desired, without incorrectly changing the zref parameter within the MO part of the code.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
