### PR TITLE
Add `offset` information to probe and plane `native` sampling

### DIFF
--- a/src/utilities/sampling/PlaneSampler.H
+++ b/src/utilities/sampling/PlaneSampler.H
@@ -63,6 +63,8 @@ public:
     void
     populate_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
 
+    void populate_info_file(std::ostream& fh) const override;
+
     //! Name of this sampling object
     [[nodiscard]] std::string label() const override { return m_label; }
     std::string& label() override { return m_label; }

--- a/src/utilities/sampling/PlaneSampler.cpp
+++ b/src/utilities/sampling/PlaneSampler.cpp
@@ -193,8 +193,7 @@ void PlaneSampler::populate_netcdf_metadata(
 void PlaneSampler::populate_info_file(std::ostream& fh) const
 {
     const auto write_real_list =
-        [&fh](const std::string& key,
-              const amrex::Vector<amrex::Real>& v) {
+        [&fh](const std::string& key, const amrex::Vector<amrex::Real>& v) {
             fh << "   " << key << ": [";
             for (amrex::Long i = 0; i < v.size(); ++i) {
                 if (i > 0) {

--- a/src/utilities/sampling/PlaneSampler.cpp
+++ b/src/utilities/sampling/PlaneSampler.cpp
@@ -190,4 +190,22 @@ void PlaneSampler::populate_netcdf_metadata(
 {}
 #endif
 
+void PlaneSampler::populate_info_file(std::ostream& fh) const
+{
+    const auto write_real_list =
+        [&fh](const std::string& key,
+              const amrex::Vector<amrex::Real>& v) {
+            fh << "   " << key << ": [";
+            for (amrex::Long i = 0; i < v.size(); ++i) {
+                if (i > 0) {
+                    fh << ", ";
+                }
+                fh << v[i];
+            }
+            fh << "]\n";
+        };
+    write_real_list("offset_vector", m_offset_vector);
+    write_real_list("offsets", m_poffsets);
+}
+
 } // namespace kynema_sgf::sampling

--- a/src/utilities/sampling/ProbeSampler.H
+++ b/src/utilities/sampling/ProbeSampler.H
@@ -51,6 +51,8 @@ public:
     void
     define_netcdf_metadata(const ncutils::NCGroup& /*unused*/) const override;
 
+    void populate_info_file(std::ostream& fh) const override;
+
     [[nodiscard]] std::string label() const override { return m_label; }
     std::string& label() override { return m_label; }
     [[nodiscard]] int id() const override { return m_id; }

--- a/src/utilities/sampling/ProbeSampler.cpp
+++ b/src/utilities/sampling/ProbeSampler.cpp
@@ -134,8 +134,7 @@ void ProbeSampler::define_netcdf_metadata(
 void ProbeSampler::populate_info_file(std::ostream& fh) const
 {
     const auto write_real_list =
-        [&fh](const std::string& key,
-              const amrex::Vector<amrex::Real>& v) {
+        [&fh](const std::string& key, const amrex::Vector<amrex::Real>& v) {
             fh << "   " << key << ": [";
             for (amrex::Long i = 0; i < v.size(); ++i) {
                 if (i > 0) {

--- a/src/utilities/sampling/ProbeSampler.cpp
+++ b/src/utilities/sampling/ProbeSampler.cpp
@@ -131,4 +131,22 @@ void ProbeSampler::define_netcdf_metadata(
 {}
 #endif
 
+void ProbeSampler::populate_info_file(std::ostream& fh) const
+{
+    const auto write_real_list =
+        [&fh](const std::string& key,
+              const amrex::Vector<amrex::Real>& v) {
+            fh << "   " << key << ": [";
+            for (amrex::Long i = 0; i < v.size(); ++i) {
+                if (i > 0) {
+                    fh << ", ";
+                }
+                fh << v[i];
+            }
+            fh << "]\n";
+        };
+    write_real_list("offset_vector", m_offset_vector);
+    write_real_list("offsets", m_poffsets);
+}
+
 } // namespace kynema_sgf::sampling

--- a/src/utilities/sampling/SamplerBase.H
+++ b/src/utilities/sampling/SamplerBase.H
@@ -6,6 +6,7 @@
 #include "src/utilities/ncutils/nc_interface.H"
 #include "src/utilities/constants.H"
 #include "AMReX_REAL.H"
+#include <ostream>
 
 using namespace amrex::literals;
 
@@ -146,6 +147,9 @@ public:
     virtual void output_netcdf_data(
         const ncutils::NCGroup& /*unused*/, const size_t /*unused*/) const
     {}
+
+    //! Populate sampler-specific YAML keys to the native/ascii info file.
+    virtual void populate_info_file(std::ostream& /*unused*/) const {}
 };
 
 } // namespace sampling

--- a/src/utilities/sampling/Sampling.cpp
+++ b/src/utilities/sampling/Sampling.cpp
@@ -444,6 +444,7 @@ void Sampling::write_info_file(const std::string& fname)
         fh << " - index: " << i << '\n';
         fh << "   label: " << m_samplers[i]->label() << '\n';
         fh << "   type: " << m_samplers[i]->sampletype() << '\n';
+        m_samplers[i]->populate_info_file(fh);
     }
 
     fh.close();


### PR DESCRIPTION
## Summary

Add additional offset information to `sampling_info.yaml` files for native sampling. Netcdf output already includes this information, but when we use native, we no longer have access to it. 

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Example of a typical new `sampling_info.yaml` contents. The last two lines are new.
```
time: 0.5
samplers:
  - index: 0
    label: probe1
    type: ProbeSampler
    offset_vector: [0, 0, 1]
    offsets: [0, 200, 400, 600]
```