### PR TITLE
ChannelBuilder: apply setVal() only to the current level

### DIFF
--- a/src/physics/multiphase/ChannelBuilder.cpp
+++ b/src/physics/multiphase/ChannelBuilder.cpp
@@ -174,7 +174,6 @@ ChannelBuilder::ChannelBuilder(CFDSim& sim)
 
     m_sim.io_manager().register_output_int_var("terrain_blank");
 
-    m_terrain_blank.setVal(0);
     amrex::Vector<std::string> labels;
     amrex::ParmParse pp(identifier());
     m_is_multiphase = pp.contains("water_level");
@@ -389,11 +388,11 @@ void ChannelBuilder::initialize_fields(int level, const amrex::Geometry& geom)
     amrex::MultiFab* levelset_lev{nullptr};
     // Set all velocity to 0 for the sake of blanked cells
     if (initialize_velocity) {
-        velocity.setVal(0.0_rt);
+        velocity(level).setVal(0.0_rt);
     }
     // Set density in single-phase case
     if (!multiphase) {
-        m_repo.get_field("density").setVal(m_rho_init);
+        m_repo.get_field("density")(level).setVal(m_rho_init);
     } else {
         levelset_lev = &(m_repo.get_field("levelset")(level));
     }


### PR DESCRIPTION
## Summary

initialize_fields() is called for every level. Within that function, I was calling a setVal() for the whole field. That means when the function was called on the finest level, it was erasing work done on the coarser levels.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
