### PR TITLE
Add time.max_wall_time 

### DIFF
--- a/docs/sphinx/user/inputs_time.rst
+++ b/docs/sphinx/user/inputs_time.rst
@@ -27,6 +27,19 @@ This section also addresses the time-dependent nature of checkpoint files, plot 
    The number of timesteps to run before termination. See also
    :input_param:`time.stop_time`.
 
+.. input_param:: time.max_wall_time
+
+   **type:** Real number, optional, default = -1.0
+
+   The maximum wall clock time (in hours) that the simulation is allowed to run.
+   When the elapsed wall clock time exceeds this limit, the simulation will stop
+   after completing the current timestep. The simulation will stop at whichever
+   comes first: :input_param:`time.stop_time`, :input_param:`time.max_step`, or
+   :input_param:`time.max_wall_time`. This parameter is useful for batch job
+   scheduling systems with strict wall time limits. A checkpoint file is always
+   written when the simulation stops due to wall time limit being exceeded,
+   allowing for easy restart. If this value is negative, there is no wall time limit.
+
 .. input_param:: time.fixed_dt
 
    **type:** Real number

--- a/src/core/SimTime.H
+++ b/src/core/SimTime.H
@@ -178,6 +178,12 @@ public:
         m_stop_time = -1.0_rt;
     }
 
+    //! Set the initialization time (wall clock)
+    void set_init_time(amrex::Real wall_start) { m_wall_start = wall_start; }
+
+    //! Check if maximum wall clock time has been exceeded
+    [[nodiscard]] bool exceed_max_wall_time() const;
+
     /** Return true if TinyProfiler output should be sent to the log file at
      * this timestep
      */
@@ -199,6 +205,12 @@ private:
 
     //! Max time for simulation
     amrex::Real m_stop_time{-1.0_rt};
+
+    //! Maximum wall clock time in hours. If negative, unlimited.
+    amrex::Real m_max_wall_time{-1.0_rt};
+
+    //! Initialization time (wall clock seconds). Set by incflo.
+    amrex::Real m_wall_start{0.0_rt};
 
     //! Delayed adaptive stepping
     amrex::Real m_delay_time{-1.0_rt};

--- a/src/core/SimTime.H
+++ b/src/core/SimTime.H
@@ -178,8 +178,11 @@ public:
         m_stop_time = -1.0_rt;
     }
 
-    //! Set the initialization time (wall clock)
-    void set_init_time(amrex::Real wall_start) { m_wall_start = wall_start; }
+    //! Set the wall clock start time
+    void set_wall_start_time(amrex::Real wall_start)
+    {
+        m_wall_start = wall_start;
+    }
 
     //! Check if maximum wall clock time has been exceeded
     [[nodiscard]] bool exceed_max_wall_time() const;
@@ -206,10 +209,10 @@ private:
     //! Max time for simulation
     amrex::Real m_stop_time{-1.0_rt};
 
-    //! Maximum wall clock time in hours. If negative, unlimited.
+    //! Maximum wall clock time in hours
     amrex::Real m_max_wall_time{-1.0_rt};
 
-    //! Initialization time (wall clock seconds). Set by incflo.
+    //! Initialization wall clock time in seconds
     amrex::Real m_wall_start{0.0_rt};
 
     //! Delayed adaptive stepping

--- a/src/core/SimTime.H
+++ b/src/core/SimTime.H
@@ -178,11 +178,8 @@ public:
         m_stop_time = -1.0_rt;
     }
 
-    //! Set the wall clock start time
-    void set_wall_start_time(amrex::Real wall_start)
-    {
-        m_wall_start = wall_start;
-    }
+    //! Set the wall clock start time (captures current wall time)
+    void set_wall_start_time();
 
     //! Check if maximum wall clock time has been exceeded
     [[nodiscard]] bool exceed_max_wall_time() const;

--- a/src/core/SimTime.cpp
+++ b/src/core/SimTime.cpp
@@ -471,6 +471,12 @@ bool SimTime::output_profiling_info() const
         (m_time_index % m_profiling_interval == 0));
 }
 
+void SimTime::set_wall_start_time()
+{
+    m_wall_start =
+        static_cast<amrex::Real>(amrex::ParallelDescriptor::second());
+}
+
 bool SimTime::exceed_max_wall_time() const
 {
     if (m_max_wall_time <= 0.0_rt) {

--- a/src/core/SimTime.cpp
+++ b/src/core/SimTime.cpp
@@ -477,8 +477,9 @@ bool SimTime::exceed_max_wall_time() const
         return false;
     }
     auto current_wall_time =
-        static_cast<amrex::Real>(amrex::ParallelDescriptor::second()) - m_wall_start;
-    amrex::ParallelDescriptor::ReduceRealMax(current_wall_time);    
+        static_cast<amrex::Real>(amrex::ParallelDescriptor::second()) -
+        m_wall_start;
+    amrex::ParallelDescriptor::ReduceRealMax(current_wall_time);
     return current_wall_time > (m_max_wall_time * 3600.0_rt);
 }
 

--- a/src/core/SimTime.cpp
+++ b/src/core/SimTime.cpp
@@ -19,6 +19,7 @@ void SimTime::parse_parameters()
     amrex::ParmParse pp("time");
     pp.query("stop_time", m_stop_time);
     pp.query("max_step", m_stop_time_index);
+    pp.query("max_wall_time", m_max_wall_time);
     pp.query("delay_time", m_delay_time);
     pp.query("fixed_dt", m_fixed_dt);
     pp.query("initial_dt", m_initial_dt);
