### PR TITLE
Refactor velocity perturbation parsing in ChannelFlow

### DIFF
--- a/src/physics/ChannelFlow.cpp
+++ b/src/physics/ChannelFlow.cpp
@@ -44,7 +44,7 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
             pp.query("Mean_Velocity", m_mean_vel);
             pp.query("half_channel", m_half);
             if (m_perturb_vel) {
-                // When m_laminar and m_perturb_vel are both true, assume DNS
+                // Assumes DNS when m_laminar and m_perturb_vel are both true
                 pp.query("re_tau", m_re_tau);
             }
         } else {
@@ -149,7 +149,8 @@ void ChannelFlow::initialize_fields(
     const auto y_perturb = m_perturb_y_period * 2.0_rt * pi / lengths[1];
     const auto z_perturb = m_perturb_z_period * 2.0_rt * pi / lengths[2];
 
-    if (!m_laminar) {
+    if (!m_laminar || (m_laminar && m_perturb_vel)) {
+        // Non-laminar case or "laminar" DNS with perturbations
         if (m_analytical_smagorinsky_test) {
             auto coeffs = m_sim.turbulence_model().model_coeffs();
             const auto Cs = coeffs["Cs"];
@@ -224,48 +225,10 @@ void ChannelFlow::initialize_fields(
             amrex::Gpu::streamSynchronize();
         }
     } else {
-        // Laminar case: initialize with constant velocity or perturbations
-        if (m_perturb_vel) {
-            // DNS-style initialization: Reichardt profile with perturbations
-            auto& walldist = m_repo.get_field("wall_dist")(level);
-            const auto& vel_arrs = velocity.arrays();
-            const auto& wd_arrs = walldist.arrays();
-
-            amrex::ParallelFor(
-                velocity, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
-                    const int n_ind = idxOp(i, j, k);
-                    amrex::Real h =
-                        problo[n_idx] + ((n_ind + 0.5_rt) * dx[n_idx]);
-                    if (h > 1.0_rt) {
-                        h = 2.0_rt - h;
-                    }
-                    wd_arrs[nbx](i, j, k) = h;
-                    const amrex::Real hp = h / y_tau;
-                    vel_arrs[nbx](i, j, k, 0) =
-                        utau *
-                        (1.0_rt / kappa * std::log1p(kappa * hp) +
-                         7.8_rt * (1.0_rt - std::exp(-hp / 11.0_rt) -
-                                   (hp / 11.0_rt) * std::exp(-hp / 3.0_rt)));
-
-                    const amrex::Real y = problo[1] + ((j + 0.5_rt) * dx[1]);
-                    const amrex::Real z = problo[2] + ((k + 0.5_rt) * dx[2]);
-                    const amrex::Real perty = z_perturb * perturb_amp *
-                                              std::sin(y_perturb * y) *
-                                              std::cos(z_perturb * z);
-                    const amrex::Real pertz = -y_perturb * perturb_amp *
-                                              std::cos(y_perturb * y) *
-                                              std::sin(z_perturb * z);
-                    vel_arrs[nbx](i, j, k, 1) = perty;
-                    vel_arrs[nbx](i, j, k, 2) = pertz;
-                });
-            amrex::Gpu::streamSynchronize();
-        } else {
-            // Standard laminar initialization: constant velocity
-            velocity.setVal(0.0_rt);
-            velocity.setVal(
-                m_mean_vel, m_mean_vel_dir, 1,
-                velocity_field.num_grow()[m_mean_vel_dir]);
-        }
+        velocity.setVal(0.0_rt);
+        velocity.setVal(
+            m_mean_vel, m_mean_vel_dir, 1,
+            velocity_field.num_grow()[m_mean_vel_dir]);
     }
 }
 

--- a/src/physics/ChannelFlow.cpp
+++ b/src/physics/ChannelFlow.cpp
@@ -35,18 +35,22 @@ ChannelFlow::ChannelFlow(CFDSim& sim)
         pp.query("flow_direction", m_mean_vel_dir);
         pp.query("normal_direction", m_norm_dir);
         pp.query("error_log_file", m_output_fname);
+        pp.query("perturb_velocity", m_perturb_vel);
+        pp.query("perturb_y_period", m_perturb_y_period);
+        pp.query("perturb_z_period", m_perturb_z_period);
+        pp.query("perturb_factor", m_perturb_fac);
 
         if (m_laminar) {
             pp.query("Mean_Velocity", m_mean_vel);
             pp.query("half_channel", m_half);
+            if (m_perturb_vel) {
+                // When m_laminar and m_perturb_vel are both true, assume DNS
+                pp.query("re_tau", m_re_tau);
+            }
         } else {
             pp.query("re_tau", m_re_tau);
             pp.query("tke0", m_tke0);
             pp.query("sdr0", m_sdr0);
-            pp.query("perturb_velocity", m_perturb_vel);
-            pp.query("perturb_y_period", m_perturb_y_period);
-            pp.query("perturb_z_period", m_perturb_z_period);
-            pp.query("perturb_factor", m_perturb_fac);
             pp.query(
                 "analytical_smagorinsky_test", m_analytical_smagorinsky_test);
             if (m_analytical_smagorinsky_test) {
@@ -220,10 +224,48 @@ void ChannelFlow::initialize_fields(
             amrex::Gpu::streamSynchronize();
         }
     } else {
-        velocity.setVal(0.0_rt);
-        velocity.setVal(
-            m_mean_vel, m_mean_vel_dir, 1,
-            velocity_field.num_grow()[m_mean_vel_dir]);
+        // Laminar case: initialize with constant velocity or perturbations
+        if (m_perturb_vel) {
+            // DNS-style initialization: Reichardt profile with perturbations
+            auto& walldist = m_repo.get_field("wall_dist")(level);
+            const auto& vel_arrs = velocity.arrays();
+            const auto& wd_arrs = walldist.arrays();
+
+            amrex::ParallelFor(
+                velocity, [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                    const int n_ind = idxOp(i, j, k);
+                    amrex::Real h =
+                        problo[n_idx] + ((n_ind + 0.5_rt) * dx[n_idx]);
+                    if (h > 1.0_rt) {
+                        h = 2.0_rt - h;
+                    }
+                    wd_arrs[nbx](i, j, k) = h;
+                    const amrex::Real hp = h / y_tau;
+                    vel_arrs[nbx](i, j, k, 0) =
+                        utau *
+                        (1.0_rt / kappa * std::log1p(kappa * hp) +
+                         7.8_rt * (1.0_rt - std::exp(-hp / 11.0_rt) -
+                                   (hp / 11.0_rt) * std::exp(-hp / 3.0_rt)));
+
+                    const amrex::Real y = problo[1] + ((j + 0.5_rt) * dx[1]);
+                    const amrex::Real z = problo[2] + ((k + 0.5_rt) * dx[2]);
+                    const amrex::Real perty = z_perturb * perturb_amp *
+                                              std::sin(y_perturb * y) *
+                                              std::cos(z_perturb * z);
+                    const amrex::Real pertz = -y_perturb * perturb_amp *
+                                              std::cos(y_perturb * y) *
+                                              std::sin(z_perturb * z);
+                    vel_arrs[nbx](i, j, k, 1) = perty;
+                    vel_arrs[nbx](i, j, k, 2) = pertz;
+                });
+            amrex::Gpu::streamSynchronize();
+        } else {
+            // Standard laminar initialization: constant velocity
+            velocity.setVal(0.0_rt);
+            velocity.setVal(
+                m_mean_vel, m_mean_vel_dir, 1,
+                velocity_field.num_grow()[m_mean_vel_dir]);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

This PR refactors how the velocity perturbations are parsed when initializing a velocity field with `ChannelFlow` physics. Previously, the velocity perturbations were only parsed when `turbulence.model != Laminar`, which meant this functionality was not available for DNS simulations. This implementation assumes that a "Laminar" turbulence model coupled with `ChannelFlow.perturb_velocity = true` implies DNS, and shouldn't impact any of the existing tests that use `ChannelFlow`.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
