### PR TITLE
Add missing GPU syncs

### DIFF
--- a/src/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
+++ b/src/equation_systems/icns/source_terms/ABLMeanBoussinesq.cpp
@@ -3,6 +3,7 @@
 #include "src/core/FieldUtils.H"
 #include "src/wind_energy/ABL.H"
 #include "src/utilities/linear_interpolation.H"
+#include "AMReX_Gpu.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_REAL.H"
 
@@ -95,6 +96,7 @@ void ABLMeanBoussinesq::operator()(
 
     m_transport.beta_fill(lev, (*m_beta_scratch)(lev));
     m_transport.ref_theta_fill(lev, (*m_ref_theta_scratch)(lev));
+    amrex::Gpu::streamSynchronize();
 
     const auto& problo = m_mesh.Geom(lev).ProbLoArray();
     const auto& dx = m_mesh.Geom(lev).CellSizeArray();
@@ -123,6 +125,7 @@ void ABLMeanBoussinesq::operator()(
             const amrex::Real fac = beta_arrs[nbx](i, j, k) * (temp - T0);
             src_arrs[nbx](i, j, k, n) += gravity[n] * fac;
         });
+    amrex::Gpu::streamSynchronize();
 }
 
 void ABLMeanBoussinesq::mean_temperature_init(const FieldPlaneAveraging& tavg)

--- a/src/equation_systems/icns/source_terms/DragForcing.cpp
+++ b/src/equation_systems/icns/source_terms/DragForcing.cpp
@@ -446,6 +446,7 @@ void DragForcing::operator()(
                 src_arrs[nbx](i, j, k, 2) -= damping_arrs[nbx](i, j, k) * uz1;
             }
         });
+    amrex::Gpu::streamSynchronize();
 }
 
 } // namespace kynema_sgf::pde::icns

--- a/src/equation_systems/temperature/source_terms/TemperatureFreeAtmosphereForcing.cpp
+++ b/src/equation_systems/temperature/source_terms/TemperatureFreeAtmosphereForcing.cpp
@@ -174,6 +174,7 @@ void TemperatureFreeAtmosphereForcing::operator()(
                     (temperature(i, j, k) - sponge_density * ref_temp);
             });
     }
+    amrex::Gpu::streamSynchronize();
 }
 
 } // namespace kynema_sgf::pde::temperature

--- a/src/equation_systems/tke/source_terms/KransAxell.cpp
+++ b/src/equation_systems/tke/source_terms/KransAxell.cpp
@@ -1,5 +1,5 @@
-#include <AMReX_Orientation.H>
-
+#include "AMReX_Orientation.H"
+#include "AMReX_Gpu.H"
 #include "src/equation_systems/tke/source_terms/KransAxell.H"
 #include "src/CFDSim.H"
 #include "src/turbulence/TurbulenceModel.H"
@@ -92,6 +92,7 @@ void KransAxell::operator()(
         m_ref_theta_scratch = m_sim.repo().create_scratch_field(1, 0);
     }
     m_transport.ref_theta_fill(lev, (*m_ref_theta_scratch)(lev));
+    amrex::Gpu::streamSynchronize();
 
     const auto& geom = m_mesh.Geom(lev);
     const auto& problo = geom.ProbLoArray();
@@ -329,6 +330,7 @@ void KransAxell::operator()(
                 });
         }
     }
+    amrex::Gpu::streamSynchronize();
 }
 
 } // namespace kynema_sgf::pde::tke


### PR DESCRIPTION
## Summary

There are missing GPU syncs in some of the fused MFiters. Curious to see if this will help with the nondeterminism on the GPU.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
