### PR TITLE
ChannelBuilder: only re-initialize terrain-related fields 

### DIFF
--- a/src/physics/multiphase/ChannelBuilder.H
+++ b/src/physics/multiphase/ChannelBuilder.H
@@ -114,6 +114,7 @@ private:
     bool m_initialize_velocity{true};
     bool m_zero_blanked_velocity{true};
     bool m_initialize_drag{false};
+    bool m_terrain_fields_only{false};
     amrex::Real m_rho_init{1.0_rt};
     amrex::Real m_water_level{0.0_rt};
     amrex::Real m_land_level{0.0_rt};

--- a/src/physics/multiphase/ChannelBuilder.cpp
+++ b/src/physics/multiphase/ChannelBuilder.cpp
@@ -360,6 +360,12 @@ void ChannelBuilder::initialize_fields(int level, const amrex::Geometry& geom)
             "multiphase channel builder");
     }
 
+    // Modify flags if only terrain fields are being initialized (after regrid)
+    if (m_terrain_fields_only) {
+        m_initialize_velocity = false;
+        m_zero_blanked_velocity = false;
+    }
+
     const auto& dx = geom.CellSizeArray();
     const auto& prob_lo = geom.ProbLoArray();
     auto& velocity = m_repo.get_field("velocity");
@@ -392,7 +398,9 @@ void ChannelBuilder::initialize_fields(int level, const amrex::Geometry& geom)
     }
     // Set density in single-phase case
     if (!multiphase) {
-        m_repo.get_field("density")(level).setVal(m_rho_init);
+        if (!m_terrain_fields_only) {
+            m_repo.get_field("density")(level).setVal(m_rho_init);
+        }
     } else {
         levelset_lev = &(m_repo.get_field("levelset")(level));
     }
@@ -551,6 +559,9 @@ void ChannelBuilder::initialize_fields(int level, const amrex::Geometry& geom)
             if (multiphase) {
                 // Set levelset field so vof can be initialized
                 phi_arrs[nbx](i, j, k) = water_level - z;
+                // Levelset field only gets converted to vof at initialization,
+                // so this does not matter for post_regrid actions
+
                 // Above land level means unblanked
                 outside_channel = (z > land_level) ? false : outside_channel;
             }
@@ -592,14 +603,12 @@ void ChannelBuilder::initialize_fields(int level, const amrex::Geometry& geom)
             });
     }
 
-    // Do not set "drag" cells until improving drag forcing to handle different
-    // directions (i.e., not just above terrain)
-
-    // Same goes for roughness
+    // Roughness field is untouched, stick with uniform roughness only
 }
 
 void ChannelBuilder::post_regrid_actions()
 {
+    m_terrain_fields_only = true;
     const int nlevels = m_sim.repo().num_active_levels();
     for (int lev = 0; lev < nlevels; ++lev) {
         initialize_fields(lev, m_sim.repo().mesh().Geom(lev));


### PR DESCRIPTION
(stop changing velocity after regrid)

## Summary

ChannelBuilder used TerrainDrag as a template, which applies initialize_fields within post_regrid_actions. This makes sense for the sake of the terrain related fields (terrain_blank, terrain_drag) so those fields have as much accuracy as possible given the current mesh. However, ChannelBuilder typically sets other fields within initialize_fields, which should not change after a regrid. This PR remedies that by disabling those fields from changing when called from post_regrid_actions.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

Should fix restart-related issues from ChannelBuilder.