@@ -120,6 +121,10 @@ bool SimTime::new_timestep()
         } else if (m_stop_time_index >= 0) {
             amrex::Print() << "  Run for " << m_stop_time_index << " timesteps"
                            << '\n';
+        }
+        if (m_max_wall_time > 0) {
+            amrex::Print() << "  Max wall clock time: " << m_max_wall_time
+                           << " hours" << '\n';
         }
         if (m_adaptive) {
             amrex::Print() << "  Adaptive timestepping with max. CFL = "
@@ -336,6 +341,10 @@ bool SimTime::continue_simulation() const
         return stop_simulation;
     }
 
+    if (exceed_max_wall_time()) {
+        return stop_simulation;
+    }
+
     return !(stop_simulation);
 }
 
@@ -460,6 +469,17 @@ bool SimTime::output_profiling_info() const
     return (
         (m_profiling_interval > 0) &&
         (m_time_index % m_profiling_interval == 0));
+}
+
+bool SimTime::exceed_max_wall_time() const
+{
+    if (m_max_wall_time <= 0.0_rt) {
+        return false;
+    }
+    auto current_wall_time =
+        static_cast<amrex::Real>(amrex::ParallelDescriptor::second()) - m_wall_start;
+    amrex::ParallelDescriptor::ReduceRealMax(current_wall_time);    
+    return current_wall_time > (m_max_wall_time * 3600.0_rt);
 }
 
 } // namespace kynema_sgf

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -338,6 +338,8 @@ void incflo::Evolve()
 
     const auto init_time =
         static_cast<amrex::Real>(amrex::ParallelDescriptor::second());
+    // Set initialization time in SimTime so it can check wall clock limits
+    m_time.set_init_time(init_time);
 
     while (m_time.new_timestep()) {
         const auto time0 =
@@ -391,6 +393,11 @@ void incflo::Evolve()
     amrex::Print() << "\n======================================================"
                       "========================\n"
                    << '\n';
+
+    if (m_time.exceed_max_wall_time()) {
+        amrex::Print() << "Simulation stopped: Maximum wall clock time exceeded"
+                       << '\n';
+    }
 
     // Output at final time
     if (m_time.write_last_plot_file()) {

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -222,7 +222,6 @@ void incflo::InitData()
     init_mesh();
     init_kynema_sgf_modules();
 
-    // Set wall start time before initial pressure iterations
     m_time.set_wall_start_time();
 
     prepare_for_time_integration();
@@ -339,6 +338,9 @@ void incflo::post_advance_work()
 void incflo::Evolve()
 {
     BL_PROFILE("kynema-sgf::incflo::Evolve()");
+
+    const auto init_time =
+        static_cast<amrex::Real>(amrex::ParallelDescriptor::second());
 
     while (m_time.new_timestep()) {
         const auto time0 =

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -221,6 +221,10 @@ void incflo::InitData()
 
     init_mesh();
     init_kynema_sgf_modules();
+
+    // Set wall start time before initial pressure iterations
+    m_time.set_wall_start_time();
+
     prepare_for_time_integration();
 }
 
@@ -335,10 +339,6 @@ void incflo::post_advance_work()
 void incflo::Evolve()
 {
     BL_PROFILE("kynema-sgf::incflo::Evolve()");
-
-    const auto init_time =
-        static_cast<amrex::Real>(amrex::ParallelDescriptor::second());
-    m_time.set_wall_start_time(init_time);
 
     while (m_time.new_timestep()) {
         const auto time0 =

--- a/src/incflo.cpp
+++ b/src/incflo.cpp
@@ -338,8 +338,7 @@ void incflo::Evolve()
 
     const auto init_time =
         static_cast<amrex::Real>(amrex::ParallelDescriptor::second());
-    // Set initialization time in SimTime so it can check wall clock limits
-    m_time.set_init_time(init_time);
+    m_time.set_wall_start_time(init_time);
 
     while (m_time.new_timestep()) {
         const auto time0 =


### PR DESCRIPTION
## Summary

This PR adds a runtime parameter for setting the max wall time of a simulation, `time.max_wall_time`. This is something we've done in the Pele codes that I find incredibly useful as you can set `time.max_wall_time = 0.95 * (#SBATCH --time)`, ensuring plt and chk files are written moments before a job exceeds its time limit on HPC. The parameter is in hours to match most HPC systems. 

In this example, `time.max_wall_time = 1/60`:
~~~
==============================================================================
Step: 16 dt: 8.21903417e-07 Time: 6.251462737e-06 to 7.073366154e-06
CFL: 0.497649 (conv: 0.435051 diff: 0.0560785 src: 0.0569585 )

Godunov:
  System                     Iters      Initial residual        Final residual
  ----------------------------------------------------------------------------
  MAC_projection                 9           330.5998488       2.881904493e-09
  Nodal_projection              10           631.4607669       1.090319302e-08

WallClockTime in Evolve() for step 16: Pre: 0.00636 Solve: 3.65 Post: 0.00645 Total: 3.663
Cumulative WallClockTime in Evolve(): 56.95

==============================================================================
Step: 17 dt: 9.040937587e-07 Time: 7.073366154e-06 to 7.977459912e-06
CFL: 0.547059 (conv: 0.478212 diff: 0.0616864 src: 0.0625852 )

Godunov:
  System                     Iters      Initial residual        Final residual
  ----------------------------------------------------------------------------
  MAC_projection                 9           367.3604088       2.792688747e-09
  Nodal_projection              10           686.6406014       1.197207666e-08

WallClockTime in Evolve() for step 17: Pre: 0.00646 Solve: 3.73 Post: 0.00361 Total: 3.74
Cumulative WallClockTime in Evolve(): 60.69

==============================================================================

Simulation stopped: Maximum wall clock time exceeded
Writing plot file       plt00017 at time 7.977459912e-06
Writing checkpoint file chk00017 at time 7.977459912e-06
Time spent in InitData():    11.798376
Time spent in Evolve():      60.883974
~~~

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
