### PR TITLE
TiogaInterface: Initialize the scratch fields again after regrid

### DIFF
--- a/src/overset/TiogaInterface.cpp
+++ b/src/overset/TiogaInterface.cpp
@@ -59,6 +59,14 @@ void TiogaInterface::post_init_actions()
 
 void TiogaInterface::post_regrid_actions()
 {
+    // Initialize the scratch fields again after regrid
+    const auto& repo = m_sim.repo();
+    const int num_ghost = m_sim.pde_manager().num_ghost_state();
+    m_iblank_cell_host = repo.create_int_scratch_field_on_host(
+        "iblank_cell_host", 1, num_ghost, FieldLoc::CELL);
+    m_iblank_node_host = repo.create_int_scratch_field_on_host(
+        "iblank_node_host", 1, num_ghost, FieldLoc::NODE);
+
     amr_to_tioga_mesh();
     amr_to_tioga_iblank();
 


### PR DESCRIPTION
## Summary

Throughout the code, usage of scratch fields has them re-initialized after a regrid. This was not taking place for the scratch fields within the TIOGA interface, but it needs to be done before amr_to_tioga_iblank in post_regrid_actions().

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: closes #1959 
