### PR TITLE
Add masked quantities based on terrain location

### DIFF
--- a/docs/sphinx/user/inputs_Sampling.rst
+++ b/docs/sphinx/user/inputs_Sampling.rst
@@ -75,7 +75,16 @@ inputs <inputs_post_processing>`
 
    **type:** List of one or more strings
 
-   List of CFD simulation derived fields to sample and output (e.g. mag_vorticity)
+   List of CFD simulation derived fields to sample and output (e.g. mag_vorticity, mask_terrain(velocity))
+
+   The ``mask_terrain(<field>)`` derived field copies ``<field>`` and overwrites
+   every cell inside the terrain body (where ``terrain_blank == 1``) with ``NaN``,
+   producing a plot variable named ``<field>_masked``. For example,
+   ``mask_terrain(velocity)`` outputs ``velocity_masked``. It requires the
+   ``terrain_blank`` int field, which is provided by physics modules such as
+   ``TerrainDrag`` or ``ChannelBuilder``. Note that because sampling interpolates
+   field values to the probe locations, any probe whose interpolation stencil
+   touches a masked (``NaN``) cell will itself return ``NaN``.
 
 AMReX particle binary format
 ````````````````````````````

--- a/docs/sphinx/user/inputs_Subvolume.rst
+++ b/docs/sphinx/user/inputs_Subvolume.rst
@@ -41,7 +41,16 @@ The prefix is the label set in ``incflo.post_processing``. For example
 
    **type:** List of strings, optional, default is empty
 
-   Specify which derived field arrays should be output within the selected subvolume
+   Specify which derived field arrays should be output within the selected subvolume (e.g. mag_vorticity, mask_terrain(velocity)). 
+
+   The ``mask_terrain(<field>)`` derived field copies ``<field>`` and overwrites
+   every cell inside the terrain body (where ``terrain_blank == 1``) with ``NaN``,
+   producing a plot variable named ``<field>_masked``. For example,
+   ``mask_terrain(velocity)`` outputs ``velocity_masked``. It requires the
+   ``terrain_blank`` int field, which is provided by physics modules such as
+   ``TerrainDrag`` or ``ChannelBuilder``. The subvolume output copies derived
+   values directly into the output (no interpolation), so the ``NaN`` cells are
+   written to the plotfile unchanged.
 
 .. input_param:: subvol1.output_rename
 

--- a/src/utilities/DerivedQtyDefs.H
+++ b/src/utilities/DerivedQtyDefs.H
@@ -134,6 +134,26 @@ private:
     const Field* m_phi;
 };
 
+struct MaskTerrain : public DerivedQty::Register<MaskTerrain>
+{
+    static std::string identifier() { return "mask_terrain"; }
+
+    MaskTerrain(const FieldRepo& repo, const std::vector<std::string>& args);
+
+    [[nodiscard]] std::string name() const override
+    {
+        return m_phi->name() + "_masked";
+    }
+
+    [[nodiscard]] int num_comp() const override { return m_phi->num_comp(); }
+
+    void operator()(ScratchField& fld, int scomp = 0) const override;
+
+private:
+    const Field* m_phi;
+    const IntField* m_blank;
+};
+
 struct FieldComponents : public DerivedQty::Register<FieldComponents>
 {
     static std::string identifier() { return "components"; }

--- a/src/utilities/DerivedQtyDefs.cpp
+++ b/src/utilities/DerivedQtyDefs.cpp
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include "src/utilities/DerivedQtyDefs.H"
 #include "src/core/field_ops.H"
 #include "src/fvm/fvm.H"
@@ -109,6 +111,44 @@ void Laplacian::operator()(ScratchField& fld, const int scomp) const
     AMREX_ASSERT(m_phi->num_grow() > amrex::IntVect(0));
     auto lapphi = fld.subview(scomp, num_comp());
     fvm::laplacian(lapphi, *m_phi);
+}
+
+MaskTerrain::MaskTerrain(
+    const FieldRepo& repo, const std::vector<std::string>& args)
+{
+    AMREX_ALWAYS_ASSERT(args.size() == 1U);
+    m_phi = &repo.get_field(args[0]);
+    if (!repo.int_field_exists("terrain_blank")) {
+        amrex::Abort(
+            "mask_terrain requires the terrain_blank int field; enable a "
+            "physics module that declares it (e.g. TerrainDrag or "
+            "ChannelBuilder).");
+    }
+    m_blank = &repo.get_int_field("terrain_blank");
+}
+
+void MaskTerrain::operator()(ScratchField& fld, const int scomp) const
+{
+    AMREX_ASSERT(fld.num_comp() >= (scomp + num_comp()));
+    field_ops::copy(fld, *m_phi, 0, scomp, num_comp(), 0);
+
+    const int ncomp = num_comp();
+    const int dstcomp = scomp;
+    const int nlevels = fld.repo().num_active_levels();
+    for (int lev = 0; lev < nlevels; ++lev) {
+        const auto& arrs = fld(lev).arrays();
+        const auto& blank_arrs = (*m_blank)(lev).const_arrays();
+        amrex::ParallelFor(
+            fld(lev), [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
+                if (blank_arrs[nbx](i, j, k, 0) == 1) {
+                    for (int n = 0; n < ncomp; ++n) {
+                        arrs[nbx](i, j, k, dstcomp + n) =
+                            std::numeric_limits<amrex::Real>::quiet_NaN();
+                    }
+                }
+            });
+    }
+    amrex::Gpu::streamSynchronize();
 }
 
 FieldComponents::FieldComponents(

--- a/src/utilities/DerivedQtyDefs.cpp
+++ b/src/utilities/DerivedQtyDefs.cpp
@@ -135,6 +135,7 @@ void MaskTerrain::operator()(ScratchField& fld, const int scomp) const
     const int ncomp = num_comp();
     const int dstcomp = scomp;
     const int nlevels = fld.repo().num_active_levels();
+    const amrex::Real nan = std::numeric_limits<amrex::Real>::quiet_NaN();
     for (int lev = 0; lev < nlevels; ++lev) {
         const auto& arrs = fld(lev).arrays();
         const auto& blank_arrs = (*m_blank)(lev).const_arrays();
@@ -142,13 +143,11 @@ void MaskTerrain::operator()(ScratchField& fld, const int scomp) const
             fld(lev), [=] AMREX_GPU_DEVICE(int nbx, int i, int j, int k) {
                 if (blank_arrs[nbx](i, j, k, 0) == 1) {
                     for (int n = 0; n < ncomp; ++n) {
-                        arrs[nbx](i, j, k, dstcomp + n) =
-                            std::numeric_limits<amrex::Real>::quiet_NaN();
+                        arrs[nbx](i, j, k, dstcomp + n) = nan;
                     }
                 }
             });
     }
-    amrex::Gpu::streamSynchronize();
 }
 
 FieldComponents::FieldComponents(

--- a/src/utilities/tagging/RefinementCriteria.H
+++ b/src/utilities/tagging/RefinementCriteria.H
@@ -25,7 +25,7 @@ class CFDSim;
  *
  *  This class provides an API that can be used by concrete implementations to
  *  tag cells that must be refined based on a pre-defined criteria. The criteria
- *  can be a heuristic determined from the solution (e.g., vorticity magntiude
+ *  can be a heuristic determined from the solution (e.g., vorticity magnitude
  *  or gradients), or some user defined criteria (e.g., static, nested
  * refinements).
  */

--- a/test/test_files/terrain_box_amr/terrain_box_amr.inp
+++ b/test/test_files/terrain_box_amr/terrain_box_amr.inp
@@ -55,8 +55,9 @@ incflo.verbose          =   0          # incflo_level
 
 incflo.post_processing = sampling
 sampling.labels = volume1
-sampling.fields = velocity mask_terrain(velocity)
+sampling.fields = velocity
 sampling.int_fields = terrain_blank
+sampling.derived_fields = mask_terrain(velocity)
 sampling.volume1.type        = VolumeSampler
 sampling.volume1.hi        = 600 600 200
 sampling.volume1.lo      =  400 400 0.0

--- a/test/test_files/terrain_box_amr/terrain_box_amr.inp
+++ b/test/test_files/terrain_box_amr/terrain_box_amr.inp
@@ -55,7 +55,7 @@ incflo.verbose          =   0          # incflo_level
 
 incflo.post_processing = sampling
 sampling.labels = volume1
-sampling.fields = velocity
+sampling.fields = velocity mask_terrain(velocity)
 sampling.int_fields = terrain_blank
 sampling.volume1.type        = VolumeSampler
 sampling.volume1.hi        = 600 600 200


### PR DESCRIPTION
This PR adds a new derived quantity, `mask_terrain(<field>)`, that masks values inside terrain cells by writing `NaN` where `terrain_blank == 1`. The motivation of this is for sampling data over complex terrain for external coupling to other codes. 

Added the use of a masked quantity in one of the regression tests.

Please check the type of change introduced:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [x] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Test input file provided for reference [masked_velocity_test.i.txt](https://github.com/user-attachments/files/30064600/masked_velocity_test.i.txt). Sample terrain (mountain) can generated using [make_mountain_terrain.py](https://github.com/user-attachments/files/30064480/make_mountain_terrain.py) script. 

Test outputs of the test case. Flor is left to right; shown in a vertical slice.

Regular `velocityx`
<img width="802" height="807" alt="image" src="https://github.com/user-attachments/assets/8381e159-61b5-4279-b129-6542bb9ac803" />

`terrain_blank`:
<img width="784" height="787" alt="image" src="https://github.com/user-attachments/assets/0e3bb533-4458-454c-b0be-81f4815947b1" />

Masked quantity:
<img width="805" height="801" alt="image" src="https://github.com/user-attachments/assets/a28bf8bb-9c3b-460d-a8d5-837edf983352" />


